### PR TITLE
[FIX] Package tests: context needs to be re-initialized in order to

### DIFF
--- a/src/test/java/org/basex/test/query/expr/PackageAPITest.java
+++ b/src/test/java/org/basex/test/query/expr/PackageAPITest.java
@@ -51,6 +51,7 @@ public final class PackageAPITest extends AdvancedQueryTest {
     for(final IOFile f : new IOFile(REPO).children()) {
       if(f.isDir() && f.name().contains(".")) f.delete();
     }
+    context = new Context();
     context.mprop.set(MainProp.REPOPATH, REPO);
   }
 

--- a/src/test/java/org/basex/test/query/func/FNRepoTest.java
+++ b/src/test/java/org/basex/test/query/func/FNRepoTest.java
@@ -31,6 +31,7 @@ public class FNRepoTest extends AdvancedQueryTest {
    */
   @Before
   public void setupTest() {
+    context = new Context();
     context.mprop.set(MainProp.REPOPATH, REPO);
     new IOFile(REPO, PKG3ID).delete();
   }


### PR DESCRIPTION
discard cached repo info between tests
