### PR TITLE
Attempt to fix BaseXdb/basex#88

### DIFF
--- a/src/main/java/org/basex/query/ft/FTWords.java
+++ b/src/main/java/org/basex/query/ft/FTWords.java
@@ -145,6 +145,9 @@ public final class FTWords extends FTExpr {
       @Override
       public FTNode next() {
         if(iat == null) {
+          // return if txt is empty.
+          // s/o pls check that this is the right location to return.
+          if(0 == txt.size()) return null;
           final FTLexer lex = new FTLexer(ftt.opt);
 
           // index iterator tree


### PR DESCRIPTION
ft:search($node, "") throwing NPE
(see BaseXdb/basex#88)
Now returning null in the FTWords.next() if search text has length of zero.
