### PR TITLE
[ADD] Index cache: new implementation based on java.util.WeakHashMap using soft references

### DIFF
--- a/src/main/java/org/basex/index/IndexCache.java
+++ b/src/main/java/org/basex/index/IndexCache.java
@@ -1,69 +1,257 @@
 package org.basex.index;
 
-import java.util.Arrays;
+import static org.basex.util.Token.*;
 
-import org.basex.util.hash.TokenSet;
+import java.lang.ref.*;
 
 /**
  * This class caches sizes and pointers from index results.
  *
  * @author BaseX Team 2005-12, BSD License
- * @author Sebastian Gath
+ * @author Dimitar Popov
  */
-public final class IndexCache extends TokenSet {
-  /** Number of position values. */
-  private int[] sizes = new int[CAP];
-  /** Pointer on token data. */
-  private long[] pointers = new long[CAP];
+public final class IndexCache {
+  /** Default initial capacity: MUST be a power of two. */
+  private static final int DEFAULT_INITIAL_CAPACITY = 16;
+  /** Default load factor. */
+  private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+
+  /** Hash table buckets. */
+  private BucketEntry[] bucket = new BucketEntry[DEFAULT_INITIAL_CAPACITY];
+  /** Queue used to collect unused keys. */
+  private final ReferenceQueue<CacheEntry> queue = new ReferenceQueue<CacheEntry>();
+
+  /** Load factor. */
+  private final float loadFactor = DEFAULT_LOAD_FACTOR;
+  /** Next size value at which to resize. */
+  private int threshold = (int) (DEFAULT_INITIAL_CAPACITY * loadFactor);
+  /** Number of entries in the cache. */
+  private int size;
 
   /**
-   * Indexes the specified keys and values.
+   * Get cached entry for the specified key.
    * @param key key
-   * @param s size
-   * @param p pointer
+   * @return cached entry or {@code null} if the entry is stale
+   */
+  public CacheEntry get(final byte[] key) {
+    purge();
+
+    final int hash = hash(key);
+    final int i = indexFor(hash, bucket.length);
+
+    BucketEntry e = bucket[i];
+    BucketEntry prev = e;
+    while(e != null) {
+      final BucketEntry next = e.next;
+      final CacheEntry entry = e.get();
+      if(entry == null) {
+        delete(i, e, prev, next);
+      } else if(e.hash == hash && (entry.key == key || eq(entry.key, key))) {
+        return entry;
+      }
+
+      prev = e;
+      e = next;
+    }
+
+    return null;
+  }
+
+  /**
+   * Add a new cache entry. If an entry with the specified key already exists,
+   * it will be updated.
+   * @param key key
+   * @param s number of index hits
+   * @param p pointer to id list
    */
   public void add(final byte[] key, final int s, final long p) {
-    final int i = add(key);
-    if(i > 0) {
-      sizes[i] = s;
-      pointers[i] = p;
+    purge();
+
+    final int hash = hash(key);
+    final int i = indexFor(hash, bucket.length);
+
+    BucketEntry e = bucket[i];
+    BucketEntry prev = e;
+    while(e != null) {
+      final BucketEntry next = e.next;
+      final CacheEntry entry = e.get();
+      if(entry == null) {
+        delete(i, e, prev, next);
+      } else if(e.hash == hash && (entry.key == key || eq(entry.key, key))) {
+        entry.size = s;
+        entry.pointer = p;
+        return;
+      }
+
+      prev = e;
+      e = next;
+    }
+
+    e = bucket[i];
+    bucket[i] = new BucketEntry(hash, e, new CacheEntry(key, s, p), queue);
+    if(++size >= threshold) resize(2 * bucket.length);
+  }
+
+  /**
+   * Delete a cached entry.
+   * @param key key
+   */
+  public void delete(final byte[] key) {
+    purge();
+
+    final int hash = hash(key);
+    final int i = indexFor(hash, bucket.length);
+
+    BucketEntry e = bucket[i];
+    BucketEntry prev = e;
+    while(e != null) {
+      final BucketEntry next = e.next;
+      final CacheEntry entry = e.get();
+      if(entry == null) {
+        delete(i, e, prev, next);
+      } else if(e.hash == hash && (entry.key == key || eq(entry.key, key))) {
+        delete(i, e, prev, next);
+        return;
+      }
+
+      prev = e;
+      e = next;
     }
   }
 
   /**
-   * Indexes the specified keys and values.
-   * @param id cache id of the key
-   * @param s size
-   * @param p pointer
+   * Delete a cached entry from the bucket with the specified index.
+   * @param i bucket index
+   * @param e cached entry to delete
+   * @param p previous cache entry
+   * @param n next cache entry
    */
-  public void update(final int id, final int s, final long p) {
-    sizes[id] = s;
-    pointers[id] = p;
+  private void delete(final int i, final BucketEntry e,
+      final BucketEntry p, final BucketEntry n) {
+    if(p == e) bucket[i] = n;
+    else p.next = n;
+    e.next = null;
+    --size;
   }
 
   /**
-   * Returns the size for the specified key.
-   * @param id id of the key to be found
-   * @return size
+   * Purge stale entries from the cache.
+   * TODO: add a minimal load, after which the bucket array should be shrunk
    */
-  public int size(final int id) {
-    return sizes[id];
+  private void purge() {
+    for(Object x; (x = queue.poll()) != null;) {
+      // {@link java.lang.ref.ReferenceQueue} is not thread-safe.
+      synchronized(queue) {
+        BucketEntry e = (BucketEntry) x;
+        int i = indexFor(e.hash, bucket.length);
+
+        BucketEntry prev = bucket[i];
+        BucketEntry p = prev;
+        while(p != null) {
+          BucketEntry next = p.next;
+          if(p == e) {
+            if(prev == e) bucket[i] = next;
+            else prev.next = next;
+            e.next = null;
+            --size;
+            break;
+          }
+          prev = p;
+          p = next;
+        }
+      }
+    }
   }
 
   /**
-   * Returns the pointer for the specified key.
-   * @param id id of the key to be found
-   * @return pointer
+   * Rehashes the contents of the cache into a new array with larger capacity.
+   * @param newCapacity new capacity; MUST be a power of two
    */
-  public long pointer(final int id) {
-    return pointers[id];
+  private void resize(final int newCapacity) {
+    purge();
+
+    final BucketEntry[] newBucket = new BucketEntry[newCapacity];
+    transfer(bucket, newBucket);
+    bucket = newBucket;
+
+    threshold = (int) (newCapacity * loadFactor);
   }
 
-  @Override
-  protected void rehash() {
-    super.rehash();
-    final int s = size << 1;
-    pointers = Arrays.copyOf(pointers, s);
-    sizes = Arrays.copyOf(sizes, s);
+  /**
+   * Returns bucket index for a hash code.
+   * @param h hash code
+   * @param n number of available buckets
+   * @return index of a bucket
+   */
+  private static int indexFor(final int h, final int n) {
+    return h & (n - 1);
+  }
+
+  /**
+   * Transfer all entries from source buckets to destination buckets.
+   * @param src source buckets
+   * @param dest destination buckets
+   */
+  private static void transfer(final BucketEntry[] src,
+      final BucketEntry[] dest) {
+    for(int j = 0; j < src.length; ++j) {
+      BucketEntry e = src[j];
+      src[j] = null;
+      while(e != null) {
+        BucketEntry next = e.next;
+        int i = indexFor(e.hash, dest.length);
+        e.next = dest[i];
+        dest[i] = e;
+        e = next;
+      }
+    }
+  }
+
+  /** Cache entry data. */
+  public static class CacheEntry {
+    /** Entry key. */
+    public byte[] key;
+    /** Number of index hits for the key. */
+    public int size;
+    /** Pointer to the id list for the key. */
+    public long pointer;
+
+    /**
+     * Constructor.
+     * @param k key
+     * @param s number of hits
+     * @param p pointer to the id list
+     */
+    public CacheEntry(final byte[] k, final int s, final long p) {
+      key = k;
+      size = s;
+      pointer = p;
+    }
+  }
+
+  /**
+   * Cache bucket entry. Used to implement a linked list of cache entries for
+   * each bucket. It also stores the hash of the current entry for better
+   * performance.
+   */
+  private static class BucketEntry extends SoftReference<CacheEntry> {
+    /** Hash code of the stored cache entry key. */
+    final int hash;
+    /** Next bucket entry or {@code null} if the last one for this bucket. */
+    BucketEntry next;
+
+    /**
+     * Constructor.
+     * @param h hash code of the cache entry key
+     * @param n next bucket entry or {@code null} if the last one
+     * @param v stored cache entry
+     * @param rq reference queue
+     */
+    public BucketEntry(final int h, final BucketEntry n,
+        final CacheEntry v, final ReferenceQueue<CacheEntry> rq) {
+      super(v, rq);
+      hash = h;
+      next = n;
+    }
   }
 }

--- a/src/main/java/org/basex/index/ft/FTFuzzy.java
+++ b/src/main/java/org/basex/index/ft/FTFuzzy.java
@@ -10,6 +10,7 @@ import java.io.*;
 import org.basex.core.*;
 import org.basex.data.*;
 import org.basex.index.*;
+import org.basex.index.IndexCache.CacheEntry;
 import org.basex.io.random.*;
 import org.basex.util.*;
 import org.basex.util.ft.*;
@@ -98,8 +99,8 @@ final class FTFuzzy extends FTIndex {
     if(lex.ftOpt().is(FZ)) return Math.max(1, data.meta.size / 10);
 
     final byte[] tok = lex.get();
-    final int id = cache.id(tok);
-    if(id > 0) return cache.size(id);
+    final CacheEntry e = cache.get(tok);
+    if(e != null) return e.size;
 
     int s = 0;
     long poi = 0;
@@ -124,13 +125,12 @@ final class FTFuzzy extends FTIndex {
     }
 
     // return cached or new result
-    final int id = cache.id(tok);
-    if(id == 0) {
-      final int p = token(tok);
-      return p > -1 ? iter(pointer(p, tok.length),
-          size(p, tok.length), inZ, false) : FTIndexIterator.FTEMPTY;
-    }
-    return iter(cache.pointer(id), cache.size(id), inZ, false);
+    final CacheEntry e = cache.get(tok);
+    if(e != null) return iter(e.pointer, e.size, inZ, false);
+
+    final int p = token(tok);
+    return p > -1 ? iter(pointer(p, tok.length),
+        size(p, tok.length), inZ, false) : FTIndexIterator.FTEMPTY;
   }
 
   @Override

--- a/src/main/java/org/basex/index/ft/FTTrie.java
+++ b/src/main/java/org/basex/index/ft/FTTrie.java
@@ -11,6 +11,7 @@ import java.util.*;
 import org.basex.core.*;
 import org.basex.data.*;
 import org.basex.index.*;
+import org.basex.index.IndexCache.CacheEntry;
 import org.basex.io.random.*;
 import org.basex.util.*;
 import org.basex.util.ft.*;
@@ -77,8 +78,8 @@ final class FTTrie extends FTIndex {
       return Math.max(1, data.meta.size / 10);
 
     final byte[] token = lex.get();
-    final int id = cache.id(token);
-    if(id > 0) return cache.size(id);
+    final CacheEntry e = cache.get(token);
+    if(e != null) return e.size;
 
     int size = 0;
     long poi = 0;
@@ -110,9 +111,9 @@ final class FTTrie extends FTIndex {
     }
 
     // return cached or new result
-    final int id = cache.id(token);
-    return id == 0 ? iter(0, token, false) :
-      iter(cache.pointer(id), cache.size(id), inB, false);
+    final CacheEntry e = cache.get(token);
+    return e == null ? iter(0, token, false) :
+      iter(e.pointer, e.size, inB, false);
   }
 
   @Override

--- a/src/main/java/org/basex/index/value/UpdatableDiskValues.java
+++ b/src/main/java/org/basex/index/value/UpdatableDiskValues.java
@@ -2,14 +2,14 @@ package org.basex.index.value;
 
 import static org.basex.data.DataText.*;
 import static org.basex.util.Token.*;
-import java.io.IOException;
-import org.basex.data.Data;
-import org.basex.index.IndexIterator;
-import org.basex.index.RangeToken;
-import org.basex.util.Num;
-import org.basex.util.hash.TokenObjMap;
-import org.basex.util.list.IntList;
-import org.basex.util.list.TokenList;
+
+import java.io.*;
+
+import org.basex.data.*;
+import org.basex.index.*;
+import org.basex.util.*;
+import org.basex.util.hash.*;
+import org.basex.util.list.*;
 
 /**
  * This class provides access to attribute values and text contents stored on
@@ -165,10 +165,8 @@ public final class UpdatableDiskValues extends DiskValues {
     final long newpos = idxl.appendNums(ids);
     idxr.write5(ix * 5L, newpos);
 
-    // check if key is cached and update the cache entry
-    final int cacheid = cache.id(key);
-    if(cacheid > 0)
-      cache.update(cacheid, ids.length, newpos + Num.length(ids.length));
+    // update the cache entry
+    cache.add(key, ids.length, newpos + Num.length(ids.length));
   }
 
   @Override
@@ -220,10 +218,8 @@ public final class UpdatableDiskValues extends DiskValues {
 
     idxl.writeNums(pos, nids);
 
-    // check if key is cached and update the cache entry
-    final int cacheid = cache.id(key);
-    if(cacheid > 0)
-      cache.update(cacheid, nids.length, pos + Num.length(nids.length));
+    // update the cache entry
+    cache.add(key, nids.length, pos + Num.length(nids.length));
 
     return nids.length;
   }
@@ -313,10 +309,8 @@ public final class UpdatableDiskValues extends DiskValues {
       final long newpos = idxl.appendNums(ids);
       idxr.write5(ix * 5L, newpos);
 
-      // check if key is cached and update the cache entry
-      final int cacheid = cache.id(key);
-      if(cacheid > 0)
-        cache.update(cacheid, ids.length, newpos + Num.length(ids.length));
+      // update the cache entry
+      cache.add(key, ids.length, newpos + Num.length(ids.length));
     }
   }
 

--- a/src/test/java/org/basex/test/index/IndexCacheTest.java
+++ b/src/test/java/org/basex/test/index/IndexCacheTest.java
@@ -1,0 +1,94 @@
+package org.basex.test.index;
+
+import static org.basex.util.Token.*;
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.basex.index.*;
+import org.basex.index.IndexCache.CacheEntry;
+import org.junit.*;
+
+/** Tests for {@link IndexCache}. */
+public final class IndexCacheTest {
+  /** Test instance. */
+  private IndexCache cache;
+
+  /** Set up method. */
+  @Before
+  public void setUp() {
+    cache = new IndexCache();
+  }
+
+  /** Test for method {@link IndexCache#add(byte[], int, long)}. */
+  @Test
+  public void testAdd() {
+    for(int i = 0; i < 4000; ++i) {
+      final byte[] key = token("keyAdd" + i);
+      final int size = i;
+      final long pointer = i + 5000L;
+
+      cache.add(key, size, pointer);
+      assertCacheEntry(key, size, pointer);
+    }
+  }
+
+  /** Test for method {@link IndexCache#add(byte[], int, long)}: update. */
+  @Test
+  public void testUpdate() {
+    final byte[] key = token("keyUpdate");
+    final int size = 10;
+    final long pointer = 12L;
+
+    cache.add(key, size - 1, pointer - 1L);
+    cache.add(key, size, pointer);
+
+    assertCacheEntry(key, size, pointer);
+  }
+
+  /** Test for method {@link IndexCache#delete(byte[])}. */
+  @Test
+  public void testDelete() {
+    final byte[] key = token("keyDelete");
+    final int size = 10;
+    final long pointer = 12L;
+
+    cache.add(key, size, pointer);
+    cache.delete(key);
+
+    assertNull(cache.get(key));
+  }
+
+  /**
+   * Test that new records can be continuously added without hitting
+   * {@link OutOfMemoryError}.
+   * TODO: assert progress, i.e. that the loop is not stuck.
+   */
+  @Test
+  @Ignore("Start this test with a small heap size (e.g. -Xmx64m)")
+  public void testPerformance() {
+    final Random random = new Random(System.nanoTime());
+
+    while(true) {
+      final byte[] key = new byte[100];
+      random.nextBytes(key);
+      final int size = random.nextInt();
+      final long pointer = random.nextLong();
+
+      cache.add(key, size, pointer);
+    }
+  }
+
+  /**
+   * Assert a cache entry is found in the cache.
+   * @param key key
+   * @param size number of index hits
+   * @param pointer pointer to id list
+   */
+  private void assertCacheEntry(final byte[] key, final int size,
+      final long pointer) {
+    final CacheEntry entry = cache.get(key);
+    assertEquals(entry.size, size);
+    assertEquals(entry.pointer, pointer);
+  }
+}


### PR DESCRIPTION
I've re-written the IndexCache class by using some of the ideas in java.util.WeakHashMap. The result is a hash-map which has a soft reference to both key and value.
The TokenObjMap could not be used, since it does not offer a convenient way of shrinking the bucket lists. The implementation in java.util.WeakHashMap uses linked lists, which I'm also using.
The cache interface is also cleaned up - there are no more hash map ids, which makes the code cleaner.
Open issues:
1. Please, REVIEW THE CODE BEFORE MERGING! There are simple unit tests and a "performance" unit test which shows that the cache can continuously store new records (it is, however, annotated with @Ignored, since it is not supposed to finish). However, there might be bugs ;)
2. Currently, the bucket array is not shrunk (the same is in java.util.WeakHashMap). A minimal threshold should be introduced, if we want to support that.
3. The default constants are chosen similar to the one in java.util.WeakHashMap. However, a proper constructor could be added.
