### PR TITLE
Unique Variable Names in Expr#toString()

### DIFF
--- a/basex-core/src/main/java/org/basex/query/var/Var.java
+++ b/basex-core/src/main/java/org/basex/query/var/Var.java
@@ -199,7 +199,7 @@ public final class Var extends ExprInfo {
   public String toString() {
     final TokenBuilder tb = new TokenBuilder();
     if(name != null) {
-      tb.add(QueryText.DOLLAR).add(name.string())/* .add('_').addInt(id) */;
+      tb.add(QueryText.DOLLAR).add(name.string()).add('_').addInt(id);
       if(declType != null) tb.add(' ' + QueryText.AS);
     }
     if(declType != null) tb.add(" " + declType);

--- a/basex-core/src/main/java/org/basex/query/var/VarRef.java
+++ b/basex-core/src/main/java/org/basex/query/var/VarRef.java
@@ -115,7 +115,7 @@ public final class VarRef extends ParseExpr {
   @Override
   public String toString() {
     return new TokenBuilder(DOLLAR).add(
-        var.name.toString())/* .add('_').addInt(var.id) */.toString();
+        var.name.toString()).add('_').addInt(var.id).toString();
   }
 
   @Override


### PR DESCRIPTION
Because of inlining, the output of `Expr#toString()` can become invalid when a variable reference is inlined into the scope of another variable with the same name:

``` xquery
let $a := random:integer()
let $b := $a
for $a in 1 to 10
return $b
```

... would be shown as

``` xquery
let $a := random:integer()
for $a in (1 to 10)
return $a
```

Now it will become:

``` xquery
let $a_0 := random:integer()
for $a_2 in (1 to 10)
return $a_0
```

This change makes the output of the _Query Info_ a bit less readable in simple cases, but a low less confusing in more complex ones.
