### PR TITLE
[FIX] GH-556: Correctly reset tail-call depth after function returns.

### DIFF
--- a/src/main/java/org/basex/query/func/BaseFuncCall.java
+++ b/src/main/java/org/basex/query/func/BaseFuncCall.java
@@ -29,38 +29,50 @@ public final class BaseFuncCall extends UserFuncCall {
   public Item item(final QueryContext ctx, final InputInfo ii) throws QueryException {
     Expr fun = func;
     Var[] args = args(ctx);
-    do {
-      // cache arguments, evaluate function and reset variable scope
-      final VarStack cs = addArgs(ctx, args);
-      ctx.tailCalls = 0;
-      try {
-        return fun.item(ctx, ii);
-      } catch(final Continuation c) {
-        fun = c.getFunc();
-        args = c.getArgs();
-      } finally {
-        ctx.vars.reset(cs);
-      }
-    } while(true);
+
+    final int calls = ctx.tailCalls;
+    try {
+      do {
+        // cache arguments, evaluate function and reset variable scope
+        final VarStack cs = addArgs(ctx, args);
+        ctx.tailCalls = 0;
+        try {
+          return fun.item(ctx, ii);
+        } catch(final Continuation c) {
+          fun = c.getFunc();
+          args = c.getArgs();
+        } finally {
+          ctx.vars.reset(cs);
+        }
+      } while(true);
+    } finally {
+      ctx.tailCalls = calls;
+    }
   }
 
   @Override
   public Value value(final QueryContext ctx) throws QueryException {
     Expr fun = func;
     Var[] args = args(ctx);
-    do {
-      // cache arguments, evaluate function and reset variable scope
-      final VarStack cs = addArgs(ctx, args);
-      ctx.tailCalls = 0;
-      try {
-        return ctx.value(fun);
-      } catch(final Continuation c) {
-        fun = c.getFunc();
-        args = c.getArgs();
-      } finally {
-        ctx.vars.reset(cs);
-      }
-    } while(true);
+
+    final int calls = ctx.tailCalls;
+    try {
+      do {
+        // cache arguments, evaluate function and reset variable scope
+        final VarStack cs = addArgs(ctx, args);
+        ctx.tailCalls = 0;
+        try {
+          return ctx.value(fun);
+        } catch(final Continuation c) {
+          fun = c.getFunc();
+          args = c.getArgs();
+        } finally {
+          ctx.vars.reset(cs);
+        }
+      } while(true);
+    } finally {
+      ctx.tailCalls = calls;
+    }
   }
 
   @Override

--- a/src/test/java/org/basex/test/query/ast/TCOTest.java
+++ b/src/test/java/org/basex/test/query/ast/TCOTest.java
@@ -1,5 +1,6 @@
 package org.basex.test.query.ast;
 
+import org.basex.query.expr.*;
 import org.basex.query.func.*;
 import org.basex.util.*;
 import org.junit.*;
@@ -73,8 +74,36 @@ public class TCOTest extends QueryPlanTest {
         null,
 
         "exists(//" + Util.name(UserFunc.class) + "/" +
-        Util.name(TailFuncCall.class) + ")",
+            Util.name(TailFuncCall.class) + ")",
         "exists(//" + Util.name(BaseFuncCall.class) + ")"
+    );
+  }
+
+  /** Checks if a function only containing a tail call is properly optimized. */
+  @Test
+  public void selfRecursive() {
+    check("declare function local:f($i) { if($i eq 12345) then $i else local:f($i+1) };" +
+        "local:f(0)",
+
+        "12345",
+
+        "exists(//" + Util.name(If.class) + "/" +
+            Util.name(TailFuncCall.class) + ")"
+    );
+  }
+
+  /** Checks if a function only containing a tail call is properly optimized. */
+  @Test
+  public void mixedSelfRecursive() {
+    check("declare function local:inc($i) { $i + 1 };" +
+        "declare function local:f($i) { if($i eq 12345) then $i " +
+        "else local:f(local:inc($i)) };" +
+        "local:f(0)",
+
+        "12345",
+
+        "exists(//" + Util.name(If.class) + "/" +
+            Util.name(TailFuncCall.class) + ")"
     );
   }
 }


### PR DESCRIPTION
The old tail-call depth wasn't correctly reset after function calls returned.
