### PR TITLE
[MOD] Do not expose server object before construction finished.

### DIFF
--- a/basex-core/src/test/java/org/basex/SandboxTest.java
+++ b/basex-core/src/test/java/org/basex/SandboxTest.java
@@ -1,18 +1,24 @@
 package org.basex;
 
-import static org.basex.core.Text.*;
-import static org.junit.Assert.*;
+import org.basex.api.client.ClientSession;
+import org.basex.core.Command;
+import org.basex.core.Context;
+import org.basex.core.GlobalOptions;
+import org.basex.io.IOFile;
+import org.basex.io.out.NullOutput;
+import org.basex.util.Prop;
+import org.basex.util.Util;
+import org.basex.util.list.StringList;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
-import java.io.*;
-import java.util.concurrent.*;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.concurrent.CountDownLatch;
 
-import org.basex.api.client.*;
-import org.basex.core.*;
-import org.basex.io.*;
-import org.basex.io.out.*;
-import org.basex.util.*;
-import org.basex.util.list.*;
-import org.junit.*;
+import static org.basex.core.Text.S_ADMIN;
+import static org.basex.core.Text.S_LOCALHOST;
+import static org.junit.Assert.assertTrue;
 
 /**
  * If this class is extended, tests will be run in a sandbox.
@@ -81,7 +87,7 @@ public abstract class SandboxTest {
       System.setOut(NULL);
       final StringList sl = new StringList().add("-z").add("-p9999").add("-e9998");
       for(final String a : args) sl.add(a);
-      final BaseXServer server = new BaseXServer(sl.finish());
+      final BaseXServer server = BaseXServer.createServer(sl.finish());
       server.context.globalopts.set(GlobalOptions.DBPATH, sandbox().path());
       return server;
     } finally {


### PR DESCRIPTION
As discussed, I do think exposing the object before construction is complete is always a problem.

From www.ibm.com/developerworks/java/library/j-jtp0618/index.html:

> The practices detailed above for thread-safe construction take on even more importance when we consider the effects of synchronization. For example, when thread A starts thread B, the Java Language Specification (JLS) guarantees that all variables that were visible to thread A when it starts thread B are visible to thread B, which is effectively like having an implicit synchronization in Thread.start(). If we start a thread from within a constructor, the object under construction is not completely constructed, and so we lose these visibility guarantees. 

This is just a first commit, as I wanted to discuss if you agree with the problem. 

To fix this issue in the complete code base requires a bit more work, because there are quite a number of occurences of code in constructors like

```
Runtime.getRuntime().addShutdownHook(new Thread() {
  @Override
  public synchronized void run() {
    context.close();
  }
});
```

which is also unsafe (in my opinion).
