### PR TITLE
Use original casing of archive name.

### DIFF
--- a/basex-core/src/main/java/org/basex/build/DirParser.java
+++ b/basex-core/src/main/java/org/basex/build/DirParser.java
@@ -128,7 +128,7 @@ public final class DirParser extends Parser {
           for(ZipEntry ze; (ze = is.getNextEntry()) != null;) {
             if(ze.isDirectory()) continue;
             final String path = ze.getName();
-            source = new IOStream(is, archiveName ? (name + '/' + path) : path);
+            source = new IOStream(is, archiveName ? (input.name() + '/' + path) : path);
             source.length(ze.getSize());
             parseResource(builder);
           }


### PR DESCRIPTION
Hi Christian,

Thanks for adding this feature! It seems to work well. I noticed that the archive file name is being converted to lower case in the path. This pull request is to use the original casing of the archive file name. 

Vincent