### PR TITLE
[FIX] Install web.xml in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,4 +10,4 @@ basex-api
 !basex-api/license.txt
 !basex-api/pom.xml
 !basex-api/src/main/java
-!basex-api/src/main/resources
+!basex-api/src/main/webapp/WEB-INF

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,13 @@ MAINTAINER BaseX Team <basex-talk@mailman.uni-konstanz.de>
 COPY . /usr/src/basex/
 RUN cd /usr/src/basex && \
     mvn clean install -DskipTests && \
-    ln -s /usr/src/basex/basex-*/etc/* /usr/local/bin
+    ln -s /usr/src/basex/basex-*/etc/* /usr/local/bin && \
+    cp -r /usr/src/basex/basex-api/src/main/webapp/WEB-INF /srv
 
 # Run as non-privileged user with fixed UID
 RUN adduser --system --home /srv --disabled-password --disabled-login --uid 1984 basex && \
     mkdir /srv/BaseXData /srv/BaseXRepo /srv/BaseXWeb && \
-    chown basex /srv /srv/*
+    chown -R basex /srv
 USER basex
 
 # 1984/tcp: API


### PR DESCRIPTION
Up to now, the Dockerfile copied an instance of the `web.xml` file from the ressources folder into the image. This one is not available in git, though -- resulting in the build process working fine locally, but breaking on the Docker hub.

This commit should fix image creation.