### PR TITLE
[ADD] Tests for fn:id/fn:idref, idref fix, open issue

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/Ids.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/Ids.java
@@ -55,7 +55,8 @@ abstract class Ids extends StandardFunc {
       // collect and return index results, filtered by id/idref attributes
       final ANodeList results = new ANodeList();
       for(final ANode attr : va.iter(qc)) {
-        if(XMLToken.isId(attr.name(), idref)) results.add(idref ? attr : attr.parent());
+        if(XMLToken.isId(attr.name(), idref) && attr.root().is(root))
+          results.add(idref ? attr : attr.parent());
       }
       return results.iter();
     }

--- a/basex-core/src/test/java/org/basex/index/ValueIndexTest.java
+++ b/basex-core/src/test/java/org/basex/index/ValueIndexTest.java
@@ -42,6 +42,8 @@ public final class ValueIndexTest extends SandboxTest {
     final List<Object[]> paramsSet = new ArrayList<>();
     paramsSet.add(paramSet(false, false));
     paramsSet.add(paramSet(true, false));
+    paramsSet.add(paramSet(false, true));
+    paramsSet.add(paramSet(true, true));
     return paramsSet;
   }
 

--- a/basex-core/src/test/java/org/basex/query/simple/IdIdrefTest.java
+++ b/basex-core/src/test/java/org/basex/query/simple/IdIdrefTest.java
@@ -1,0 +1,90 @@
+package org.basex.query.simple;
+
+import java.util.*;
+import java.util.List;
+
+import org.basex.core.*;
+import org.basex.core.cmd.*;
+import org.basex.core.cmd.Set;
+import org.basex.query.*;
+import org.junit.*;
+import org.junit.runner.*;
+import org.junit.runners.*;
+import org.junit.runners.Parameterized.*;
+
+/**
+ * Tests for {@code id} and {@code idref}.
+ *
+ * @author BaseX Team 2005-16, BSD License
+ * @author Jens Erat
+ */
+@RunWith(Parameterized.class)
+public final class IdIdrefTest extends QueryTest {
+  /** Test parameters. */
+  private final Collection<Set> paramSet;
+
+  /**
+   * Runs tests with different parameters, like in-memory or disk databases.
+   * @return collection of parameter sets
+   */
+  @Parameters
+  public static Collection<Object[]> generateParams() {
+    final List<Object[]> paramsSet = new ArrayList<>();
+    paramsSet.add(paramSet(false, false, false));
+    paramsSet.add(paramSet(false, false, true));
+    paramsSet.add(paramSet(false, true, false));
+    paramsSet.add(paramSet(false, true, true));
+    paramsSet.add(paramSet(true, false, false));
+    paramsSet.add(paramSet(true, false, true));
+    paramsSet.add(paramSet(true, true, false));
+    paramsSet.add(paramSet(true, true, true));
+    return paramsSet;
+  }
+
+  /**
+   * Return parameter set for parameterized execution.
+   * @param mainmem MAINMEM option
+   * @param updindex UPDINDEX option
+   * @param tokenindex TOKENINDEXoption
+   * @return parameter set
+   */
+  private static Object[] paramSet(final boolean mainmem, final boolean updindex,
+      final boolean tokenindex) {
+    final ArrayList<Set> params = new ArrayList<>();
+    params.add(new Set(MainOptions.MAINMEM, mainmem));
+    params.add(new Set(MainOptions.UPDINDEX, updindex));
+    params.add(new Set(MainOptions.TOKENINDEX, tokenindex));
+    final ArrayList<ArrayList<Set>> paramArray = new ArrayList<>();
+    paramArray.add(params);
+    return paramArray.toArray();
+  }
+
+  /**
+   * Apply parameter sets.
+   * @param paramSet parameter set for current test run
+   */
+  public IdIdrefTest(final Collection<Set> paramSet) {
+    this.paramSet = paramSet;
+  }
+
+  /**
+   * Prepare test, setting up parametrized environment.
+   */
+  @Before
+  public void setup() {
+    // set up environment
+    for(final Set option : paramSet) execute(option);
+    execute(new CreateDB(NAME));
+    execute(new Add("1.xml", "<root1 id='foo' idref='bar quix' />"));
+    execute(new Add("2.xml", "<root2 id='batz' idref2='quix' />"));
+
+    queries = new Object[][] {
+        { "id1", nodes(1), "db:open('" + NAME + "', '1.xml')/id('foo')"},
+        { "id2", nodes(5), "db:open('" + NAME + "', '2.xml')/id('batz')"},
+        { "idref1", nodes(3), "db:open('" + NAME + "', '1.xml')/idref('bar')"},
+        { "idref2", nodes(7), "db:open('" + NAME + "', '2.xml')/idref('quix')"},
+        { "idref2", nodes(3, 7),
+            "for $doc in collection('" + NAME + "') return idref('quix', $doc)"},
+      };
+  }
+}


### PR DESCRIPTION
Added parametrized test for fn:id and fn:idref with several combinations
of in-memory databases, updating and token indexes.

Fixed bug in fn:idref, which did not test whether the found node is the
desired document.

In case of `UPDINDEX=false` and `TOKENINDEX=true` there is still some issue left, as the test shows.