### PR TITLE
fix a bug on a query example for python

### DIFF
--- a/basex-api/src/main/python/QueryExample.py
+++ b/basex-api/src/main/python/QueryExample.py
@@ -16,9 +16,7 @@ try:
     input = "for $i in 1 to 10 return <xml>Text { $i }</xml>"
     query = session.query(input)
 
-    # loop through all results
-    while query.more():
-      print query.next()
+    print query.execute()
   
     # close query object  
     query.close()


### PR DESCRIPTION
Methods used by the former example,  `query.more()` and `query.next()`, do not exist any longer. 
I've modified  them to `query.execute()`, according to `BaseXClient.py`, to make it run as good as it should be.
