### PR TITLE
Validation Module Fix

### DIFF
--- a/src/main/java/org/basex/query/func/FNValidate.java
+++ b/src/main/java/org/basex/query/func/FNValidate.java
@@ -156,10 +156,7 @@ public class FNValidate extends StandardFunc {
     public void fatalError(final SAXParseException ex) throws SAXException {
       error(ex);
     }
-    @Override
-    public void warning(final SAXParseException ex) throws SAXException {
-      error(ex);
-    }
+
     @Override
     public void error(final SAXParseException ex) throws SAXException {
       // may be recursively called if external validator (e.g. Saxon) is used


### PR DESCRIPTION
[MOD] Updated Javadoc for FNValidate#xsd(ctx)
[MOD] Updated Javadoc for FNValidate#dtd(ctx)
[FIX] Sax Warnings are no longer treated as errors in FNValidate
