### PR TITLE
[FIX] GH-267: IterFilter Doesn't Reset the Context

### DIFF
--- a/src/main/java/org/basex/query/expr/IterFilter.java
+++ b/src/main/java/org/basex/query/expr/IterFilter.java
@@ -3,6 +3,7 @@ package org.basex.query.expr;
 import org.basex.query.QueryContext;
 import org.basex.query.QueryException;
 import org.basex.query.item.Item;
+import org.basex.query.item.Value;
 import org.basex.query.iter.Iter;
 
 /**
@@ -32,12 +33,21 @@ final class IterFilter extends Filter {
         // first call - initialize iterator
         if(iter == null) iter = ctx.iter(root);
 
-        // loop through all items
-        while(true) {
-          ctx.checkStop();
-          final Item it = iter.next();
-          if(it == null) return null;
-          if(preds(it, ctx)) return it;
+        // cache context
+        final Value cv = ctx.value;
+        final long cp = ctx.pos;
+        final long cs = ctx.size;
+        try {
+          while(true) {
+            ctx.checkStop();
+            final Item it = iter.next();
+            if(it == null) return null;
+            if(preds(it, ctx)) return it;
+          }
+        } finally {
+          ctx.value = cv;
+          ctx.pos = cp;
+          ctx.size = cs;
         }
       }
     };

--- a/src/test/java/org/basex/test/query/simple/SimpleTest.java
+++ b/src/test/java/org/basex/test/query/simple/SimpleTest.java
@@ -75,6 +75,8 @@ public final class SimpleTest extends QueryTest {
 
       { "SeqError 1", "()()" },
       { "SeqError 2", "() ()" },
+
+      { "ContextItem 1", node(0), "42[not(.)], ." },
     };
   }
 }


### PR DESCRIPTION
Added the reset and wrapped it in `try`/`finally`, because otherwise the context could leak in presence of exceptions.
