### PR TITLE
Compare Strings using equals()

### DIFF
--- a/basex-core/src/main/java/org/basex/io/in/TextDecoder.java
+++ b/basex-core/src/main/java/org/basex/io/in/TextDecoder.java
@@ -38,10 +38,10 @@ abstract class TextDecoder {
    */
   static TextDecoder get(final String enc) throws IOException {
     final TextDecoder td;
-    if(enc == UTF8) td = new UTF8();
-    else if(enc == UTF32) td = new UTF32();
-    else if(enc == UTF16LE) td = new UTF16LE();
-    else if(enc == UTF16 || enc == UTF16BE) td = new UTF16BE();
+    if(UTF8.equals(enc)) td = new UTF8();
+    else if(UTF32.equals(enc)) td = new UTF32();
+    else if(UTF16LE.equals(enc)) td = new UTF16LE();
+    else if(UTF16.equals(enc) || UTF16BE.equals(enc)) td = new UTF16BE();
     else td = new Generic(enc);
     td.encoding = enc;
     return td;

--- a/basex-core/src/main/java/org/basex/query/MainModule.java
+++ b/basex-core/src/main/java/org/basex/query/MainModule.java
@@ -181,7 +181,7 @@ public final class MainModule extends StaticScope {
       // name is unknown at compile time: return false
       if(db == null) return false;
       // if context item is found on top level, it will refer to currently opened database
-      if(level == 0 || db != DBLocking.CONTEXT) sl.add(db);
+      if(level == 0 || !DBLocking.CONTEXT.equals(db)) sl.add(db);
       return true;
     }
 

--- a/basex-core/src/main/java/org/basex/query/func/convert/ConvertFn.java
+++ b/basex-core/src/main/java/org/basex/query/func/convert/ConvertFn.java
@@ -71,7 +71,7 @@ public abstract class ConvertFn extends StandardFunc {
    * @throws CharacterCodingException character coding exception
    */
   public static byte[] toBinary(final byte[] in, final String enc) throws CharacterCodingException {
-    if(enc == Strings.UTF8) return in;
+    if(Strings.UTF8.equals(enc)) return in;
     final ByteBuffer bb = Charset.forName(enc).newEncoder().encode(CharBuffer.wrap(string(in)));
     final int il = bb.limit();
     final byte[] tmp = bb.array();

--- a/basex-core/src/main/java/org/basex/util/Token.java
+++ b/basex-core/src/main/java/org/basex/util/Token.java
@@ -208,7 +208,7 @@ public final class Token {
    */
   public static byte[] utf8(final byte[] token, final String encoding) {
     // UTF8 (comparison by ref.) or no special characters: return input
-    if(encoding == Strings.UTF8 || ascii(token)) return token;
+    if(Strings.UTF8.equals(encoding) || ascii(token)) return token;
 
     // convert to utf8. if errors occur while converting, an empty is returned.
     try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Findbugs rule ES_COMPARING_STRINGS_WITH_EQ - “Bad practice - comparison of String objects using == or != ”. You can find more information about the issue here: http://findbugs.sourceforge.net/bugDescriptions.html#ES_COMPARING_STRINGS_WITH_EQ
Please let me know if you have any questions.
Ayman Abdelghany.