### PR TITLE
Explicitly set Content-Type when making XHR request from DBA

### DIFF
--- a/basex-api/src/main/webapp/dba/files/js.js
+++ b/basex-api/src/main/webapp/dba/files/js.js
@@ -148,5 +148,6 @@ function request(method, url, data, success, failure) {
   };
   // synchronous querying: wait for server feedback
   req.open(method, url, true);
+  req.setRequestHeader("Content-Type", "text/plain");
   req.send(data);
 };


### PR DESCRIPTION
Explicitly setting Content-Type to text/plain in the request function of js.js. When it is not set, Safari (testing on 7.1.6 Mac) defaults to 'application/xml' and so BaseX refuses to accept anything that isn't XML. This can be seen when trying to save an xquery.

(Firefox defaults to 'text/plain' so there shouldn't be any change in behaviour there.)

I think I've checked for all current cases where this function is called as POST with data (the only time it'll be a problem) and text/plain works for all.