### PR TITLE
[FIX] Better typing for inline functions.

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryCompiler.java
+++ b/basex-core/src/main/java/org/basex/query/QueryCompiler.java
@@ -6,6 +6,7 @@ import java.util.*;
 
 import org.basex.query.func.*;
 import org.basex.query.util.*;
+import org.basex.query.value.item.*;
 import org.basex.query.var.*;
 import org.basex.util.*;
 import org.basex.util.list.*;
@@ -208,6 +209,11 @@ final class QueryCompiler {
       @Override
       public boolean inlineFunc(final Scope sub) {
         return sub.visit(this);
+      }
+
+      @Override
+      public boolean funcItem(final FuncItem func) {
+        return neighbor(func);
       }
 
       /**

--- a/basex-core/src/main/java/org/basex/query/func/FNXQuery.java
+++ b/basex-core/src/main/java/org/basex/query/func/FNXQuery.java
@@ -127,8 +127,8 @@ public final class FNXQuery extends StandardFunc {
    * @return the argument expression
    */
   private Expr type(final QueryContext ctx) {
-    FNInfo.dump(Util.inf("{ type: %, size: % }", expr[0].type(), expr[0].size()),
-        token(expr[0].toString()), ctx);
+    FNInfo.dump(Util.inf("{ type: %, size: %, exprSize: % }", expr[0].type(), expr[0].size(),
+        expr[0].exprSize()), token(expr[0].toString()), ctx);
     return expr[0];
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/InlineFunc.java
+++ b/basex-core/src/main/java/org/basex/query/func/InlineFunc.java
@@ -143,7 +143,9 @@ public final class InlineFunc extends Single implements Scope {
 
   @Override
   public Expr optimize(final QueryContext ctx, final VarScope scp) throws QueryException {
-    type = FuncType.get(ann, args, ret).seqType();
+    final SeqType r = expr.type();
+    final SeqType retType = ret == null || r.instanceOf(ret) ? r : ret;
+    type = FuncType.get(ann, args, retType).seqType();
     size = 1;
 
     final int fp = scope.enter(ctx);
@@ -200,8 +202,8 @@ public final class InlineFunc extends Single implements Scope {
 
   @Override
   public FuncItem item(final QueryContext ctx, final InputInfo ii) throws QueryException {
-    final FuncType ft = FuncType.get(ann, args, ret);
-    final boolean c = ft.type != null && !expr.type().instanceOf(ft.type);
+    final FuncType ft = (FuncType) type().type;
+    final boolean c = ret != null && !expr.type().instanceOf(ret);
 
     // collect closure
     final Map<Var, Value> clos = new HashMap<Var, Value>();

--- a/basex-core/src/main/java/org/basex/query/func/StaticFuncs.java
+++ b/basex-core/src/main/java/org/basex/query/func/StaticFuncs.java
@@ -209,7 +209,12 @@ public final class StaticFuncs extends ExprInfo {
 
   @Override
   public void plan(final FElem plan) {
-    if(!funcs.isEmpty()) addPlan(plan, planElem(), funcs());
+    if(!funcs.isEmpty()) {
+      final FElem el = planElem();
+      plan.add(el);
+      for(final StaticFunc f : funcs())
+        if(f != null && f.compiled()) f.plan(el);
+    }
   }
 
   /**
@@ -228,7 +233,9 @@ public final class StaticFuncs extends ExprInfo {
   public String toString() {
     final StringBuilder sb = new StringBuilder();
     for(final FuncCache fc : funcs.values()) {
-      sb.append(fc.func.toString()).append(Text.NL);
+      if(fc.func != null && fc.func.compiled()) {
+        sb.append(fc.func.toString()).append(Text.NL);
+      }
     }
     return sb.toString();
   }

--- a/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java
@@ -77,9 +77,9 @@ public final class FuncItemTest extends QueryPlanTest {
   @Test
   public void compStatUnusedTest() {
     check("declare function local:foo() { abs(?) };" +
-        "function-lookup(xs:QName('local:foo'), 0)()(-42)",
+        "function-lookup(xs:QName(('local:foo')[random:double() < 1]), 0)()(-42)",
         "42",
-        "exists(//" + Util.className(PartFunc.class) + ')'
+        "empty(//" + Util.className(StaticFuncs.class) + "/*)"
     );
   }
 

--- a/basex-core/src/test/java/org/basex/query/func/FNInspectTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FNInspectTest.java
@@ -29,12 +29,12 @@ public final class FNInspectTest extends AdvancedQueryTest {
     query(func + "/return/@type/data()", "item()");
     query(func + "/return/@occurrence/data()", "*");
 
-    func = query(_INSPECT_FUNCTION.args(" function($a as xs:string) as item() { $a }"));
+    func = query(_INSPECT_FUNCTION.args(" function($a as xs:int) as xs:integer { $a + 1 }"));
     query(func + "/@name/data()", "");
     query(func + "/@uri/data()", "");
     query(func + "/argument/@name/data()", "");
-    query(func + "/argument/@type/data()", "xs:string");
-    query(func + "/return/@type/data()", "item()");
+    query(func + "/argument/@type/data()", "xs:int");
+    query(func + "/return/@type/data()", "xs:integer");
     query(func + "/return/@occurrence/data()", "");
 
     func = query("declare %private function Q{U}f($v as xs:int) as xs:integer {$v};" +


### PR DESCRIPTION
- inferred return type of inline functions is reflected in their type
- only compiled functions are shown in the _Info View_
