### PR TITLE
Correct variable name in drop() function in Optimize

### DIFF
--- a/basex-api/src/main/webapp/dba/databases/optimize.xqm
+++ b/basex-api/src/main/webapp/dba/databases/optimize.xqm
@@ -157,7 +157,7 @@ function _:drop(
 ) {
   cons:check(),
   try {
-    util:update("$names ! db:optimize(.)", map { 'n': $names }),
+    util:update("$n ! db:optimize(.)", map { 'n': $names }),
     db:output(web:redirect($_:CAT, map { 'info': 'Optimized databases: ' || count($names) }))
   } catch * {
     db:output(web:redirect($_:CAT, map { 'error': $err:description }))


### PR DESCRIPTION
Pressing Optimize on the databases screens fails with an error that $names is not defined.

In optimize.xqm the function string call to util:update contains the variable name $names when the map variable is called $n. This now matches the function in databases.xqm.