### PR TITLE
NPE in Parsing of Partial Applications

### DIFF
--- a/src/main/java/org/basex/query/QueryParser.java
+++ b/src/main/java/org/basex/query/QueryParser.java
@@ -2094,11 +2094,13 @@ public class QueryParser extends InputParser {
     ap = qp;
     ctx.ns.uri(name);
     name.uri(name.ns() ? ctx.ns.uri(name.pref(), false, input()) : ctx.nsFunc);
+
+    final Var[] vars = new Var[args.length];
+    final boolean part = partial(args, vars);
     final TypedFunc f = ctx.funcs.get(name, args, ctx, this);
     if(f != null) {
       alter = null;
-      final Var[] part = new Var[args.length];
-      return partial(args, part) ? new PartFunApp(input(), f, part) : f.fun;
+      return part ? new PartFunApp(input(), f, vars) : f.fun;
     }
     qp = p;
     return null;

--- a/src/test/java/org/basex/test/query/expr/HigherOrderTest.java
+++ b/src/test/java/org/basex/test/query/expr/HigherOrderTest.java
@@ -87,4 +87,10 @@ public final class HigherOrderTest extends AdvancedQueryTest {
   public void emptyFunTest() {
     error("()()", Err.XPEMPTY);
   }
+
+  /**  Tests the creation of a cast function as function item. */
+  @Test
+  public void xsNCNameTest() {
+    query("xs:NCName(?)('two')", "two");
+  }
 }


### PR DESCRIPTION
An NPE was thrown when a casting function was partially applied (e.g. `xs:NCName(?)`).
