### PR TITLE
[MOD] CLI scripts do need " for correct encapsulation

### DIFF
--- a/basex-api/etc/basexhttp
+++ b/basex-api/etc/basexhttp
@@ -17,4 +17,4 @@ CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar "$BXCORE/lib/"*.jar)"
 BASEX_JVM="-Xmx512m $BASEX_JVM"
 
 # Run code
-java -cp $CP $BASEX_JVM org.basex.BaseXHTTP $@
+java -cp "$CP" $BASEX_JVM org.basex.BaseXHTTP "$@"

--- a/basex-api/etc/basexhttpstop
+++ b/basex-api/etc/basexhttpstop
@@ -14,4 +14,4 @@ BXCORE="$( cd -P "$BX/../basex-core" && pwd )"
 CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar "$BXCORE/lib/"*.jar)"
 
 # Run code
-java -cp $CP $BASEX_JVM org.basex.BaseXHTTP $@ stop
+java -cp "$CP" $BASEX_JVM org.basex.BaseXHTTP "$@" stop

--- a/basex-core/etc/basex
+++ b/basex-core/etc/basex
@@ -16,4 +16,4 @@ CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar)"
 BASEX_JVM="-Xmx512m $BASEX_JVM"
 
 # Run code
-java -cp $CP $BASEX_JVM org.basex.BaseX $@
+java -cp "$CP" $BASEX_JVM org.basex.BaseX "$@"

--- a/basex-core/etc/basexclient
+++ b/basex-core/etc/basexclient
@@ -13,4 +13,4 @@ BX="$( cd -P "$(dirname "$FILE")/.." && pwd )"
 CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar)"
 
 # Run code
-java -cp $CP $BASEX_JVM org.basex.BaseXClient $@
+java -cp "$CP" $BASEX_JVM org.basex.BaseXClient "$@"

--- a/basex-core/etc/basexgui
+++ b/basex-core/etc/basexgui
@@ -16,4 +16,4 @@ CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar)"
 BASEX_JVM="-Xmx512m $BASEX_JVM"
 
 # Run code
-java -cp $CP $BASEX_JVM org.basex.BaseXGUI $@
+java -cp "$CP" $BASEX_JVM org.basex.BaseXGUI "$@"

--- a/basex-core/etc/basexserver
+++ b/basex-core/etc/basexserver
@@ -16,4 +16,4 @@ CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar)"
 BASEX_JVM="-Xmx512m $BASEX_JVM"
 
 # Run code
-java -cp $CP $BASEX_JVM org.basex.BaseXServer $@
+java -cp "$CP" $BASEX_JVM org.basex.BaseXServer "$@"

--- a/basex-core/etc/basexserverstop
+++ b/basex-core/etc/basexserverstop
@@ -13,4 +13,4 @@ BX="$( cd -P "$(dirname "$FILE")/.." && pwd )"
 CP="$BX/target/classes"
 
 # Run code
-java -cp $CP $BASEX_JVM org.basex.BaseXServer $@ stop
+java -cp "$CP" $BASEX_JVM org.basex.BaseXServer "$@" stop


### PR DESCRIPTION
Mainly a revert of 23bb2aa51e543af6e3bf80a18bbe1d91c21bc2b8, although `BASEX_JVM` should not be encapsulated.

The problem described at https://mailman.uni-konstanz.de/pipermail/basex-talk/2014-November/007570.html is fixed by this, otherwise the encapsulation is not correct. So seems like the "" are indeed necessary.
