### PR TITLE
Allow HTTPPayload to process XML documents with a charset in the Content-Type

### DIFF
--- a/basex-core/src/main/java/org/basex/io/MimeTypes.java
+++ b/basex-core/src/main/java/org/basex/io/MimeTypes.java
@@ -78,9 +78,9 @@ public final class MimeTypes {
    */
   public static boolean isXML(final String type) {
     return type.startsWith(TEXT_XML) ||
-	type.startsWith(TEXT_XML_EXT) ||
-	type.startsWith(APP_XML) ||
-	type.startsWith(APP_XML_EXTERNAL) ||
+        type.startsWith(TEXT_XML_EXT) ||
+        type.startsWith(APP_XML) ||
+        type.startsWith(APP_XML_EXTERNAL) ||
         type.endsWith(XML_SUFFIX);
   }
 


### PR DESCRIPTION
Allow HTTPPayload to process XML documents with a charset in the Content-Type by relaxing boolean expression MimeTypes.isXML()
