### PR TITLE
Proposal for passing authorization ahead to restxq when scheme isn't known

### DIFF
--- a/basex-api/src/main/java/org/basex/http/HTTPContext.java
+++ b/basex-api/src/main/java/org/basex/http/HTTPContext.java
@@ -119,7 +119,7 @@ public final class HTTPContext {
     final String[] ams = Strings.split(value, ' ', 2);
     final AuthMethod am = StaticOptions.AUTHMETHOD.get(ams[0]);
     if(am == null){
-      if(StaticOptions.CUSTOMAUTH.value()) return;
+      if(context.soptions.get(StaticOptions.CUSTOMAUTH)) return;
       else throw new BaseXException(WHICHAUTH, value);
     } 
     

--- a/basex-api/src/main/java/org/basex/http/HTTPContext.java
+++ b/basex-api/src/main/java/org/basex/http/HTTPContext.java
@@ -118,7 +118,11 @@ public final class HTTPContext {
 
     final String[] ams = Strings.split(value, ' ', 2);
     final AuthMethod am = StaticOptions.AUTHMETHOD.get(ams[0]);
-    if(am == null) throw new BaseXException(WHICHAUTH, value);
+    if(am == null){
+      if(StaticOptions.CUSTOMAUTH.value()) return;
+      else throw new BaseXException(WHICHAUTH, value);
+    } 
+    
 
     // overwrite credentials with client data (basic or digest)
     if(am == AuthMethod.BASIC) {

--- a/basex-api/src/main/java/org/basex/http/webdav/BXServletRequest.java
+++ b/basex-api/src/main/java/org/basex/http/webdav/BXServletRequest.java
@@ -56,7 +56,19 @@ final class BXServletRequest extends AbstractRequest {
   BXServletRequest(final HttpServletRequest req) {
     this.req = req;
     method = Method.valueOf(req.getMethod());
-    url = req.getRequestURL().toString(); // MiltonUtils.stripContext(r);
+    String u = req.getRequestURL().toString();
+    // encoded characters: try to guess character set
+    if(u.indexOf("%") != -1) {
+      try {
+        final String enc = req.getCharacterEncoding();
+        final String ud = URLDecoder.decode(u, enc == null ? Strings.UTF8 : enc);
+        u = ud.contains("\uFFFD") ? URLDecoder.decode(u, "ISO-8859-1") : ud;
+      } catch(final Exception ignore) {
+        Util.debug(ignore);
+      }
+    }
+    url = u;
+    System.out.println("=> " + url);
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/core/MainOptions.java
+++ b/basex-core/src/main/java/org/basex/core/MainOptions.java
@@ -166,6 +166,11 @@ public final class MainOptions extends Options {
   /** Maximum number of index occurrences to print. */
   public static final NumberOption MAXSTAT = new NumberOption("MAXSTAT", 30);
 
+  // Authorization
+  
+  /** Allow for custom Authorization header */
+  public static final BooleanOption CUSTOMAUTH = new BooleanOption("CUSTOMAUTH", false);
+
   // Other
 
   /** Options that are adopted from parent options. */

--- a/basex-core/src/main/java/org/basex/core/MainOptions.java
+++ b/basex-core/src/main/java/org/basex/core/MainOptions.java
@@ -166,11 +166,6 @@ public final class MainOptions extends Options {
   /** Maximum number of index occurrences to print. */
   public static final NumberOption MAXSTAT = new NumberOption("MAXSTAT", 30);
 
-  // Authorization
-  
-  /** Allow for custom Authorization header */
-  public static final BooleanOption CUSTOMAUTH = new BooleanOption("CUSTOMAUTH", false);
-
   // Other
 
   /** Options that are adopted from parent options. */

--- a/basex-core/src/main/java/org/basex/core/StaticOptions.java
+++ b/basex-core/src/main/java/org/basex/core/StaticOptions.java
@@ -101,6 +101,9 @@ public final class StaticOptions extends Options {
       return name.substring(0, 1) + name.substring(1).toLowerCase(Locale.ENGLISH);
     }
   }
+  
+  /** Allow for custom Authorization header */
+  public static final BooleanOption CUSTOMAUTH = new BooleanOption("CUSTOMAUTH", false);
 
   /**
    * Constructor, adopting system properties starting with "org.basex.".


### PR DESCRIPTION
Depending on a boolean property CUSTOMAUTH the authorization could be passed on to the application code (RESTXQ) instead of raising an exception.
This allows for custom authorization handling (use case: Authorization: Bearer XXXYYYZZZ).