### PR TITLE
Changed redirect to a relative address

### DIFF
--- a/basex-api/src/main/webapp/dba/util.xqm
+++ b/basex-api/src/main/webapp/dba/util.xqm
@@ -17,7 +17,7 @@ declare
   %rest:path("dba")
 function _:redirect(
 ) {
-  web:redirect('/dba/databases')
+  web:redirect('dba/databases')
 };
 
 (:~


### PR DESCRIPTION
When an absolute address was used, the redirection possibly stripped the base path away. Especially using BaseX as a Tomcat webapp, the redirection was broken. Instead of the correct redirection:
``http://localhost:8080/webapp-name/dba`` -> ``http://localhost:8080/webapp-name/dba/databases``
this incorrect was produced:
``http://localhost:8080/webapp-name/dba`` -> ``http://localhost:8080/dba/databases``

 Using a relative address should work *always*.

This solves a problem partially mentioned in #1060 