### PR TITLE
[ADD] XQ 3.0: added grouping by expression instead of variable

### DIFF
--- a/src/main/java/org/basex/query/expr/VarRef.java
+++ b/src/main/java/org/basex/query/expr/VarRef.java
@@ -1,7 +1,6 @@
 package org.basex.query.expr;
 
 import static org.basex.query.QueryText.*;
-import static org.basex.util.Token.*;
 import java.io.IOException;
 
 import org.basex.io.serial.Serializer;
@@ -107,12 +106,14 @@ public final class VarRef extends ParseExpr {
 
   @Override
   public boolean sameAs(final Expr cmp) {
-    return cmp instanceof VarRef  && var.sameAs(((VarRef) cmp).var);
+    return cmp instanceof VarRef && var.sameAs(((VarRef) cmp).var);
   }
 
   @Override
   public void plan(final Serializer ser) throws IOException {
-    ser.emptyElement(this, NAM, token(var.toString()));
+    ser.openElement(this);
+    var.plan(ser);
+    ser.closeElement();
   }
 
   @Override

--- a/src/main/java/org/basex/query/flwor/GFLWOR.java
+++ b/src/main/java/org/basex/query/flwor/GFLWOR.java
@@ -55,21 +55,18 @@ public class GFLWOR extends ParseExpr {
 
   /**
    * Returns a GFLWOR instance.
-   * @param f variable inputs
-   * @param w where clause
-   * @param o order expression
-   * @param g group by expression
-   * @param r return expression
+   * @param fl variable inputs
+   * @param whr where clause
+   * @param ord order expression
+   * @param grp group-by expression
+   * @param ret return expression
    * @param ii input info
    * @return GFLWOR instance
    */
-  public static GFLWOR get(final ForLet[] f, final Expr w, final OrderBy[] o,
-      final Var[][] g, final Expr r, final InputInfo ii) {
-
-    if(o == null && g == null) return new FLWR(f, w, r, ii);
-    final Order ord = o == null ? null : new Order(ii, o);
-    final Group grp = g == null ? null : new Group(ii, g[0], g[1], g[2]);
-    return new GFLWOR(f, w, ord, grp, r, ii);
+  public static GFLWOR get(final ForLet[] fl, final Expr whr, final Order ord,
+      final Group grp, final Expr ret, final InputInfo ii) {
+    return ord == null && grp == null ? new FLWR(fl, whr, ret, ii) :
+      new GFLWOR(fl, whr, ord, grp, ret, ii);
   }
 
   @Override

--- a/src/main/java/org/basex/query/flwor/Group.java
+++ b/src/main/java/org/basex/query/flwor/Group.java
@@ -2,15 +2,14 @@ package org.basex.query.flwor;
 
 import static org.basex.query.QueryText.*;
 import java.io.IOException;
-
 import org.basex.io.serial.Serializer;
 import org.basex.query.QueryContext;
 import org.basex.query.QueryException;
-import org.basex.query.expr.Expr;
-import org.basex.query.expr.ParseExpr;
-import org.basex.query.item.SeqType;
+import org.basex.query.expr.*;
+import org.basex.query.func.*;
+import org.basex.query.item.*;
 import org.basex.query.iter.Iter;
-import org.basex.query.util.Var;
+import org.basex.query.util.*;
 import org.basex.util.InputInfo;
 import org.basex.util.TokenBuilder;
 import org.basex.util.Util;
@@ -23,7 +22,7 @@ import org.basex.util.Util;
  */
 public final class Group extends ParseExpr {
   /** Group by specification. */
-  private final Var[] groupby;
+  private final Spec[] groupby;
   /** Non-grouping variables. */
   private final Var[][] nongroup;
   /** Grouping partition. **/
@@ -33,14 +32,12 @@ public final class Group extends ParseExpr {
    * Constructor.
    * @param ii input info
    * @param gb group by expression
-   * @param ng non-grouping variables
-   * @param ngc copies of non-grouping variables
+   * @param ng non-grouping variables and their copies
    */
-  public Group(final InputInfo ii, final Var[] gb, final Var[] ng,
-      final Var[] ngc) {
+  public Group(final InputInfo ii, final Spec[] gb, final Var[][] ng) {
     super(ii);
     groupby = gb;
-    nongroup = new Var[][]{ ng, ngc };
+    nongroup = ng;
   }
 
   /**
@@ -53,9 +50,10 @@ public final class Group extends ParseExpr {
 
   @Override
   public Expr comp(final QueryContext ctx) throws QueryException {
-    for(final Var g : groupby) {
+    for(final Spec g : groupby) {
       g.comp(ctx);
-      if(g.ret != null) g.ret = SeqType.get(g.ret.type, 1);
+      if(g.grp.ret != null) g.grp.ret = SeqType.get(g.grp.ret.type, 1);
+      ctx.vars.add(g.grp);
     }
 
     for(final Var v : nongroup[1]) ctx.vars.add(v);
@@ -69,7 +67,7 @@ public final class Group extends ParseExpr {
 
   @Override
   public boolean uses(final Use use) {
-    for(final Var v : groupby) if(v.uses(use)) return true;
+    for(final Spec v : groupby) if(v.uses(use)) return true;
     return false;
   }
 
@@ -77,7 +75,7 @@ public final class Group extends ParseExpr {
   public int count(final Var v) {
     // non-grouping variables must be counted here (not in the return clause)
     int c = 0;
-    for(final Var g : groupby) c += g.count(v);
+    for(final Spec g : groupby) c += g.count(v);
     for(final Var g : nongroup[0]) c += g.count(v);
     return c;
   }
@@ -85,7 +83,7 @@ public final class Group extends ParseExpr {
   @Override
   public boolean removable(final Var v) {
     // don't allow removal if variable is used
-    for(final Var g : groupby) if(g.count(v) != 0) return false;
+    for(final Spec g : groupby) if(g.count(v) != 0) return false;
     for(final Var g : nongroup[0]) if(g.count(v) != 0) return false;
     return true;
   }
@@ -106,5 +104,52 @@ public final class Group extends ParseExpr {
   public String toString() {
     return new TokenBuilder(' ' + GROUP + ' ' + BY + ' ').
       addSep(groupby, SEP).toString();
+  }
+
+  /**
+   * Grouping spec.
+   *
+   * @author BaseX Team 2005-12, BSD License
+   * @author Leo Woerteler
+   */
+  public static class Spec extends Single {
+    /** Grouping variable. */
+    public final Var grp;
+
+    /**
+     * Constructor.
+     * @param ii input info
+     * @param gv grouping variable
+     * @param e grouping expression
+     */
+    public Spec(final InputInfo ii, final Var gv, final Expr e) {
+      super(ii, e);
+      grp = gv;
+    }
+
+    @Override
+    public void plan(final Serializer ser) throws IOException {
+      ser.openElement(this);
+      grp.plan(ser);
+      expr.plan(ser);
+      ser.closeElement();
+    }
+
+    @Override
+    public String toString() {
+      return grp + " " + ASSIGN + ' ' + expr;
+    }
+
+    @Override
+    public Item item(final QueryContext ctx, final InputInfo ii) throws QueryException {
+      return value(ctx).item(ctx, ii);
+    }
+
+    @Override
+    public Value value(final QueryContext ctx) throws QueryException {
+      final Value val = expr.value(ctx);
+      if(val.size() > 1) throw Err.XGRP.thrw(input);
+      return val.isEmpty() ? val : StandardFunc.atom(val.itemAt(0), input);
+    }
   }
 }

--- a/src/main/java/org/basex/query/flwor/GroupPartition.java
+++ b/src/main/java/org/basex/query/flwor/GroupPartition.java
@@ -6,6 +6,7 @@ import java.util.*;
 
 import org.basex.query.*;
 import org.basex.query.expr.*;
+import org.basex.query.flwor.Group.Spec;
 import org.basex.query.item.*;
 import org.basex.query.iter.*;
 import org.basex.query.util.*;
@@ -26,7 +27,7 @@ final class GroupPartition {
   private final Order order;
 
   /** Grouping variables. */
-  private final Var[] gv;
+  private final Group.Spec[] gv;
   /** Non-grouping variables. */
   private final Var[][] ngv;
 
@@ -40,14 +41,14 @@ final class GroupPartition {
   /**
    * Sets up an empty partitioning.
    * Sets up the ordering scheme.
-   * @param g grouping variables
+   * @param groupby grouping variables
    * @param ng non-grouping variables
    * @param ob order by specifier
    * @param ii input info
    */
-  GroupPartition(final Var[] g, final Var[][] ng, final Order ob,
+  GroupPartition(final Spec[] groupby, final Var[][] ng, final Order ob,
       final InputInfo ii) {
-    gv = g;
+    gv = groupby;
     ngv = ng;
     order = ob;
     items = ngv[0].length != 0 ? new ArrayList<ItemCache[]>() : null;
@@ -69,7 +70,7 @@ final class GroupPartition {
     final int gl = gv.length;
     final Value[] vals = new Value[gl];
     for(int i = 0; i < gl; i++) {
-      final Value val = ctx.value(ctx.vars.get(gv[i]));
+      final Value val = ctx.value(gv[i]);
       if(val.size() > 1) XGRP.thrw(input);
       vals[i] = val;
     }
@@ -135,7 +136,7 @@ final class GroupPartition {
     for(int i = 0; i < part.size(); ++i) {
       final GroupNode gn = part.get(i);
       for(int j = 0; j < gv.length; ++j)
-        ctx.vars.add(gv[j].copy().bind(gn.vals[j], ctx));
+        ctx.vars.add(gv[j].grp.copy().bind(gn.vals[j], ctx));
 
       if(items != null) {
         final ItemCache[] ii = items.get(i);

--- a/src/main/java/org/basex/query/func/FNGen.java
+++ b/src/main/java/org/basex/query/func/FNGen.java
@@ -106,7 +106,7 @@ public final class FNGen extends StandardFunc {
         final Item it = ir.next();
         if(it == null) return null;
         if(it.type.isFunction()) FNATM.thrw(input, FNGen.this);
-        return atom(it);
+        return atom(it, input);
       }
     };
   }

--- a/src/main/java/org/basex/query/func/FNSeq.java
+++ b/src/main/java/org/basex/query/func/FNSeq.java
@@ -260,7 +260,7 @@ public final class FNSeq extends StandardFunc {
           Item i = ir.next();
           if(i == null) return null;
           ctx.checkStop();
-          i = atom(i);
+          i = atom(i, input);
           if(map.index(input, i)) return i;
         }
       }

--- a/src/main/java/org/basex/query/func/StandardFunc.java
+++ b/src/main/java/org/basex/query/func/StandardFunc.java
@@ -81,13 +81,14 @@ public abstract class StandardFunc extends Arr {
   /**
    * Atomizes the specified item.
    * @param it input item
+   * @param ii input info
    * @return atomized item
    * @throws QueryException query exception
    */
-  final Item atom(final Item it) throws QueryException {
+  public static final Item atom(final Item it, final InputInfo ii) throws QueryException {
     final Type ip = it.type;
     return ip.isNode() ? ip == NodeType.PI || ip == NodeType.COM ?
-        Str.get(it.string(input)) : new Atm(it.string(input)) : it;
+        Str.get(it.string(ii)) : new Atm(it.string(ii)) : it;
   }
 
   @Override

--- a/src/main/java/org/basex/query/util/Var.java
+++ b/src/main/java/org/basex/query/util/Var.java
@@ -266,7 +266,7 @@ public final class Var extends ParseExpr {
 
   @Override
   public void plan(final Serializer ser) throws IOException {
-    ser.openElement(this, NAM, Token.token(toString()));
+    ser.openElement(this, NAM, Token.token(toString()), ID, Token.token(id));
     if(expr != null) expr.plan(ser);
     ser.closeElement();
   }

--- a/src/test/java/org/basex/test/query/simple/XQuery30Test.java
+++ b/src/test/java/org/basex/test/query/simple/XQuery30Test.java
@@ -57,6 +57,14 @@ public final class XQuery30Test extends QueryTest {
       { "FLWOR 13", itr(2), "for $a in 1 let $a:=$a+1 group by $a return $a" },
       { "FLWOR 14", itr(1, 2),
           "for $i as xs:integer in (1,2) let $j := 42 group by $j return $i" },
+      { "FLWOR 15", itr(2, 4, 1, 3), "for $i in 1 to 4 group by $g := $i mod 2 " +
+          "order by $g return $i" },
+      { "FLWOR 16", itr(1, 2, 3, 4), "for $i in 1 to 4 group by $g := 5 return $i" },
+      { "FLWOR 17", itr(2, 4, 1, 3), "for $i in 1 to 4 " +
+          "group by $g as xs:integer := $i mod 2 order by $g return $i" },
+      { "FLWOR 18", itr(1, 2), "for $i in 1 to 2 group by $g as item() := 5 return $i" },
+      { "FLWOR 19", "for $i in 1 to 2 group by $g as node() := 5 return $i" },
+      { "FLWOR 19", "for $i in 1 to 2 let $g := $i group by $i as xs:integer return $i" },
 
       { "Concat 1", str("ab"), "'a'||'b'" },
       { "Concat 2", str("ab"), "'a' || 'b'" },


### PR DESCRIPTION
``` xquery
for $i in 1 to 10
group by $g := $i mod 2
return <group key='{$g}'>{$i}</group>
```

Also tested QT3TS and BaseX-API.
