### PR TITLE
[FIX] GH-176: perform TCO on static user-defined functions only

### DIFF
--- a/src/main/java/org/basex/query/expr/InlineFunc.java
+++ b/src/main/java/org/basex/query/expr/InlineFunc.java
@@ -97,4 +97,9 @@ public final class InlineFunc extends UserFunc {
     if(ret != null) tb.append("as ").append(ret.toString()).append(' ');
     return tb.append("{ ").append(expr).append(" }").toString();
   }
+
+  @Override
+  boolean tco() {
+    return false;
+  }
 }

--- a/src/main/java/org/basex/query/expr/LitFunc.java
+++ b/src/main/java/org/basex/query/expr/LitFunc.java
@@ -43,4 +43,9 @@ public final class LitFunc extends UserFunc {
     final int par = str.indexOf('(');
     return (par > -1 ? str.substring(0, par) : str) + "#" + args.length;
   }
+
+  @Override
+  boolean tco() {
+    return false;
+  }
 }

--- a/src/main/java/org/basex/query/expr/PartFunApp.java
+++ b/src/main/java/org/basex/query/expr/PartFunApp.java
@@ -78,4 +78,9 @@ public final class PartFunApp extends UserFunc {
     for(final Var v : vars) if(v != null) out = Array.add(out, v);
     return out;
   }
+
+  @Override
+  boolean tco() {
+    return false;
+  }
 }

--- a/src/main/java/org/basex/query/expr/UserFunc.java
+++ b/src/main/java/org/basex/query/expr/UserFunc.java
@@ -88,7 +88,7 @@ public class UserFunc extends Single {
     ctx.vars.reset(s);
 
     // convert all function calls in tail position to proper tail calls
-    expr.markTailCalls();
+    if(tco()) expr.markTailCalls();
 
     // remove redundant cast
     if(ret != null && (ret.type == AtomType.BLN || ret.type == AtomType.FLT ||
@@ -147,5 +147,13 @@ public class UserFunc extends Single {
     if(ret != null) tb.add(' ' + AS + ' ' + ret);
     if(expr != null) tb.add(" { " + expr + " }; ");
     return tb.toString();
+  }
+
+  /**
+   * Checks if this function is tail-call optimizable.
+   * @return {@code true} if it is optimizable, {@code false} otherwise
+   */
+  boolean tco() {
+    return true;
   }
 }


### PR DESCRIPTION
Should only affect users of both higher-order functions and deeply recursive algorithms.
