### PR TITLE
[FIX] Tests are always skipped from maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.9</version>
         <configuration>
-          <skipTests>true</skipTests>
+          <skipTests>false</skipTests>
           <forkMode>always</forkMode>
         </configuration>
       </plugin>


### PR DESCRIPTION
Reset tests to not automatically be skipped when building with maven.
