### PR TITLE
[FIX] Allow global read lock with concurrent write lock

### DIFF
--- a/basex-api/src/main/webapp/dba/settings/settings.xqm
+++ b/basex-api/src/main/webapp/dba/settings/settings.xqm
@@ -9,6 +9,8 @@ import module namespace Request = 'http://exquery.org/ns/request';
 import module namespace cons = 'dba/cons' at '../modules/cons.xqm';
 import module namespace tmpl = 'dba/tmpl' at '../modules/tmpl.xqm';
 
+declare option query:write-lock 'settings';
+
 (:~ Top category :)
 declare variable $_:CAT := 'settings';
 

--- a/basex-core/src/main/java/org/basex/core/locks/DBLocking.java
+++ b/basex-core/src/main/java/org/basex/core/locks/DBLocking.java
@@ -138,7 +138,9 @@ public final class DBLocking implements Locking {
       }
       // global read locking
       if(read == null) {
-        while(localWriters > 0) {
+        while(localWriters > 0 &&
+            // We're the only writer, allow global read lock anyway
+            !(1 == localWriters && !(null == write || write.isEmpty()))) {
           try {
             globalLock.wait();
           } catch(final InterruptedException ex) {

--- a/basex-core/src/test/java/org/basex/core/LockingTest.java
+++ b/basex-core/src/test/java/org/basex/core/LockingTest.java
@@ -64,6 +64,21 @@ public final class LockingTest extends SandboxTest {
   }
 
   /**
+   * Single thread acquires both global read lock and a single write lock.
+   * @throws InterruptedException Got interrupted.
+   */
+  @Test
+  public void singleThreadGlobalReadLocalWriteTest() throws InterruptedException {
+    final CountDownLatch test = new CountDownLatch(1);
+    final LockTester th1 = new LockTester(null, null, objects, test);
+
+    th1.start();
+    assertTrue("Thread should be able to acquire lock.",
+        test.await(WAIT, TimeUnit.MILLISECONDS));
+    th1.release();
+  }
+
+  /**
    * Test for concurrent writes.
    * @throws InterruptedException Got interrupted.
    */


### PR DESCRIPTION
BaseX ran into a deadlock when a global read lock with a
concurrent local write lock was requested.