### PR TITLE
Testing again

### DIFF
--- a/src/test/java/org/basex/test/server/ServerCmdTest.java
+++ b/src/test/java/org/basex/test/server/ServerCmdTest.java
@@ -1,10 +1,17 @@
 package org.basex.test.server;
 
 import static org.basex.core.Text.*;
+
+import java.io.IOException;
+
 import org.basex.BaseXServer;
+import org.basex.core.cmd.CreateUser;
+import org.basex.core.cmd.Kill;
 import org.basex.server.ClientSession;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
@@ -25,6 +32,7 @@ public final class ServerCmdTest extends CmdTest {
 
     try {
       session = new ClientSession(CONTEXT, ADMIN, ADMIN);
+      cleanUp();
     } catch(final Exception ex) {
       fail(ex.toString());
     }
@@ -41,4 +49,18 @@ public final class ServerCmdTest extends CmdTest {
     // stop server instance
     server.stop();
   }
+  /** Kill test.
+   * @throws IOException on Server error.*/
+  @Test
+  public void kill() throws IOException {
+    no(new Kill("admin"));
+    no(new Kill("admin2"));
+    no(new Kill("ha*"));
+    ok(new CreateUser(NAME2, "test"));
+    ClientSession cs = new ClientSession(CONTEXT, NAME2, "test");
+    ok(new Kill(NAME2));
+    no(new Kill(NAME2 + "?"));
+    cs.close();
+  }
+
 }


### PR DESCRIPTION
@BeforeClass was already present in CmdTest

> The method start() was already annotated with @BeforeClass
> and consequently ignored because before() had precedence.
> also moved kill() to ServerCmdTest
