### PR TITLE
Two more HOFs: `hof:take-while($seq, $pred)` and `hof:scan-left($seq, $start, $f)`.

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -970,7 +970,14 @@ public enum Function {
 
   /** XQuery function. */
   _HOF_SORT_WITH(HofSortWith.class, "sort-with(items,lt-fun)",
-      arg(ITEM_ZM, FuncType.get(BLN, ITEM, ITEM).seqType()), ITEM_ZM, HOF_URI),
+      arg(ITEM_ZM, FuncType.get(BLN, ITEM, ITEM).seqType()), ITEM_ZM, flag(HOF), HOF_URI),
+  /** XQuery function. */
+  _HOF_TAKE_WHILE(HofTakeWhile.class, "take-while(items,pred)",
+      arg(ITEM_ZM, FuncType.get(BLN, ITEM).seqType()), ITEM_ZM, flag(HOF), HOF_URI),
+  /** XQuery function. */
+  _HOF_SCAN_LEFT(HofScanLeft.class, "scan-left(items,start,function)",
+      arg(ITEM_ZM, ITEM_ZM, FuncType.get(ITEM_ZM, ITEM_ZM, ITEM).seqType()), ITEM_ZM, flag(HOF),
+      HOF_URI),
   /** XQuery function. */
   _HOF_ID(HofId.class, "id(value)", arg(ITEM_ZM), ITEM_ZM, HOF_URI),
   /** XQuery function. */

--- a/basex-core/src/main/java/org/basex/query/func/hof/HofScanLeft.java
+++ b/basex-core/src/main/java/org/basex/query/func/hof/HofScanLeft.java
@@ -1,0 +1,43 @@
+package org.basex.query.func.hof;
+
+import org.basex.query.*;
+import org.basex.query.expr.*;
+import org.basex.query.func.*;
+import org.basex.query.iter.*;
+import org.basex.query.value.*;
+import org.basex.query.value.item.*;
+import org.basex.query.var.*;
+
+/**
+ * Inplements the {@code hof:scan-left($seq, $start, $f)} function.
+ *
+ * @author BaseX Team 2005-15, BSD License
+ * @author Leo Woerteler
+ */
+public final class HofScanLeft extends StandardFunc {
+  @Override
+  public Iter iter(final QueryContext qc) throws QueryException {
+    final Iter outer = qc.iter(exprs[0]);
+    final FItem f = checkArity(exprs[2], 2, qc);
+    return new Iter() {
+      private Value acc = qc.value(exprs[1]);
+      private Iter inner = acc.iter();
+      @Override
+      public Item next() throws QueryException {
+        for(;;) {
+          final Item i = inner.next();
+          if(i != null) return i;
+          final Item o = outer.next();
+          if(o == null) return null;
+          acc = f.invokeValue(qc, info, acc, o);
+          inner = acc.iter();
+        }
+      }
+    };
+  }
+
+  @Override
+  protected Expr opt(final QueryContext qc, final VarScope scp) throws QueryException {
+    return exprs[0].isEmpty() ? exprs[1] : this;
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/func/hof/HofTakeWhile.java
+++ b/basex-core/src/main/java/org/basex/query/func/hof/HofTakeWhile.java
@@ -1,0 +1,49 @@
+package org.basex.query.func.hof;
+
+import org.basex.query.*;
+import org.basex.query.expr.*;
+import org.basex.query.func.*;
+import org.basex.query.iter.*;
+import org.basex.query.value.*;
+import org.basex.query.value.item.*;
+import org.basex.query.value.seq.*;
+import org.basex.query.var.*;
+
+/**
+ * Inplements the {@code hof:take-while($seq, $pred)} function.
+ *
+ * @author BaseX Team 2005-15, BSD License
+ * @author Leo Woerteler
+ */
+public final class HofTakeWhile extends StandardFunc {
+  @Override
+  public Iter iter(final QueryContext qc) throws QueryException {
+    final Iter in = qc.iter(exprs[0]);
+    final FItem pred = checkArity(exprs[1], 1, qc);
+    return new Iter() {
+      @Override
+      public Item next() throws QueryException {
+        final Item it = in.next();
+        if(it != null && pred.invokeValue(qc, info, it).ebv(qc, info).bool(info)) return it;
+        return null;
+      }
+    };
+  }
+
+  @Override
+  public Value value(final QueryContext qc) throws QueryException {
+    final ValueBuilder vb = new ValueBuilder();
+    final FItem pred = checkArity(exprs[1], 1, qc);
+    final Iter iter = qc.iter(exprs[0]);
+    for(Item it; (it = iter.next()) != null;) {
+      if(!pred.invokeValue(qc, info, it).ebv(qc, info).bool(info)) break;
+      vb.add(it);
+    }
+    return vb.value();
+  }
+
+  @Override
+  protected Expr opt(final QueryContext qc, final VarScope scp) throws QueryException {
+    return exprs[0].isEmpty() ? Empty.SEQ : this;
+  }
+}


### PR DESCRIPTION
 * `hof:take-while($seq, $pred)` is equivalent to:

   ```xquery
   declare function hof:take-while($seq, $pred) {
     if(empty($seq) or not($pred(head($seq)))) then ()
     else (
       head($seq),
       hof:take-while(tail($seq), $pred)
     )
   };
   ```
 * `hof:scan-left($seq, $start, $f)` is equivalent to:

   ```xquery
   declare function hof:scan-left($seq, $acc, $f) {
     if(empty($seq)) then $acc
     else (
       $acc,
       hof:scan-left(tail($seq), $f($acc, head($seq)), $f)
     )
   };
   ```