### PR TITLE
Added Dockerimage for automatic builds of basexhttp, DBA

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+**/.gitignore
+**/*.bat
+.git
+basex-examples
+basex-tests
+basex-api
+!basex-api/.classpath
+!basex-api/etc
+!basex-api/lib
+!basex-api/license.txt
+!basex-api/pom.xml
+!basex-api/src/main/java
+!basex-api/src/main/resources

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM maven:3-jdk-7
+MAINTAINER BaseX Team <basex-talk@mailman.uni-konstanz.de>
+
+# Compile BaseX, install
+COPY . /usr/src/basex/
+RUN cd /usr/src/basex && \
+    mvn clean install -DskipTests && \
+    ln -s /usr/src/basex/basex-*/etc/* /usr/local/bin
+
+# Run as non-privileged user with fixed UID
+RUN adduser --system --home /srv --disabled-password --disabled-login --uid 1984 basex && \
+    mkdir /srv/BaseXData /srv/BaseXRepo /srv/BaseXWeb && \
+    chown basex /srv /srv/*
+USER basex
+
+# 1984/tcp: API
+# 1985/tcp: Event
+# 8984/tcp: HTTP
+# 8985/tcp: HTTP stop
+EXPOSE 1984 1985 8984 8985
+VOLUME ["/srv/BaseXData"]
+WORKDIR /srv
+
+# Run BaseX HTTP server by default, logging to STDOUT
+CMD ["/usr/local/bin/basexhttp", "-d"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ on the Docker Hub, providing both release and nightly builds. All images are
 automatically rebuild if Docker provides updated base images.
 
 To start a BaseX container based on the latest development release publishing
-the BaseX server and HTTP ports `1984` and `8984` and bind-mounting your user's `BaseXData` directory, run
+the BaseX server and HTTP ports `1984` and `8984` and bind-mounting your user's
+`BaseXData` directory, run
 
     docker run -ti \
         --name basexhttp \
@@ -51,6 +52,15 @@ BaseX command line:
     docker run -ti \
         --link basexhttp:basexhttp \
         basex/basexhttp:nightly basexclient -nbasexhttp
+
+If you prefer the DBA web interface, this can also be linked against your
+server container:
+
+    docker run -d \
+        --name basex-dba \
+        --publix 18984:8984 \
+        --link basexhttp:basexhttp \
+        basex/dba
 
 If you want to add your own application, create an image
 `FROM basex/basexhttp:[tag]` with `[tag]` being the BaseX version you're

--- a/README.md
+++ b/README.md
@@ -1,36 +1,40 @@
-BaseX  
-=========================================================================================================================
+BaseX
+===============================================================================
 
 Welcome to the source code of BaseX.
 
-To get the project running as smooth as possible, please consider the following notes:
+To get the project running as smooth as possible, please consider the following
+notes:
 
 Compiling BaseX
 ---------------
 
-JDK 1.7 and JUnit is currently required to compile the complete sources
-of the main project. If you are using another environment than Eclipse
-or don't have JUnit installed, just delete the `test` packages inside
-the project and rebuild the project.
+JDK 1.7 and JUnit is currently required to compile the complete sources of the
+main project. If you are using another environment than Eclipse or don't have
+JUnit installed, just delete the `test` packages inside the project and rebuild
+the project.
 
-Please take a look at the [Maven documentation](https://docs.basex.org/wiki/Maven) for information on how to use Maven.
+Please take a look at the [Maven documentation] for information on how to use
+Maven.
 
-You can launch the following classes, which are all placed in the basex-core directory and the `org.basex` main package:
+You can launch the following classes, which are all placed in the basex-core
+directory and the `org.basex` main package:
 
     BaseX        : console mode
     BaseXServer  : server instance, waiting for requests
     BaseXClient  : console mode, interacting with the server
     BaseXGUI     : graphical user interface
 
-Moreover, try `-h` to list the available command line options. For
-example, you can use BaseX to process XQuery expressions without
-entering the console.
+Moreover, try `-h` to list the available command line options. For example, you
+can use BaseX to process XQuery expressions without entering the console.
+
+[Maven documentation]: https://docs.basex.org/wiki/Maven
 
 Docker Image
 ------------
 
 The BaseX server is also available as automated build
-[`basex/basexhttp`](https://hub.docker.com/r/basex/basexhttp/)
+[`basex/basexhttp`]
 on the Docker Hub, providing both release and nightly builds. All images are
 automatically rebuild if Docker provides updated base images.
 
@@ -69,14 +73,17 @@ developing against. Usually, you will add your application code to
 a volume, which means it cannot be preinitialized in the application image.
 
 For further information on using the Docker image, refer to the
-[BaseX Docker documentation](http://docs.basex.org/wiki/Docker).
+[BaseX Docker documentation].
+
+[`basex/basexhttp`]: https://hub.docker.com/r/basex/basexhttp/
+[BaseX Docker documentation]: http://docs.basex.org/wiki/Docker
 
 Using Eclipse
 -------------
 
-BaseX is being developed with the Eclipse environment. Some style
-guidelines are integrated in the sources of BaseX; they are being
-embedded as soon as you open the project.
+BaseX is being developed with the Eclipse environment. Some style guidelines
+are integrated in the sources of BaseX; they are being embedded as soon as you
+open the project.
 
 ### Running BaseX
 
@@ -101,19 +108,23 @@ Some additional Checkstyle guidelines are defined in the project:
 Using Git
 ---------
 
-The code base of BaseX can be accessed via [GitHub](https://www.github.com).
+The code base of BaseX can be accessed via [GitHub].
+
+[GitHub]: https://www.github.com
 
 Feedback
 --------
 
-Any kind of feedback is welcome; please check out the [documentation](https://docs.basex.org).
+Any kind of feedback is welcome; please check out the [documentation].
 
 Tell us if you run into any troubles installing BaseX:
 
-    basex-talk@mailman.uni-konstanz.de.
+<basex-talk@mailman.uni-konstanz.de>
 
-You are as well invited to contribute to our [bug tracker](https://github.com/BaseXdb/BaseX/issues).
+You are as well invited to contribute to our [bug tracker].
 
-All the best,
-
+All the best,  
 BaseX Team, 2016
+
+[documentation]: (https://docs.basex.org)
+[bug tracker]: (https://github.com/BaseXdb/BaseX/issues)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,41 @@ Moreover, try `-h` to list the available command line options. For
 example, you can use BaseX to process XQuery expressions without
 entering the console.
 
+Docker Image
+------------
+
+The BaseX server is also available as automated build
+[`basex/basexhttp`](https://hub.docker.com/r/basex/basexhttp/)
+on the Docker Hub, providing both release and nightly builds. All images are
+automatically rebuild if Docker provides updated base images.
+
+To start a BaseX container based on the latest development release publishing
+the BaseX server and HTTP ports `1984` and `8984` and bind-mounting your user's `BaseXData` directory, run
+
+    docker run -ti \
+        --name basexhttp \
+        --publish 1984:1984 \
+        --publish 8984:8984 \
+        --volume ~/BaseXData:/srv/BaseXData \
+        basex/basexhttp:nightly
+
+By passing any other BaseX executable, you can also for example run a BaseX
+client connecting to the linked BaseX server for management opeartions on the
+BaseX command line:
+
+    docker run -ti \
+        --link basexhttp:basexhttp \
+        basex/basexhttp:nightly basexclient -nbasexhttp
+
+If you want to add your own application, create an image
+`FROM basex/basexhttp:[tag]` with `[tag]` being the BaseX version you're
+developing against. Usually, you will add your application code to
+`/srv/BaseXWeb` and modules to `/srv/BaseXModule`. `BaseXData` is persisted as
+a volume, which means it cannot be preinitialized in the application image.
+
+For further information on using the Docker image, refer to the
+[BaseX Docker documentation](http://docs.basex.org/wiki/Docker).
+
 Using Eclipse
 -------------
 
@@ -33,8 +68,7 @@ BaseX is being developed with the Eclipse environment. Some style
 guidelines are integrated in the sources of BaseX; they are being
 embedded as soon as you open the project.
 
-Running BaseX
--------------
+### Running BaseX
 
 The following steps can be performed to start BaseX with Eclipse:
 
@@ -44,8 +78,7 @@ The following steps can be performed to start BaseX with Eclipse:
  - Choose a `Main class` (e.g., org.basex.BaseXGUI)
  - Launch the project via `Run`
 
-Adding Checkstyle
------------------
+### Adding Checkstyle
 
 Some additional Checkstyle guidelines are defined in the project:
 

--- a/basex-api/src/main/webapp/dba/Dockerfile
+++ b/basex-api/src/main/webapp/dba/Dockerfile
@@ -1,0 +1,24 @@
+# This Dockerfile provides an image for the BaseX DBA application.
+# At the same time, it demonstrates general useage of the basexhttp
+# Docker image for RestXQ applications.
+
+# For production applications, better choose a fixed version tag
+FROM basex/basexhttp:nightly
+MAINTAINER BaseX Team <basex-talk@mailman.uni-konstanz.de>
+
+# If you need to install additional Java dependencies, switch to root
+# USER root
+# RUN apt-get update && \
+#     apt-get install some-debian-package
+
+# Don't forget to switch back to the BaseX user!
+# USER basex
+
+# Setting environment variables like CLASSPATH and JVM options
+# to increase BaseX' memory limit
+# ENV BASEX_JVM="-Xmx2048m"
+
+# Add source code
+COPY . /srv/BaseXWeb
+
+# RUN is inherited from basex/basexhttp and not required again


### PR DESCRIPTION
These commits:

- add a Dockerfile for `basexhttp`, including a `.dockerignore` file to prevent git history, programming APIs, the full test suite and other superfluous stuff of being added
- add a Dockerfile for the DBA, also providing an example on Docker usage for RestXQ projects
- update the `README.md` (which is also used on the Docker Hub) with information on Docker usage
- move some headings in the slightly enlarged readme file to the third headings level, to unclutter sectioning a little bit

After merging, I'll register the builds `basex/basexhttp` and `basex/dba` on Docker hub and put together documentation in the Wiki.