### PR TITLE
Fixes for XQDoc parsing.

### DIFF
--- a/basex-core/src/main/java/org/basex/query/util/inspect/PlainDoc.java
+++ b/basex-core/src/main/java/org/basex/query/util/inspect/PlainDoc.java
@@ -139,7 +139,7 @@ public final class PlainDoc extends Inspect {
     final SeqType rt = sf != null ? sf.type() : ftype.type;
     final FElem ret = type(rt, elem("return", function));
     final TokenList returns = doc != null ? doc.get(DOC_RETURN) : null;
-    if(returns != null) for(final byte[] val : returns) ret.add(val);
+    if(returns != null) for(final byte[] val : returns) add(val, ctx.context, ret);
     return function;
   }
 

--- a/basex-core/src/main/java/org/basex/query/util/inspect/XQDoc.java
+++ b/basex-core/src/main/java/org/basex/query/util/inspect/XQDoc.java
@@ -82,21 +82,33 @@ public final class XQDoc extends Inspect {
     // functions
     final FElem functions = elem("functions", xqdoc);
     for(final StaticFunc sf : qp.funcs) {
-      final int al = sf.args.length;
+      final int al = sf.arity();
+      final QNm name = sf.fName();
+      final FuncType t = sf.funcType();
       final FElem function = elem("function", functions).add("arity", token(al));
       comment(sf, function);
-      elem("name", function).add(sf.name.string());
-      if(sf.name.hasPrefix()) nsCache.put(sf.name.prefix(), sf.name.uri());
+      elem("name", function).add(name.string());
+      if(name.hasPrefix()) nsCache.put(name.prefix(), name.uri());
       annotations(sf.ann, function);
 
-      elem("signature", function).add(sf.toString().replaceAll(" \\{.*| \\w+;.*", ""));
+      final TokenBuilder tb = new TokenBuilder(DECLARE).add(' ').addExt(sf.ann);
+      tb.add(FUNCTION).add(' ').add(name.string()).add(PAR1);
+      for(int i = 0; i < al; i++) {
+        final Var v = sf.args[i];
+        if(i > 0) tb.add(SEP);
+        tb.add(DOLLAR).add(v.name.string()).add(' ').add(AS).add(' ').addExt(t.args[i]);
+      }
+      tb.add(PAR2).add(' ' + AS + ' ' + t.type);
+      if(sf.expr == null) tb.add(" external");
+
+      elem("signature", function).add(tb.toString());
       if(al != 0) {
         final FElem fparameters = elem("parameters", function);
         for(int a = 0; a < al; a++) {
           final FElem fparameter = elem("parameter", fparameters);
           final Var v = sf.args[a];
           elem("name", fparameter).add(v.name.string());
-          type(v.declType, fparameter);
+          type(t.args[a], fparameter);
         }
       }
       type(sf.type(), elem("return", function));


### PR DESCRIPTION
- `PlainDoc`: allowed HTML in `@param` and `@return`
- `XQDoc`: no variable IDs in function signature
