### PR TITLE
Multiscreen setup

### DIFF
--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogAbout.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogAbout.java
@@ -70,6 +70,6 @@ public final class DialogAbout extends BaseXDialog {
     p.add(newButtons(B_OK));
     add(p, BorderLayout.EAST);
 
-    finish(null);
+    finish();
   }
 }

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogEdit.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogEdit.java
@@ -105,7 +105,7 @@ public final class DialogEdit extends BaseXDialog {
     pp.add(buttons, BorderLayout.EAST);
 
     set(pp, BorderLayout.SOUTH);
-    finish(null);
+    finish();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogExport.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogExport.java
@@ -130,7 +130,7 @@ public final class DialogExport extends BaseXDialog {
     set(pp, BorderLayout.SOUTH);
 
     action(method);
-    finish(null);
+    finish();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogInput.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogInput.java
@@ -66,7 +66,7 @@ final class DialogInput extends BaseXDialog {
     buttons = newButtons(B_OK, B_CANCEL);
     set(buttons, BorderLayout.SOUTH);
     action(null);
-    finish(null);
+    finish();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogInsert.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogInsert.java
@@ -100,7 +100,7 @@ public final class DialogInsert extends BaseXDialog {
     change(radio[lkind]);
 
     action(null);
-    finish(null);
+    finish();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogInstallURL.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogInstallURL.java
@@ -56,7 +56,7 @@ final class DialogInstallURL extends BaseXDialog {
 
     set(p, BorderLayout.SOUTH);
     action(null);
-    finish(null);
+    finish();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogLine.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogLine.java
@@ -43,7 +43,7 @@ public final class DialogLine extends BaseXDialog {
     buttons = newButtons(B_OK, B_CANCEL);
     set(buttons, BorderLayout.SOUTH);
     action(null);
-    finish(null);
+    finish();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogManage.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogManage.java
@@ -116,7 +116,7 @@ public final class DialogManage extends BaseXDialog {
     set(tabs, BorderLayout.EAST);
 
     action(null);
-    if(dbs.length != 0) finish(null);
+    if(dbs.length != 0) finish();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogMem.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogMem.java
@@ -44,7 +44,7 @@ public final class DialogMem extends BaseXDialog {
     final BaseXBack buttons = newButtons(gc);
     set(buttons, BorderLayout.SOUTH);
     addTimer();
-    finish(null);
+    finish();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogMessage.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogMessage.java
@@ -63,7 +63,7 @@ public final class DialogMessage extends BaseXDialog {
         ((Container) bttns.getComponent(0)).getComponent(0).requestFocusInWindow();
       }
     });
-    finish(null);
+    finish();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogNew.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogNew.java
@@ -109,7 +109,7 @@ public final class DialogNew extends BaseXDialog {
     action(general.parsers);
 
     setResizable(true);
-    finish(null);
+    finish();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogPackages.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogPackages.java
@@ -96,7 +96,7 @@ public final class DialogPackages extends BaseXDialog {
 
     refresh = true;
     action(null);
-    finish(null);
+    finish();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogPass.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogPass.java
@@ -42,7 +42,7 @@ public final class DialogPass extends BaseXDialog {
     buttons = newButtons(B_OK, B_CANCEL);
     set(buttons, BorderLayout.SOUTH);
     action(null);
-    finish(null);
+    finish();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogPrefs.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogPrefs.java
@@ -45,7 +45,7 @@ public final class DialogPrefs extends BaseXDialog {
 
     set(tabs, BorderLayout.CENTER);
     action(null);
-    finish(null);
+    finish();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogProps.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogProps.java
@@ -182,7 +182,7 @@ public final class DialogProps extends BaseXDialog {
 
     action(this);
     setResizable(true);
-    finish(null);
+    finish();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogSort.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogSort.java
@@ -59,7 +59,7 @@ public final class DialogSort extends BaseXDialog {
     buttons = newButtons(B_OK, B_CANCEL);
     set(buttons, BorderLayout.SOUTH);
     action(null);
-    finish(null);
+    finish();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/gui/layout/BaseXDialog.java
+++ b/basex-core/src/main/java/org/basex/gui/layout/BaseXDialog.java
@@ -100,19 +100,33 @@ public abstract class BaseXDialog extends JDialog {
 
   /**
    * Finalizes the dialog layout and sets it visible.
+   */
+  protected final void finish() {
+    finish(null);
+  }
+
+
+  /**
+   * Finalizes the dialog layout and sets it visible.
    * @param l optional dialog location, relative to main window
    */
   protected final void finish(final int[] l) {
     pack();
     setMinimumSize(getPreferredSize());
     if(l == null) setLocationRelativeTo(gui);
-    else setLocation(gui.getX() + l[0], gui.getY() + l[1]);
+    else setLocationWithinScreen(gui.getX() + l[0], gui.getY() + l[1]);
     loc = l;
     setVisible(true);
   }
 
-  @Override
-  public void setLocation(final int x, final int y) {
+  /**
+   * Sets location relative to main window. Location is adjusted to be within the screen.
+   * This does not work well in a multiple screen setup. If the main window is not located on the primary display,
+   * the dialog will be placed at the edge of the primary display.
+   * @param x
+   * @param y
+     */
+  public void setLocationWithinScreen(final int x, final int y) {
     final Dimension scr = Toolkit.getDefaultToolkit().getScreenSize();
     final int xx = Math.max(0, Math.min(scr.width - getWidth(), x));
     final int yy = Math.max(0, Math.min(scr.height - getHeight(), y));


### PR DESCRIPTION
I am experiencing problems when the main screen of GUI is located on the second screen.
The overriden `setLocation` is always limiting dialog windows to the primary screen dimensions.
I looked around the code and noticed that this method is probably defined because of some special dialog windows that get the location adjusted in relative to the main window.

I renamed `setLocation` to `setLocationWithinScreen` to explicitly mention it's function and to disable the override that was called by the superclass.

I overloaded `finish` method to clearly separate the cases that adjust location and cases that do not. Hopefully, this will make it easier for others to find the exact cases where dialog location is adjusted.

In my opinion, `setLocationWithinScreen` is still broken and should be updated or removed. I am not aware of the initial motivations to create this method (`setLocation`) so I decided to leave it here, while limiting the use of it.