### PR TITLE
[FIX] XQUF: duplicate attributes as a result from deletes,inserts,replaces ...

### DIFF
--- a/src/main/java/org/basex/query/up/DatabaseUpdates.java
+++ b/src/main/java/org/basex/query/up/DatabaseUpdates.java
@@ -253,15 +253,22 @@ final class DatabaseUpdates {
     final NamePool pool = new NamePool();
     for(final int pre : pres) {
       final NodeUpdates ups = updatePrimitives.get(pre);
+      // add changes introduced by updates to check namespaces and duplicate attributes
       if(ups != null) for(final UpdatePrimitive up : ups.prim) up.update(pool);
     }
+    // check namespaces
     if(!pool.nsOK()) UPNSCONFL2.thrw(null);
 
-    // check for duplicate attributes
-    final IntList il = new IntList();
+    // add the already existing attributes to the name pool
+    final IntSet il = new IntSet();
     for(final int pre : pres) {
       // pre values consist exclusively of element and attribute nodes
       if(data.kind(pre) == Data.ATTR) {
+        final byte[] nm = data.name(pre, Data.ATTR);
+        final QNm name = new QNm(nm);
+        final byte[] uri = data.nspaces.uri(data.nspaces.uri(nm, pre));
+        if(uri != null) name.uri(uri);
+        pool.add(name, NodeType.ATT);
         il.add(pre);
       } else {
         final int ps = pre + data.attSize(pre, Data.ELEM);

--- a/src/test/java/org/basex/test/query/up/UpdateTest.java
+++ b/src/test/java/org/basex/test/query/up/UpdateTest.java
@@ -155,6 +155,30 @@ public final class UpdateTest extends AdvancedQueryTest {
   }
 
   /**
+   * Tests detection of duplicate attributes in insertion sequences and whether a
+   * combination of delete/insert/replace can lead to duplicate attributes.
+   */
+  @Test
+  public void duplicateAttribute() {
+    // check 'global' duplicate detection
+    String q = transform("<x/>",
+        "for $i in 1 to 2 return insert node attribute a { 'b' } into $input");
+    error(q, Err.UPATTDUPL);
+
+    // check if insertion sequence itself is duplicate free (which it is not)
+    q = transform("<x a='a'/>",
+        "delete node $input/@a," +
+        "for $i in 1 to 2 return insert node attribute a { 'b' } into $input");
+    error(q, Err.UPATTDUPL);
+
+    // replace with a + delete a + insert a
+    q = transform("<x a='a'/>",
+        "delete node $input/@a, replace node $input/@a with attribute a {'b'}," +
+        "insert node attribute a { 'b' } into $input");
+    error(q, Err.UPATTDUPL);
+  }
+
+  /**
    * Replace last node of a data instance. Checks if table limits are crossed.
    */
   @Test


### PR DESCRIPTION
Fixes this:

``` xquery
copy $c := <x a='a'/>
modify (
  delete node $c/@a,
  for $i in 1 to 2
  return insert node attribute a { 'b' } into $c
)
return $c
```

now returns ...

``` xml
[XUDY0021] Duplicate attribute a.
```

... and also fixes this:

``` xquery
copy $c := <x a='a'/>
modify (
  delete node $c/@a,
  insert node attribute a { 'b' } into $c,
  replace node $c/@a with attribute a { 'b' }
)
return $c
```

which now returns:

``` xml
[XUDY0021] Duplicate attribute a.
```
