### PR TITLE
Update HttpClient.java

### DIFF
--- a/basex-core/src/main/java/org/basex/util/http/HttpClient.java
+++ b/basex-core/src/main/java/org/basex/util/http/HttpClient.java
@@ -167,7 +167,7 @@ public final class HttpClient {
       conn.setDoOutput(true);
 
       final String timeout = request.attribute(TIMEOUT);
-      if(timeout != null) conn.setConnectTimeout(Strings.toInt(timeout));
+      if(timeout != null) conn.setConnectTimeout(Strings.toInt(timeout) * 1000);
       final String redirect = request.attribute(FOLLOW_REDIRECT);
       if(redirect != null) setFollowRedirects(Strings.yes(redirect));
 


### PR DESCRIPTION
Adhere to specification of eXpath stating that timeout on http-request has to be expressed in seconds whereas in the code currently it's passed as milliseconds.