### PR TITLE
[FIX] XQuery, GH-659: Better error description for node tests (e.g. `element(foo)`).

### DIFF
--- a/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/src/main/java/org/basex/query/value/type/SeqType.java
@@ -431,7 +431,7 @@ public final class SeqType {
       return ((FItem) it).coerceTo((FuncType) type, ctx, ii);
     }
 
-    throw Err.treat(ii, type.seqType(), it);
+    throw Err.treat(ii, withOcc(Occ.ONE), it);
   }
 
   /**


### PR DESCRIPTION
Error message for Issue #659 is `[XPTY0004] Cannot treat element() as element(a): <b/>.` again.
