### PR TITLE
 Resources should be closed And Override Hashcode

### DIFF
--- a/basex-core/src/main/java/org/basex/core/parse/StringParser.java
+++ b/basex-core/src/main/java/org/basex/core/parse/StringParser.java
@@ -48,16 +48,17 @@ final class StringParser extends CmdParser {
 
   @Override
   protected void parse(final ArrayList<Command> cmds) throws QueryException {
-    final Scanner sc = new Scanner(input).useDelimiter(single ? "\0" : "\r\n?|\n");
-    while(sc.hasNext()) {
-      final String line = sc.next().trim();
-      if(line.isEmpty() || line.startsWith("#")) continue;
-      parser = new InputParser(line);
-      parser.file = ctx.options.get(MainOptions.QUERYPATH);
-      while(parser.more()) {
-        final Cmd cmd = consume(Cmd.class, null);
-        if(cmd != null) cmds.add(parse(cmd));
-        if(parser.more() && !parser.consume(';')) throw help(null, cmd);
+    try(final Scanner sc = new Scanner(input).useDelimiter(single ? "\0" : "\r\n?|\n")){
+      while(sc.hasNext()) {
+        final String line = sc.next().trim();
+        if(line.isEmpty() || line.startsWith("#")) continue;
+        parser = new InputParser(line);
+        parser.file = ctx.options.get(MainOptions.QUERYPATH);
+        while(parser.more()) {
+          final Cmd cmd = consume(Cmd.class, null);
+          if(cmd != null) cmds.add(parse(cmd));
+          if(parser.more() && !parser.consume(';')) throw help(null, cmd);
+        }
       }
     }
   }

--- a/basex-core/src/main/java/org/basex/gui/text/SearchContext.java
+++ b/basex-core/src/main/java/org/basex/gui/text/SearchContext.java
@@ -189,4 +189,16 @@ final class SearchContext {
     return mcase == s.mcase && word == s.word && regex == s.regex && multi == s.multi &&
         Strings.eq(search, s.search);
   }
+
+  @Override
+  public int hashCode() {
+    int result = this.bar != null ? this.bar.hashCode() : 0;
+    result = 31 * result + (this.mcase ? 1 : 0);
+    result = 31 * result + (this.regex ? 1 : 0);
+    result = 31 * result + (this.multi ? 1 : 0);
+    result = 31 * result + (this.word ? 1 : 0);
+    result = 31 * result + (this.search != null ? this.search.hashCode() : 0);
+    result = 31 * result + this.nr;
+    return result;
+  }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2095 - “ Resources should be closed”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2095
And
squid:S1206 - “ equals(Object obj)"" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.