### PR TITLE
added LOGMSGMAXLEN property to set log msg cut-off.

### DIFF
--- a/src/main/java/org/basex/core/MainProp.java
+++ b/src/main/java/org/basex/core/MainProp.java
@@ -61,6 +61,8 @@ public final class MainProp extends AProp {
   public static final Object[] DEBUG = { "DEBUG", false };
   /** Defines the number of parallel readers. */
   public static final Object[] PARALLEL = { "PARALLEL", 8 };
+  /** Log message cut-off. */
+  public static final Object[] LOGMSGMAXLEN = { "LOGMSGMAXLEN", 1000 };
 
   /** Defines the locking algorithm (process vs. database locking);
    *  will be removed as soon as database locking is stable. */

--- a/src/main/java/org/basex/server/Log.java
+++ b/src/main/java/org/basex/server/Log.java
@@ -20,6 +20,8 @@ public final class Log {
   private final boolean quiet;
   /** Logging directory. */
   private final IOFile dir;
+  /** Log message cut-off. */
+  private final int maxlen;
 
   /** Start date of log. */
   private String start;
@@ -33,6 +35,7 @@ public final class Log {
    */
   public Log(final Context ctx, final boolean q) {
     dir = ctx.mprop.dbpath(".logs");
+    maxlen = ctx.mprop.num(MainProp.LOGMSGMAXLEN);
     quiet = q;
     if(!q) create(new Date());
   }
@@ -64,7 +67,7 @@ public final class Log {
     final TokenBuilder tb = new TokenBuilder(DateTime.format(now, DateTime.TIME));
     for(final Object s : str) {
       tb.add('\t');
-      tb.add(chop(token(s.toString().replaceAll("[\\r\\n ]+", " ")), 1000));
+      tb.add(chop(token(s.toString().replaceAll("[\\r\\n ]+", " ")), maxlen));
     }
     tb.add(Prop.NL);
 


### PR DESCRIPTION
LOGMSGMAXLEN allows users to set the cut-off for log messages
themselves, rather than using a hardwired cut-off of 1000 characters.
Excessive log growth is thus avoided, without having to completely
turn off logging.

This change should be backwards compatible.
