### PR TITLE
File Module unit tests and additions

### DIFF
--- a/src/main/java/org/basex/query/func/FNFile.java
+++ b/src/main/java/org/basex/query/func/FNFile.java
@@ -91,8 +91,6 @@ public final class FNFile extends Fun {
       case PATHNATIVE:  return pathToNative(path);
       case RESOLVEPATH: return Str.get(path.getAbsolutePath());
       case PATHTOURI:   return pathToUri(path);
-      case DIRSEP:      return dirSep();
-      case PATHSEP:     return pathSep();
       default:          return super.item(ctx, ii);
     }
   }
@@ -454,22 +452,6 @@ public final class FNFile extends Fun {
         if(tc != null) try { tc.close(); } catch(final IOException ex) { }
       }
     }
-  }
-
-  /**
-   * Returns the directory separator used by the operating system.
-   * @return directory separator
-   */
-  private Str dirSep() {
-    return Str.get(System.getProperty("file.separator"));
-  }
-
-  /**
-   * Returns the path separator used by the operating system.
-   * @return path separator
-   */
-  private Str pathSep() {
-    return Str.get(System.getProperty("path.separator"));
   }
 
   /**

--- a/src/main/java/org/basex/query/func/FunDef.java
+++ b/src/main/java/org/basex/query/func/FunDef.java
@@ -525,10 +525,6 @@ public enum FunDef {
   COPY(FNFile.class, "copy(source,target)", EMP, STR, STR),
   /** XQuery function */
   MOVE(FNFile.class, "move(source,target)", EMP, STR, STR),
-  /** XQuery function */
-  DIRSEP(FNFile.class, "directory-separator()", STR),
-  /** XQuery function */
-  PATHSEP(FNFile.class, "path-separator()", STR),
 
   /* FNFt functions. */
 

--- a/src/test/java/org/basex/test/query/advanced/FNFileTest.java
+++ b/src/test/java/org/basex/test/query/advanced/FNFileTest.java
@@ -21,7 +21,6 @@ public final class FNFileTest extends AdvancedQueryTest {
   /** Directory separator. */
   private static final String DIRSEP = System.getProperty("file.separator");
   /** Path separator. */
-  private static final String PATHSEP = System.getProperty("path.separator");
   /** Test name. */
   private static final String NAME = Util.name(FNFileTest.class);
   /** Test path. */
@@ -399,27 +398,5 @@ public final class FNFileTest extends AdvancedQueryTest {
     final String path2 = query(fun + "('" + PATH1 + DIRSEP + ".." + DIRSEP
         + "test.xml" + "')");
     assertEquals(path2, Prop.TMP + "test.xml");
-  }
-
-  /**
-   * Tests method for file:directory-separator() function.
-   * @throws Exception exception
-   */
-  @Test
-  public void testDirSep() throws Exception {
-    final String fun = check(FunDef.DIRSEP);
-    final String sep = query(fun + "()");
-    assertEquals(sep, DIRSEP);
-  }
-
-  /**
-   * Tests method for file:path-separator() function.
-   * @throws Exception exception
-   */
-  @Test
-  public void testPathSep() throws Exception {
-    final String fun = check(FunDef.PATHSEP);
-    final String sep = query(fun + "()");
-    assertEquals(sep, PATHSEP);
   }
 }


### PR DESCRIPTION
[ADD] added file:directory-separator() and file:path-separator()
[FIX] in case of empty path, file:base-name() returned an empty string though "." shall be returned
[ADD] unit tests for file:base-name, file:path-to-native, file:dir-name, file:path-separator and  file:directory-separator
