### PR TITLE
[FIX] Core: call read() instead of next() in BufferInput.readString(), s...

### DIFF
--- a/src/main/java/org/basex/io/in/BufferInput.java
+++ b/src/main/java/org/basex/io/in/BufferInput.java
@@ -125,7 +125,7 @@ public class BufferInput extends InputStream {
    */
   public final String readString() throws IOException {
     final ByteList bl = new ByteList();
-    for(int l; (l = next()) > 0;) bl.add(l);
+    for(int l; (l = read()) > 0;) bl.add(l);
     return bl.toString();
   }
 


### PR DESCRIPTION
...o that ArrayInput works correctly.
