### PR TITLE
[ADD] Core, Locking: Add lock:(read|write) option

### DIFF
--- a/src/main/java/org/basex/query/QueryContext.java
+++ b/src/main/java/org/basex/query/QueryContext.java
@@ -96,6 +96,11 @@ public final class QueryContext extends Progress {
   /** Full-text token counter (needed for highlighting of full-text results). */
   public byte ftoknum;
 
+  /** Strings to lock defined by lock:read option. */
+  public StringList userReadLocks = new StringList(0);
+  /** Strings to lock defined by lock:write option. */
+  public StringList userWriteLocks = new StringList(0);
+
   /** Pending updates. */
   public Updates updates;
   /** Pending output. */

--- a/src/main/java/org/basex/query/QueryParser.java
+++ b/src/main/java/org/basex/query/QueryParser.java
@@ -572,6 +572,11 @@ public class QueryParser extends InputParser {
       ctx.globalOpt.put(key, obj);
       ctx.dbOptions.add(key);
       ctx.dbOptions.add(string(val));
+    } else if(eq(name.prefix(), LOCK)) {
+      if(eq(name.local(), READ)) ctx.userReadLocks.add(string(val).split("\\s*,\\s*"));
+      else if(eq(name.local(), WRITE)) {
+        ctx.userReadLocks.add(string(val).split("\\s*,\\s*"));
+      } else error(BASX_OPTIONS, string(name.local()));
     }
     // ignore unknown options
   }

--- a/src/main/java/org/basex/query/QueryProcessor.java
+++ b/src/main/java/org/basex/query/QueryProcessor.java
@@ -240,7 +240,8 @@ public final class QueryProcessor extends Progress {
    */
   @Override
   public boolean databases(final StringList db) {
-    return ctx.root != null && ctx.root.databases(db);
+    return ctx.root != null &&
+        ctx.root.databases(db.add(ctx.userReadLocks).add(ctx.userWriteLocks));
   }
 
   /**

--- a/src/main/java/org/basex/query/QueryText.java
+++ b/src/main/java/org/basex/query/QueryText.java
@@ -442,6 +442,12 @@ public interface QueryText {
   byte[] ADMIN = token("admin");
   /** DB token. */
   byte[] DB = token("db");
+  /** LOCK token. */
+  byte[] LOCK = token("lock");
+  /** READ token. */
+  byte[] READ = token("read");
+  /** WRITE token. */
+  byte[] WRITE = token("write");
   /** Index token. */
   byte[] INDEX = token("index");
   /** FETCH token. */
@@ -567,6 +573,8 @@ public interface QueryText {
   byte[] ADMINURI = token(BXMODULES + "admin");
   /** Database module URI. */
   byte[] DBURI = token(BXMODULES + "db");
+  /** Lock module URI. */
+  byte[] LOCKURI = token(BXMODULES + "lock");  
   /** Fetch module URI. */
   byte[] FETCHURI = token(BXMODULES + "fetch");
   /** Full-text module URI. */

--- a/src/main/java/org/basex/query/util/NSGlobal.java
+++ b/src/main/java/org/basex/query/util/NSGlobal.java
@@ -56,6 +56,7 @@ public final class NSGlobal {
     NS.add(HTML, HTMLURI);
     NS.add(INDEX, INDEXURI);
     NS.add(JSON, JSONURI);
+    NS.add(LOCK, LOCKURI);
     NS.add(OUT, OUTURI);
     NS.add(PROC, PROCURI);
     NS.add(PROF, PROFURI);


### PR DESCRIPTION
Didn't use `db:` namespace as this has semantics of permanent database options to override, which would either break or enable persistent locks in BaseX config.

Putting following code into the prequel of some XQuery

```
declare option lock:read "foo";
declare option lock:read "bar";
declare option lock:write "foobar,42";
```

will put read locks on _foo_ and _bar_ and write locks on _foobar_ and _42_. Arbitrary strings are allowed which also can refer to databases. This should be added to documentation.

BaseX database locking does not yet support read and write locks at the same time, this should be finished within the next days, I will add documentation for this option after that code is merged (and thus these options are fully functional). Until then, it is ignored whether read/write locks are requested but checked whether the query is an updating one.
