### PR TITLE
Do not ignore $CLASSPATH additions

### DIFF
--- a/basex-api/etc/basexhttp
+++ b/basex-api/etc/basexhttp
@@ -11,7 +11,7 @@ BX="$( cd -P "$(dirname "$FILE")/.." && pwd )"
 BXCORE="$( cd -P "$BX/../basex-core" && pwd )"
 
 # API, core, and library classes
-CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar "$BXCORE/lib/"*.jar)"
+CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar "$BXCORE/lib/"*.jar):$CLASSPATH"
 
 # Options for virtual machine (can be extended by global options)
 BASEX_JVM="-Xmx512m $BASEX_JVM"

--- a/basex-core/etc/basex
+++ b/basex-core/etc/basex
@@ -10,7 +10,7 @@ done
 BX="$( cd -P "$(dirname "$FILE")/.." && pwd )"
 
 # Core and library classes
-CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar)"
+CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar):$CLASSPATH"
 
 # Options for virtual machine (can be extended by global options)
 BASEX_JVM="-Xmx512m $BASEX_JVM"

--- a/basex-core/etc/basexgui
+++ b/basex-core/etc/basexgui
@@ -10,7 +10,7 @@ done
 BX="$( cd -P "$(dirname "$FILE")/.." && pwd )"
 
 # Core and library classes
-CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar)"
+CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar):$CLASSPATH"
 
 # Options for virtual machine (can be extended by global options)
 BASEX_JVM="-Xmx512m $BASEX_JVM"

--- a/basex-core/etc/basexserver
+++ b/basex-core/etc/basexserver
@@ -10,7 +10,7 @@ done
 BX="$( cd -P "$(dirname "$FILE")/.." && pwd )"
 
 # Core and library classes
-CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar)"
+CP="$BX/target/classes$(printf ":%s" "$BX/lib/"*.jar):$CLASSPATH"
 
 # Options for virtual machine (can be extended by global options)
 BASEX_JVM="-Xmx512m $BASEX_JVM"


### PR DESCRIPTION
BaseX sets `-cp` when starting java to include its own classes, but thus overwrites the `$CLASSPATH` environment variable (java ignores it when `-cp` is set). This does not leave the developer the choice to use environment variables for loading additional helper classes, which sometimes is easier and cleaner compared to linking into the BaseX `lib` folder (or even isn't possible if running on a shared host without write privileges to `/usr`).

With the patch, for example Apache batik could be loaded using

    export CLASSPATH=/usr/share/java/batik.jar
    basexhttp