### PR TITLE
[FIX] RepoManager catches FNF Exception now 

### DIFF
--- a/src/main/java/org/basex/query/util/Err.java
+++ b/src/main/java/org/basex/query/util/Err.java
@@ -150,8 +150,9 @@ public enum Err {
   NECPKGNOTINST(PACK, 3, "Necessary package '%' is not installed."),
   /** PACK0004: Evaluation exception. */
   PKGDESCINV(PACK, 4, "Package descriptor: %."),
-  /** PACK0005: Evaluation exception. */
-  INVPKGNAME(PACK, 5, "Package must be a .xar file."),
+//  /** PACK0005: Evaluation exception. */
+// [MS] can be deleted
+//  INVPKGNAME(PACK, 5, "Package must be a .xar file."),
   /** PACK0006: Evaluation exception. */
   MODISTALLED(PACK, 6, "Module % is already installed within another package."),
   /** PACK0007: Evaluation exception. */

--- a/src/main/java/org/basex/query/util/pkg/RepoManager.java
+++ b/src/main/java/org/basex/query/util/pkg/RepoManager.java
@@ -4,6 +4,7 @@ import static org.basex.query.util.Err.*;
 import static org.basex.query.util.pkg.PkgText.*;
 import static org.basex.util.Token.*;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.basex.io.IO;
@@ -63,6 +64,10 @@ public final class RepoManager {
       // unzip files and register repository
       zip.unzip(repo.path(name));
       repo.add(pkg, name);
+
+    } catch(final FileNotFoundException ex1) {
+      Util.debug(ex1);
+      PKGREADFAIL.thrw(ii, io.name(), ex1.getMessage() + " not found");
     } catch(final IOException ex) {
       Util.debug(ex);
       PKGREADFAIL.thrw(ii, io.name(), ex.getMessage());


### PR DESCRIPTION
Minor fix, 
- RepoManager now checks for FNF exception during installation, such that a missing expath-pkg.xml in the root prints out a file not found error. I made it that way because I don't think adding an own error message in Err.java was necessary
- Removed PACK0005 from Err.java as it is not used anymore
