### PR TITLE
New QueryContext and QueryResources contructors to shallow copy resources and support transform expressions in parallel queries.

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryContext.java
+++ b/basex-core/src/main/java/org/basex/query/QueryContext.java
@@ -169,6 +169,20 @@ public final class QueryContext extends Proc implements Closeable {
   }
 
   /**
+   * Construct for use in a fork-join query
+   * @param qcParent
+   * @param async
+   */
+  public QueryContext(final QueryContext qcParent, boolean async ) {
+    this(qcParent.context, qcParent);
+    listen = qcParent.listen;
+    if(async) {
+      resources = new QueryResources(this, qcParent.resources);
+    } else {
+      resources = qcParent.resources;
+    }
+  }
+  /**
    * Constructor.
    * @param context database context
    * @param parent parent context (can be {@code null})

--- a/basex-core/src/main/java/org/basex/query/QueryContext.java
+++ b/basex-core/src/main/java/org/basex/query/QueryContext.java
@@ -169,9 +169,11 @@ public final class QueryContext extends Proc implements Closeable {
   }
 
   /**
-   * Construct for use in a fork-join query
-   * @param qcParent
-   * @param async
+   * Construct context for use in a parallel query. Creates shallow clone
+   * of resources in order to mitigate multi threading array syncronization issues.
+   * @param qcParent parent context
+   * @param async If true the resources will be shallow copied. If false,
+   * operates the same as if calling the standard constructor: QueryContext(final QueryContext qc) 
    */
   public QueryContext(final QueryContext qcParent, boolean async ) {
     this(qcParent.context, qcParent);

--- a/basex-core/src/main/java/org/basex/query/QueryResources.java
+++ b/basex-core/src/main/java/org/basex/query/QueryResources.java
@@ -63,6 +63,11 @@ public final class QueryResources {
     this.qc = qc;
   }
 
+  /**
+   * Contructor. Shallow copies the resources for use in paralle queries.
+   * @param qc query context
+   * @param qr resources to clone
+   */
   @SuppressWarnings("unchecked")
   QueryResources(QueryContext qc, QueryResources qr) {
     this.qc = qc;

--- a/basex-core/src/main/java/org/basex/query/QueryResources.java
+++ b/basex-core/src/main/java/org/basex/query/QueryResources.java
@@ -4,6 +4,7 @@ import static org.basex.query.QueryError.*;
 
 import java.io.*;
 import java.util.*;
+import java.util.Map.*;
 
 import org.basex.build.*;
 import org.basex.core.*;
@@ -60,6 +61,24 @@ public final class QueryResources {
    */
   QueryResources(final QueryContext qc) {
     this.qc = qc;
+  }
+
+  @SuppressWarnings("unchecked")
+  QueryResources(QueryContext qc, QueryResources qr) {
+    this.qc = qc;
+    // Shallow clone the resources 
+    for(Data d : qr.datas) { this.datas.add(d); }
+    for(String s : qr.collNames) { this.collNames.add(s); }
+    for(Value v : qr.colls) { this.colls.add(v); }
+    for(Entry<Class<? extends QueryResource>, QueryResource> e : external.entrySet()) {
+       this.external.put(e.getKey(), e.getValue());
+    }
+
+    for(Value v : qr.cache) {
+      cache.add(v);
+    }
+
+    this.modules = qr.modules;
   }
 
   /**
@@ -433,4 +452,5 @@ public final class QueryResources {
     colls.add(coll);
     collNames.add(name);
   }
+
 }


### PR DESCRIPTION
In further testing of xq-promise, which attempts to parallelize non Updating XQuery expressions. I have found one issue. Namely, transformations such as the following do not work in parallel callbacks.

```xquery
let $base-node := <node />
let $func := function ($item, $i) {
   copy $out := $item
   modify (
     rename node $out as 'test-transform',
     insert node element value {$i}
   )
   return $out
}
return p:fork-join(
  for $i in (1 to 100) return
  p:defer($func(?, $i), $base-node)
) 
```

In particular the error observed is `ArrayOutOfBounds`. It pertains to the `Updates` variable contained on the QueryContext.resources object.

The xq-promise module as it stands currently creates a new QueryContext from the parent query during a fork or fork-join operation using the QueryContext(QueryContext qc) contstructor. This is done in order to try and isolate the threads as much as possible. The one issue I have found however is this constructor simply copies the reference to the `resources` object of the parent QueryContext, which includes this Updates list.

Since the update list is mutable and will be changed during a transformation, each forked child QueryContext needs to have its own resource and in particular Update lists or else they will stomp on each other.

The idea behind this merge is to provide a QueryContext constructor which shallow copies the parent QueryContext's resources into its own set of ArrayLists and also maintains its own `Updates` list. With this change, the above example and other transform queries works as expected. 

Going forward, with a little further understanding of how the Updates are managed, I could see database updates being parallelize as well, but with some extra effort. Essentially the fork-join code would need to merge the individual threads update lists after they returned. Haven't tried that yet, but its maybe workable? Thoughts?

For now the xq-promise module throws an exception if you try and add any database updating expressions.

I am curious to hear all your thoughts.

Cheers!