### PR TITLE
fix handling of undefined key events

### DIFF
--- a/basex-core/src/main/java/org/basex/gui/layout/BaseXKeys.java
+++ b/basex-core/src/main/java/org/basex/gui/layout/BaseXKeys.java
@@ -12,6 +12,7 @@ import java.awt.event.*;
  * @author BaseX Team 2005-16, BSD License
  * @author Christian Gruen
  * @author Leo Woerteler
+ * @author Klavs Prieditis
  */
 public enum BaseXKeys {
 
@@ -149,7 +150,7 @@ public enum BaseXKeys {
   public boolean is(final KeyEvent e) {
     final int c = e.getKeyCode();
     final int m = e.getModifiers() | allowed;
-    return m == (modifiers | allowed) && (c == 0 ? e.getKeyChar() : c) == key;
+    return m == (modifiers | allowed) && (c == VK_UNDEFINED ? getExtendedKeyCodeForChar(e.getKeyChar()) : c) == key;
   }
 
   /**


### PR DESCRIPTION
From [KeyEvent docs](https://docs.oracle.com/javase/7/docs/api/java/awt/event/KeyEvent.html#VK_QUOTE):
> For key typed events, the getKeyCode method always returns VK_UNDEFINED.

> Not all keyboards or systems are capable of generating all virtual key codes. No attempt is made in Java to generate these keys artificially.

When I press `"` key the `KeyEvent e` returns `e.getKeyCode() == VK_UNDEFINED` and `e.getKeyChar() == '"'` also `BaseXKeys` returns `NEXTPAGE.is(e) == true` which is false.

`NEXTPAGE` is defined as `NEXTPAGE(NO_MOD, VK_PAGE_DOWN, SHIFT)` so `e.getKeyChar()` should never be compared to `VK_PAGE_DOWN`.

There could be one problem with this fix: `GOBACK2(VK_BACK_SPACE, NO_MOD)` sets `key = NO_MOD`, which equals to `key = 0`.