### PR TITLE
C# Client support for BaseX 8.x.

### DIFF
--- a/basex-api/src/main/c#/BaseXClient.cs
+++ b/basex-api/src/main/c#/BaseXClient.cs
@@ -1,6 +1,6 @@
 /*
  * Language Binding for BaseX.
- * Works with BaseX 7.x (but not with BaseX 8.0 and later)
+ * Works with BaseX 8.x
  *
  * Documentation: http://docs.basex.org/wiki/Clients
  *

--- a/basex-api/src/main/c#/BaseXClient.cs
+++ b/basex-api/src/main/c#/BaseXClient.cs
@@ -35,12 +35,26 @@ namespace BaseXClient
       socket = new TcpClient(host, port);
       stream = socket.GetStream();
       ehost = host;
-      string ts = Receive();
+      string[] response = Receive().Split(':');
+
+      string nonce;
+      string code;
+      if (response.Length > 1)
+      {
+          code = username + ":" + response[0] + ":" + pw;
+          nonce = response[1];
+      }
+      else
+      {
+          code = pw;
+          nonce = response[0];
+      }
+
       Send(username);
-      Send(MD5(MD5(pw) + ts));
+      Send(MD5(MD5(code) + nonce));
       if (stream.ReadByte() != 0)
       {
-        throw new IOException("Access denied.");
+          throw new IOException("Access denied.");
       }
     }
 


### PR DESCRIPTION
Now the session constructor uses the nonce sent by BaseX server when opening a session.