### PR TITLE
[FIX] Core, Locking: Downgrades to no Write locks

### DIFF
--- a/basex-core/src/main/java/org/basex/core/DBLocking.java
+++ b/basex-core/src/main/java/org/basex/core/DBLocking.java
@@ -248,6 +248,14 @@ public final class DBLocking implements Locking {
       }
     }
 
+    // Downgrade from local write lock to no write locks
+    synchronized(globalLock) {
+      if(write.isEmpty()) {
+        localWriters--;
+        globalLock.notifyAll();
+      }
+    }
+
     // Write back new locking lists
     writeLocked.put(thread, newWriteObjects);
     if (null != newReadObjects)

--- a/basex-core/src/main/java/org/basex/query/QueryContext.java
+++ b/basex-core/src/main/java/org/basex/query/QueryContext.java
@@ -309,7 +309,7 @@ public final class QueryContext extends Proc {
    */
   public Value update() throws QueryException {
     if(updating) {
-      //context.downgrade(this, updates.databases());
+      context.downgrade(this, updates.databases());
       updates.apply();
       if(updates.size() != 0 && context.data() != null) context.update();
       if(output.size() != 0) return output.value();

--- a/basex-core/src/test/java/org/basex/test/core/LockingTest.java
+++ b/basex-core/src/test/java/org/basex/test/core/LockingTest.java
@@ -7,7 +7,6 @@ import java.util.*;
 import java.util.List;
 import java.util.concurrent.*;
 import org.basex.core.*;
-import org.basex.core.cmd.*;
 import org.basex.test.*;
 import org.basex.util.list.*;
 import org.junit.*;
@@ -354,18 +353,6 @@ public final class LockingTest extends SandboxTest {
   }
 
   /**
-   * Test for concurrent writes.
-   * @throws BaseXException database exception
-   */
-  @Test
-  public void downgradeTest() throws BaseXException {
-    // hangs if QueryContext.downgrade call is activated..
-    new CreateDB(NAME, "<x/>").execute(context);
-    new XQuery("delete node /y").execute(context);
-    new XQuery("let $d := '" + NAME + "' return doc($d)").execute(context);
-  }
-
-  /**
    * Lock downgrading, the other thread is reader.
    * @throws InterruptedException Got interrupted.
    */
@@ -442,6 +429,29 @@ public final class LockingTest extends SandboxTest {
         test.await(WAIT, TimeUnit.MILLISECONDS));
     th2.release();
   }
+
+  /**
+   * Downgrade from global write lock, other fetches local writes locks.
+   * @throws InterruptedException Got interrupted.
+   */
+  @Test
+  public void downgradeToNoWriteLocksTest() throws InterruptedException {
+    final CountDownLatch sync = new CountDownLatch(1), test = new CountDownLatch(1);
+
+    final LockTester th1 = new LockTester(null, NONE, objects, sync);
+    final LockTester th2 = new LockTester(sync, null, NONE, test);
+
+    th1.start();
+    th2.start();
+    assertFalse("Thread 2 shouldn't be able to acquire lock yet.",
+        test.await(WAIT, TimeUnit.MILLISECONDS));
+    th1.downgrade(NONE);
+    assertTrue("Thread 2 should be able to acquire lock now.",
+        test.await(WAIT, TimeUnit.MILLISECONDS));
+    th1.release();
+    th2.release();
+  }
+
 
   /**
    * Lock downgrading holding read locks.

--- a/basex-core/src/test/java/org/basex/test/server/LockingTest.java
+++ b/basex-core/src/test/java/org/basex/test/server/LockingTest.java
@@ -211,4 +211,16 @@ public final class LockingTest extends SandboxTest {
     for(final Client client : clients)
         assertTrue(client.error, client.error == null);
   }
+
+  /**
+   * Test for concurrent writes.
+   * @throws BaseXException database exception
+   */
+  @Test
+  public void downgradeTest() throws BaseXException {
+    // hangs if QueryContext.downgrade call is activated..
+    new CreateDB(NAME, "<x/>").execute(context);
+    new XQuery("delete node /y").execute(context);
+    new XQuery("let $d := '" + NAME + "' return doc($d)").execute(context);
+  }
 }


### PR DESCRIPTION
When downgrading from a local write lock to no write locks, the local write
lock counter was not decremented, thus global read lock transactions would
fail.

Additionally contained:
- Added locking unit test
- Moved XQuery locking test to appropriate package
- Reenabled downgrades
