### PR TITLE
[MIN] Docker: latest instead of nightly, remove EVENT port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,9 @@ RUN adduser --system --home /srv --disabled-password --disabled-login --uid 1984
 USER basex
 
 # 1984/tcp: API
-# 1985/tcp: Event
 # 8984/tcp: HTTP
 # 8985/tcp: HTTP stop
-EXPOSE 1984 1985 8984 8985
+EXPOSE 1984 8984 8985
 VOLUME ["/srv/BaseXData"]
 WORKDIR /srv
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ the BaseX server and HTTP ports `1984` and `8984` and bind-mounting your user's
         --publish 1984:1984 \
         --publish 8984:8984 \
         --volume ~/BaseXData:/srv/BaseXData \
-        basex/basexhttp:nightly
+        basex/basexhttp:latest
 
 By passing any other BaseX executable, you can also for example run a BaseX
-client connecting to the linked BaseX server for management opeartions on the
+client connecting to the linked BaseX server for management operations on the
 BaseX command line:
 
     docker run -ti \
         --link basexhttp:basexhttp \
-        basex/basexhttp:nightly basexclient -nbasexhttp
+        basex/basexhttp:latest basexclient -nbasexhttp
 
 If you prefer the DBA web interface, this can also be linked against your
 server container:


### PR DESCRIPTION
I would have preferred "nightly" as a Docker Hub tag, but we should also have "latest" and the Docker Hub merges branches resulting in different tags, deleting one of them.

The EVENT port 1985 was removed already, don't expose it any more.