### PR TITLE
Retain system properties when starting in service mode

### DIFF
--- a/basex-core/src/main/java/org/basex/util/Util.java
+++ b/basex-core/src/main/java/org/basex/util/Util.java
@@ -262,7 +262,7 @@ public final class Util {
 
     for(final Entry<Object, Object> o : System.getProperties().entrySet()) {
       final String k = o.getKey().toString();
-      if(k.startsWith(Prop.DBPREFIX)) sl.add("-D" + o.getValue());
+      if(k.startsWith(Prop.DBPREFIX)) sl.add("-D" + k + "=" + o.getValue());
     }
     sl.add(clazz.getName()).add("-D").add(args);
 


### PR DESCRIPTION
When starting in service mode, system properties got lost as the key of the property was not copied into the arguments of the new process.