### PR TITLE
[FIX] Reuse address in Server

### DIFF
--- a/src/main/java/org/basex/BaseXServer.java
+++ b/src/main/java/org/basex/BaseXServer.java
@@ -3,8 +3,10 @@ package org.basex;
 import static org.basex.core.Text.*;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketAddress;
 
 import org.basex.core.MainProp;
 import org.basex.core.Main;
@@ -91,8 +93,15 @@ public class BaseXServer extends Main {
 
       log = new Log(context, quiet);
       log.write(SERVERSTART);
-      socket = new ServerSocket(port);
-      esocket = new ServerSocket(context.mprop.num(MainProp.EVENTPORT));
+      socket = new ServerSocket();
+      socket.setReuseAddress(true);
+      SocketAddress endpoint = new InetSocketAddress(port);
+      socket.bind(endpoint);
+
+      esocket = new ServerSocket();
+      esocket.setReuseAddress(true);
+      endpoint = new InetSocketAddress(context.mprop.num(MainProp.EVENTPORT));
+      esocket.bind(endpoint);
       stop = stopFile(port);
 
       // guarantee correct shutdown...


### PR DESCRIPTION
The root cause is that when you close server socket it remains in a timeout state for a period of time and restart fails, because it is not possible to bind to a socket in timeout state.
Enabling SO_REUSEADDR prior to binding the socket using bind allows the socket to be bound even though a previous connection is in a timeout state.

Thanks to Igor Farinic

Some of the team, could you please test whether the testsuite runs without errors? It works on my machine, and the fix is quite small so it should work without any problems.
