### PR TITLE
[FIX] Comment for checkCreate

### DIFF
--- a/src/main/java/org/basex/query/expr/ParseExpr.java
+++ b/src/main/java/org/basex/query/expr/ParseExpr.java
@@ -396,7 +396,7 @@ public abstract class ParseExpr extends Expr {
   }
 
   /**
-   * Checks if the current user has admin permissions. If negative, an
+   * Checks if the current user has create permissions. If negative, an
    * exception is thrown.
    * @param ctx query context
    * @throws QueryException query exception


### PR DESCRIPTION
The javadoc said it checked for ADMIN, but it checks for CREATE permissions instead.
