### PR TITLE
use valid xs:dateTime values in db:list-details() output [both arities]

### DIFF
--- a/src/main/java/org/basex/query/func/FNDb.java
+++ b/src/main/java/org/basex/query/func/FNDb.java
@@ -5,7 +5,9 @@ import static org.basex.query.util.Err.*;
 import static org.basex.util.Token.*;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.basex.core.Prop;
 import org.basex.core.User;
@@ -87,6 +89,12 @@ public final class FNDb extends StandardFunc {
   static final QNm MDATE = new QNm("modified-date");
   /** MIME type application/xml. */
   static final byte[] APP_XML = token(MimeTypes.APP_XML);
+  /** Date format used for xs:dateTime generation */
+  public static final SimpleDateFormat DATE_FORMAT;
+  static {
+    DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+  }
 
   /**
    * Constructor.
@@ -332,7 +340,7 @@ public final class FNDb extends StandardFunc {
           di = new DataInput(meta.dbfile(DATAINF));
           meta.read(di);
           res.add(new FAttr(RESOURCES, token(meta.ndocs)));
-          final String tstamp = InfoDB.DATE.format(new Date(meta.dbtime()));
+          final String tstamp = DATE_FORMAT.format(new Date(meta.dbtime()));
           res.add(new FAttr(MDATE, token(tstamp)));
           if(ctx.context.perm(User.CREATE, meta))
             res.add(new FAttr(PATH, token(meta.original)));
@@ -428,11 +436,12 @@ public final class FNDb extends StandardFunc {
   static FNode resource(final byte[] path, final boolean raw,
       final long size, final byte[] ctype, final long mdate) {
 
+    final String tstamp = DATE_FORMAT.format(new Date(mdate));
     final FElem res = new FElem(RESOURCE).
         add(new FTxt(path)).
         add(new FAttr(RAW, token(raw))).
         add(new FAttr(CTYPE, ctype)).
-        add(new FAttr(MDATE, token(mdate)));
+        add(new FAttr(MDATE, token(tstamp)));
     return raw ? res.add(new FAttr(SIZE, token(size))) : res;
   }
 

--- a/src/test/java/org/basex/test/query/func/FNDbTest.java
+++ b/src/test/java/org/basex/test/query/func/FNDbTest.java
@@ -3,7 +3,10 @@ package org.basex.test.query.func;
 import static org.basex.core.Text.*;
 import static org.basex.query.func.Function.*;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import org.basex.core.BaseXException;
 import org.basex.core.Prop;
@@ -38,6 +41,12 @@ public final class FNDbTest extends AdvancedQueryTest {
   private static final String FLDR = "src/test/resources/dir";
   /** Number of XML files for folder. */
   private static final int NFLDR;
+
+  private static final SimpleDateFormat MODIFIED_DATE_FORMAT;
+  static {
+    MODIFIED_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    MODIFIED_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+  }
 
   static {
     int fc = 0;
@@ -183,14 +192,14 @@ public final class FNDbTest extends AdvancedQueryTest {
     final String xmlCall = _DB_LIST_DETAILS.args(DB, "xml");
     query(xmlCall + "/@raw/data()", "false");
     query(xmlCall + "/@content-type/data()", MimeTypes.APP_XML);
-    query(xmlCall + "/@modified-date/data()", CONTEXT.data().meta.time);
+    query(xmlCall + "/@modified-date/xs:dateTime(.)", MODIFIED_DATE_FORMAT.format(new Date(CONTEXT.data().meta.time)));
     query(xmlCall + "/@size/data()", "");
     query(xmlCall + "/text()", "xml");
 
     final String rawCall = _DB_LIST_DETAILS.args(DB, "raw");
     query(rawCall + "/@raw/data()", "true");
     query(rawCall + "/@content-type/data()", MimeTypes.APP_OCTET);
-    query(rawCall + "/@modified-date/data() > 0", "true");
+    query(rawCall + "/@modified-date/xs:dateTime(.) > xs:dateTime('1971-01-01T00:00:01')", "true");
     query(rawCall + "/@size/data()", "3");
     query(rawCall + "/text()", "raw");
 


### PR DESCRIPTION
Previously, `db:list-details()` used `dd.MM.yyyy HH:mm:ss` as its date format when called with no arguments, and milliseconds-since-epoch when listing resources for an individual database.

This patch modifies it to use valid `xs:dateTime` values in both cases.
