### PR TITLE
[MOD] Removed unnecessary "synchronized" keyword.

### DIFF
--- a/src/main/java/org/basex/index/value/DiskValues.java
+++ b/src/main/java/org/basex/index/value/DiskValues.java
@@ -210,7 +210,7 @@ public final class DiskValues implements Index {
    * @param key token to be found
    * @return id offset
    */
-  private synchronized long get(final byte[] key) {
+  private long get(final byte[] key) {
     int l = 0, h = size - 1;
     while(l <= h) {
       final int m = l + h >>> 1;


### PR DESCRIPTION
DiskValues.get is private and is called only from synchronized methods, so no need for it to be synchronized, too. Not a big deal, but anyway....
