### PR TITLE
Syntax highlighting in Queries (2)

### DIFF
--- a/basex-api/src/main/webapp/dba/files/editor.js
+++ b/basex-api/src/main/webapp/dba/files/editor.js
@@ -4,7 +4,9 @@ function openQuery() {
     null,
     function(req) {
       document.getElementById("editor").value = req.responseText;
-      document.getElementById("editor").dispatchEvent(new Event("change",{ bubbles: false, cancelable: false }));
+      var evt = document.createEvent("HTMLEvents");
+      evt.initEvent("change",false,false);
+      document.getElementById("editor").dispatchEvent(evt);
     },
     function(req) {
       setError('Query could not be opened.');
@@ -76,16 +78,8 @@ function queryExists() {
   return false;
 };
 
-function loadCodeMirrorCSS() {
-    var link = document.createElement("link");
-    link.setAttribute("rel", "stylesheet");
-    link.setAttribute("type", "text/css");
-    link.setAttribute("href", "files/codemirror/lib/codemirror.css");
-    document.head.appendChild(link);
-}
-
 function loadCodeMirror() {
-  if (CodeMirror) {
+  if (CodeMirror && dispatchEvent) {
     //Now replace the editor and result areas
     var editorArea = document.getElementById("editor");
     var codeMirrorEditor = CodeMirror.fromTextArea(editorArea, {

--- a/basex-api/src/main/webapp/dba/files/editor.js
+++ b/basex-api/src/main/webapp/dba/files/editor.js
@@ -4,6 +4,7 @@ function openQuery() {
     null,
     function(req) {
       document.getElementById("editor").value = req.responseText;
+      document.getElementById("editor").dispatchEvent(new Event("change",{ bubbles: false, cancelable: false }));
     },
     function(req) {
       setError('Query could not be opened.');
@@ -74,3 +75,56 @@ function queryExists() {
   }
   return false;
 };
+
+function loadCodeMirrorCSS() {
+    var link = document.createElement("link");
+    link.setAttribute("rel", "stylesheet");
+    link.setAttribute("type", "text/css");
+    link.setAttribute("href", "files/codemirror/lib/codemirror.css");
+    document.head.appendChild(link);
+}
+
+function loadCodeMirror() {
+  if (CodeMirror) {
+    //Now replace the editor and result areas
+    var editorArea = document.getElementById("editor");
+    var codeMirrorEditor = CodeMirror.fromTextArea(editorArea, {
+      mode: "xquery",
+      lineNumbers: true,
+      extraKeys: {
+        "Ctrl-Enter": function(cm) {
+           editor("Please wait…", "Query was successful.", true);
+        },
+        "Cmd-Enter": function(cm) {
+           editor("Please wait…", "Query was successful.", true);
+        }
+      }
+    });
+    codeMirrorEditor.on("change",function(cm, cmo) {
+        cm.save();
+        editor("Please wait…", "Query was successful.", false);
+      }
+    );
+    codeMirrorEditor.display.wrapper.style.border = "solid 1pt black";
+    editorArea.addEventListener("change",function() {
+      codeMirrorEditor.setValue(editorArea.value);
+    });
+    var outputArea = document.getElementById("output");
+    var codeMirrorResult = CodeMirror.fromTextArea(outputArea, {mode: "xml"});
+    codeMirrorResult.display.wrapper.style.border = "solid 1pt black";
+    outputArea.addEventListener("change",function() {codeMirrorResult.setValue(outputArea.value)});
+    window.addEventListener("load",setDisplayHeight);
+    window.addEventListener("resize",setDisplayHeight);
+  }
+}
+
+function setDisplayHeight() {
+    var elem = document.createElement("div");
+    document.body.appendChild(elem);
+    p = elem.offsetTop + 48 //To account for margin, it works but is not bullet proof.
+    var c = document.getElementsByClassName("CodeMirror")[0].offsetHeight;
+    var s = window.innerHeight;
+    Array.prototype.forEach.call(document.getElementsByClassName("CodeMirror"),function(cm) {
+        cm.CodeMirror.setSize("100%",Math.max(200,s-(p-c)));
+    });
+}

--- a/basex-api/src/main/webapp/dba/files/js.js
+++ b/basex-api/src/main/webapp/dba/files/js.js
@@ -131,6 +131,7 @@ function editor(wait, success, enforce) {
     var target = update ? 'update-query' : 'eval-query';
     query(wait, success, target, editor, enforce, function(text) {
       document.getElementById("output").value = text;
+      document.getElementById("output").dispatchEvent(new Event("change",{ bubbles: false, cancelable: false }));
     });
   }
 };

--- a/basex-api/src/main/webapp/dba/files/js.js
+++ b/basex-api/src/main/webapp/dba/files/js.js
@@ -131,7 +131,9 @@ function editor(wait, success, enforce) {
     var target = update ? 'update-query' : 'eval-query';
     query(wait, success, target, editor, enforce, function(text) {
       document.getElementById("output").value = text;
-      document.getElementById("output").dispatchEvent(new Event("change",{ bubbles: false, cancelable: false }));
+      var evt = document.createEvent("HTMLEvents");
+      evt.initEvent("change",false,false);
+      document.getElementById("output").dispatchEvent(evt);
     });
   }
 };

--- a/basex-api/src/main/webapp/dba/modules/tmpl.xqm
+++ b/basex-api/src/main/webapp/dba/modules/tmpl.xqm
@@ -41,7 +41,9 @@ declare function tmpl:wrap(
       <meta name="description" content="Database Administration"/>
       <meta name="author" content="BaseX Team, 2014-15"/>
       <link rel="stylesheet" type="text/css" href="files/style.css"/> 
+      {$options('css')[.] ! <link rel="stylesheet" type="text/css" href="files/{.}"/>} 
       <script type="text/javascript" src="files/js.js"/>
+      {$options('scripts')[.] ! <script type="text/javascript" src="files/{.}"/>} 
     </head>
     <body>
       <div class="right"><img style='padding-left:10px;padding-bottom:10px;' src="files/basex.svg"/></div>

--- a/basex-api/src/main/webapp/dba/queries/queries.xqm
+++ b/basex-api/src/main/webapp/dba/queries/queries.xqm
@@ -34,7 +34,7 @@ function _:queries(
   cons:check(),
 
   let $f := function($b) { "editor('Please wait…', 'Query was successful.', " || $b || ");" }
-  return tmpl:wrap(map { 'top': $_:CAT, 'info': $info, 'error': $error },
+  return tmpl:wrap(map { 'top': $_:CAT, 'info': $info, 'error': $error, 'css':'codemirror/lib/codemirror.css', 'scripts':('editor.js','codemirror/lib/codemirror.js','codemirror/mode/xquery/xquery.js','codemirror/mode/xml/xml.js') },
     <tr>
       <td width='50%'>
         <table width='100%'>
@@ -66,11 +66,6 @@ function _:queries(
                         onclick='saveQuery()'>Save</button>
                 <button type='delete' name='delete' id='delete' disabled='true'
                         onclick='deleteQuery()'>Delete</button>
-                <script type="text/javascript" src="files/editor.js"/>
-                <script type="text/javascript" src="files/codemirror/lib/codemirror.js"/>
-                <script type="text/javascript" src="files/codemirror/mode/xquery/xquery.js"/>
-                <script type="text/javascript" src="files/codemirror/mode/xml/xml.js"/>
-                <script type="text/javascript">loadCodeMirrorCSS();</script>
               </div>
             </td>
           </tr>

--- a/basex-api/src/main/webapp/dba/queries/queries.xqm
+++ b/basex-api/src/main/webapp/dba/queries/queries.xqm
@@ -67,6 +67,10 @@ function _:queries(
                 <button type='delete' name='delete' id='delete' disabled='true'
                         onclick='deleteQuery()'>Delete</button>
                 <script type="text/javascript" src="files/editor.js"/>
+                <script type="text/javascript" src="files/codemirror/lib/codemirror.js"/>
+                <script type="text/javascript" src="files/codemirror/mode/xquery/xquery.js"/>
+                <script type="text/javascript" src="files/codemirror/mode/xml/xml.js"/>
+                <script type="text/javascript">loadCodeMirrorCSS();</script>
               </div>
             </td>
           </tr>
@@ -82,6 +86,7 @@ function _:queries(
           </tr>
         </table>
         <textarea id='output' rows='20' readonly='' spellcheck='false'/>
+        <script type="text/javascript">loadCodeMirror();</script>
       </td>
     </tr>
   )


### PR DESCRIPTION
This pull request has the required changes to the BaseX files.

Additionally you need to have the CodeMirror files. As I'm not sure how you include (or would include) files from other projects in BaseX so I haven't added them here.

I put a folder in 'files' called 'codemirror'. Inside there:

./lib/codemirror.css
./lib/codemirror.js
./mode/xquery/xquery.js
./mode/xml/xml.js
./LICENSE

In this revised version:
- syntax highlighting of both the editor and result (XQuery and XML respectively)
- the realtime mode should work again
- resizing of the areas by dragging proved too difficult but I've implemented a function to expand them to the available screen height
- I've added a keybinding on the editor (CTRL-ENTER and CMD-ENTER) that will run the query. It's not the SHIFT-TAB you had before but it does match the GUI (and means you can use tabs in the editor)