### PR TITLE
[FIX] Resolves GH-579: NPE when pre-evaluating PartFunc

### DIFF
--- a/src/main/java/org/basex/query/func/PartFunc.java
+++ b/src/main/java/org/basex/query/func/PartFunc.java
@@ -5,6 +5,7 @@ import static org.basex.query.QueryText.*;
 import org.basex.query.*;
 import org.basex.query.expr.*;
 import org.basex.query.util.*;
+import org.basex.query.value.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.node.*;
 import org.basex.util.*;
@@ -48,6 +49,16 @@ public final class PartFunc extends UserFunc {
     compile(ctx, false);
     // defer creation of function item because of closure
     return new InlineFunc(info, ret, args, expr, ann, ctx).compile(ctx);
+  }
+
+  @Override
+  public Item item(final QueryContext ctx, final InputInfo ii) throws QueryException {
+    return compile(ctx).item(ctx, ii);
+  }
+
+  @Override
+  public Value value(final QueryContext ctx) throws QueryException {
+    return item(ctx, info);
   }
 
   @Override

--- a/src/test/java/org/basex/test/query/expr/HigherOrderTest.java
+++ b/src/test/java/org/basex/test/query/expr/HigherOrderTest.java
@@ -99,4 +99,10 @@ public final class HigherOrderTest extends AdvancedQueryTest {
   public void wrongArityTest() {
     error("count(concat#2('1','2','3'))", Err.INVARITY);
   }
+
+  /** Tests using a partial function application as the context item (see GH-579). */
+  @Test
+  public void ctxItemTest() {
+    query("declare context item := contains(?, \"a\"); .(\"abc\")", "true");
+  }
 }


### PR DESCRIPTION
PartFunc was never supposed to be evaluated directly but to be eliminated
during compilation. Now it is compiled on the fly.
