### PR TITLE
set thread context classloader during Reflect.find()

### DIFF
--- a/src/main/java/org/basex/util/Reflect.java
+++ b/src/main/java/org/basex/util/Reflect.java
@@ -65,10 +65,15 @@ public final class Reflect {
    * @return reference, or {@code null} if the class is not found
    */
   public static Class<?> find(final String name, final JarLoader jar) {
+    Thread currentThread = Thread.currentThread();
+    ClassLoader origLoader = currentThread.getContextClassLoader();
     try {
+      currentThread.setContextClassLoader(jar);
       return cache(name, Class.forName(name, true, jar));
     } catch(final Throwable ex) {
       return null;
+    } finally {
+      currentThread.setContextClassLoader(origLoader);
     }
   }
 


### PR DESCRIPTION
At present, classes which expect to be able to locate related resources using the thread context classloader during initialization are unable to be loaded as plugins to BaseX; this includes output from Clojure's ahead-of-time compiler.

This can be fixed by updating the thread context classloader during the `Class.forName()` calls used for reflection.
