### PR TITLE
[FIX] Always copy dates before adjusting time zone

### DIFF
--- a/src/main/java/org/basex/query/func/FNDate.java
+++ b/src/main/java/org/basex/query/func/FNDate.java
@@ -214,7 +214,7 @@ public final class FNDate extends StandardFunc {
       throws QueryException {
 
     final Item i = it.type.isUntyped() ? new Dat(it.string(info), info) :
-      checkType(it, AtomType.DAT);
+      new Dat((Date) checkType(it, AtomType.DAT));
     return adjust((Date) i, zon, d);
   }
 
@@ -230,7 +230,7 @@ public final class FNDate extends StandardFunc {
       throws QueryException {
 
     final Item i = it.type.isUntyped() ? new Dtm(it.string(info), info) :
-      checkType(it, AtomType.DTM);
+      new Dtm((Date) checkType(it, AtomType.DTM));
     return adjust((Date) i, zon, d);
   }
 
@@ -246,7 +246,7 @@ public final class FNDate extends StandardFunc {
       throws QueryException {
 
     final Item i = it.type.isUntyped() ? new Tim(it.string(info), info) :
-      checkType(it, AtomType.TIM);
+      new Tim((Date) checkType(it, AtomType.TIM));
     return adjust((Date) i, zon, d);
   }
 

--- a/src/main/java/org/basex/query/item/Tim.java
+++ b/src/main/java/org/basex/query/item/Tim.java
@@ -15,7 +15,7 @@ public final class Tim extends Date {
    * Constructor.
    * @param d date
    */
-  Tim(final Date d) {
+  public Tim(final Date d) {
     super(AtomType.TIM, d);
     xc.setYear(UNDEF);
     xc.setMonth(UNDEF);


### PR DESCRIPTION
Dates were not copied if no casting was needed when adjusting time
zone which resulted in mutable date variables.

Example Query:

```
let $a := xs:dateTime("2012-01-01T00:00:00.000+00:00")
let $b := adjust-dateTime-to-timezone($a, xs:dayTimeDuration("PT1H"))
return (<a>{$a}</a>,<b>{$b}</b>)
```

Expected result:

```
<a>2012-01-01T00:00:00Z</a>
<b>2012-01-01T01:00:00+01:00</b>
```

Did return:

```
<a>2012-01-01T01:00:00+01:00</a>
<b>2012-01-01T01:00:00+01:00</b>
```

Bug report on [stackoverflow](http://stackoverflow.com/q/10065571/695343).
