### PR TITLE
Allow arbitrary JVM arguments to be passed to wrapper / startup scripts

### DIFF
--- a/etc/basex
+++ b/etc/basex
@@ -16,5 +16,17 @@ CP="$CP$(for JAR in "$BX"/lib/*.jar; do echo -n ":$JAR"; done)"
 # Options for virtual machine
 VM=-Xmx512m
 
+general_args=( )
+vm_args=( )
+while (( $# )) ; do
+	if [[ $1 = "-X" ]] ; then
+		vm_args+=( "$2" )
+		shift 2
+	else
+		general_args+=( "$1" )
+		shift
+	fi
+done
+
 # Run code
-java -cp "$CP" $VM org.basex.BaseX "$@"
+java -cp "$CP" $VM "${vm_args[@]}" org.basex.BaseX "${general_args[@]}"

--- a/etc/basexclient
+++ b/etc/basexclient
@@ -13,8 +13,20 @@ BX="$( cd -P "$(dirname "$FILE")/.." && pwd )"
 CP="$BX/target/classes"
 CP="$CP$(for JAR in "$BX"/lib/*.jar; do echo -n ":$JAR"; done)"
 
+general_args=( )
+vm_args=( )
+while (( $# )) ; do
+	if [[ $1 = "-X" ]] ; then
+		vm_args+=( "$2" )
+		shift 2
+	else
+		general_args+=( "$1" )
+		shift
+	fi
+done
+
 # Options for virtual machine
 VM=
 
 # Run code
-java -cp "$CP" $VM org.basex.BaseX "$@"
+java -cp "$CP" $VM "${vm_args[@]}" org.basex.BaseX "${general_args[@]}"

--- a/etc/basexgui
+++ b/etc/basexgui
@@ -16,5 +16,17 @@ CP="$CP$(for JAR in "$BX"/lib/*.jar; do echo -n ":$JAR"; done)"
 # Options for virtual machine
 VM=-Xmx512m
 
+general_args=( )
+vm_args=( )
+while (( $# )) ; do
+	if [[ $1 = "-X" ]] ; then
+		vm_args+=( "$2" )
+		shift 2
+	else
+		general_args+=( "$1" )
+		shift
+	fi
+done
+
 # Run code
-java -cp "$CP" $VM org.basex.BaseXGUI "$@"
+java -cp "$CP" $VM "${vm_args[@]}" org.basex.BaseXGUI "${general_args[@]}"

--- a/etc/basexserver
+++ b/etc/basexserver
@@ -16,5 +16,17 @@ CP="$CP$(for JAR in "$BX"/lib/*.jar; do echo -n ":$JAR"; done)"
 # Options for virtual machine
 VM=-Xmx512m
 
+general_args=( )
+vm_args=( )
+while (( $# )) ; do
+	if [[ $1 = "-X" ]] ; then
+		vm_args+=( "$2" )
+		shift 2
+	else
+		general_args+=( "$1" )
+		shift
+	fi
+done
+
 # Run code
-java -cp "$CP" $VM org.basex.BaseXServer "$@"
+java -cp "$CP" $VM "${vm_args[@]}" org.basex.BaseXServer "${general_args[@]}"

--- a/etc/xquery
+++ b/etc/xquery
@@ -16,5 +16,17 @@ CP="$CP$(for JAR in "$BX"/lib/*.jar; do echo -n ":$JAR"; done)"
 # Options for virtual machine
 VM=-Xmx512m
 
+general_args=( )
+vm_args=( )
+while (( $# )) ; do
+	if [[ $1 = "-X" ]] ; then
+		vm_args+=( "$2" )
+		shift 2
+	else
+		general_args+=( "$1" )
+		shift
+	fi
+done
+
 # Run code
-java -cp "$CP" $VM org.basex.BaseX -q "$@"
+java -cp "$CP" $VM "${vm_args[@]}" org.basex.BaseX -q "${general_args[@]}"


### PR DESCRIPTION
Launching basex commands with `-X "<argument>"` will add `<argument>` to the argument list passed to the JVM on invocation. This allows arbitrary commands -- memory tuning, debug / JMX arguments, Java properties, etc -- to be added to startup without requiring that the user edit the startup script itself.

Multiple `-X "<argument>"` pairs can be used.

This implementation uses bash arrays to store the constructed argument list; unlike storing the desired argument list in a single variable (and passing this variable unquoted to be string-split by the shell), this approach allows arguments containing whitespace (or other values found in the global `$IFS` variable) to be included in JVM parameters.
