### PR TITLE
[MIN] `SHOW DATABASES` should not print .zip extension

### DIFF
--- a/src/main/java/org/basex/core/cmd/ShowBackups.java
+++ b/src/main/java/org/basex/core/cmd/ShowBackups.java
@@ -36,7 +36,7 @@ public final class ShowBackups extends Command {
       final String name = f.name();
       if(!name.endsWith(IO.ZIPSUFFIX)) continue;
       final TokenList tl = new TokenList();
-      tl.add(name);
+      tl.add(name.split("\\.")[0]);
       tl.add(f.length());
       table.contents.add(tl);
     }


### PR DESCRIPTION
`SHOW DATABASES` used to print the .zip extensions of backup files, while both `RESTORE` and `DROP BACKUP` don't allow backup names with extension as arguments. I propose cutting the extension off before printing, patch included.
