### PR TITLE
Syntax highlighting in Queries editor

### DIFF
--- a/basex-api/src/main/webapp/dba/files/editor.js
+++ b/basex-api/src/main/webapp/dba/files/editor.js
@@ -4,6 +4,10 @@ function openQuery() {
     null,
     function(req) {
       document.getElementById("editor").value = req.responseText;
+      //The next line sends a 'change' event to all listeners to the 'editor'
+      //This allows the syntax highlighter to hear that the text area value has changed
+      //Programatic changes to the value don't send events automatically
+      document.getElementById("editor").dispatchEvent(new Event("change",{ bubbles: false, cancelable: false }));
     },
     function(req) {
       setError('Query could not be opened.');
@@ -74,3 +78,18 @@ function queryExists() {
   }
   return false;
 };
+
+/**
+ * Replaces the 'editor' text area with a CodeMirror syntax-highlighted editor
+ * Adds event listeners to each to synchronise changes between the two
+ *
+ */
+function replaceEditor() {
+  if (CodeMirror) {
+    var editor = document.getElementById("editor")
+    var codeMirrorEditor = CodeMirror.fromTextArea(editor);
+    codeMirrorEditor.on("change",function(cm, cmo) { cm.save() });
+    codeMirrorEditor.display.wrapper.style.border = "solid 1pt black";
+    editor.addEventListener("change",function() {codeMirrorEditor.setValue(editor.value)});
+  }
+}

--- a/basex-api/src/main/webapp/dba/modules/tmpl.xqm
+++ b/basex-api/src/main/webapp/dba/modules/tmpl.xqm
@@ -41,6 +41,7 @@ declare function tmpl:wrap(
       <meta name="description" content="Database Administration"/>
       <meta name="author" content="BaseX Team, 2014-15"/>
       <link rel="stylesheet" type="text/css" href="files/style.css"/> 
+      <link rel="stylesheet" type="text/css" href="files/codemirror/lib/codemirror.css"/> 
       <script type="text/javascript" src="files/js.js"/>
     </head>
     <body>

--- a/basex-api/src/main/webapp/dba/queries/queries.xqm
+++ b/basex-api/src/main/webapp/dba/queries/queries.xqm
@@ -67,6 +67,9 @@ function _:queries(
                 <button type='delete' name='delete' id='delete' disabled='true'
                         onclick='deleteQuery()'>Delete</button>
                 <script type="text/javascript" src="files/editor.js"/>
+                <script type="text/javascript" src="files/codemirror/lib/codemirror.js"/>
+                <script type="text/javascript" src="files/codemirror/mode/xquery/xquery.js"/>
+                <script type="text/javascript">replaceEditor();</script>
               </div>
             </td>
           </tr>


### PR DESCRIPTION
It's not to the level of sophistication of the GUI but I've used CodeMirror to implement basic syntax highlighting in the Editor portion of the Queries screen in DBA.

This pull request has the required changes to the BaseX files.

Additionally you need to have the CodeMirror files. As I'm not sure how you include (or would include) files from other projects in BaseX so I haven't added them here.

I put a folder in 'files' called 'codemirror'. Inside there:

./lib/codemirror.css
./lib/codemirror.js
./mode/xquery/xquery.js
./LICENSE

![syntax-highlighting](https://cloud.githubusercontent.com/assets/12566746/7784080/6c31b466-0150-11e5-8e61-86a9993d2be4.jpg)
