### PR TITLE
[MOD] Escape newline characters in Str#toString().

### DIFF
--- a/basex-core/src/main/java/org/basex/data/DataText.java
+++ b/basex-core/src/main/java/org/basex/data/DataText.java
@@ -143,6 +143,10 @@ public interface DataText {
   byte[] E_GT = token("&gt;");
   /** LessThan entity. */
   byte[] E_LT = token("&lt;");
+  /** Carriage return. */
+  byte[] E_0D = token("&#x0D;");
+  /** Line feed. */
+  byte[] E_0A = token("&#x0A;");
   /** Line separator. */
   byte[] E_2028 = token("&#x2028;");
   /** HTML: Non-breaking space entity. */

--- a/basex-core/src/main/java/org/basex/query/value/item/Str.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/Str.java
@@ -111,6 +111,8 @@ public class Str extends AStr {
     tb.add('"');
     for(final byte v : val) {
       if(v == '&') tb.add(E_AMP);
+      else if(v == '\r') tb.add(E_0D);
+      else if(v == '\n') tb.add(E_0A);
       else tb.add(v);
       if(v == '"') tb.add('"');
     }


### PR DESCRIPTION
Makes compiler output easier to handle by printing string literals in one line.
