### PR TITLE
[FIX] Dockerfile: set ENTRYPOINT and CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,5 @@ VOLUME ["/srv/BaseXData"]
 WORKDIR /srv
 
 # Run BaseX HTTP server by default, logging to STDOUT
-CMD ["/usr/local/bin/basexhttp", "-d"]
+ENTRYPOINT ["/usr/local/bin/basexhttp"]
+CMD ["-d"]


### PR DESCRIPTION
See #1345: With recent builds `basex/basexhttp` shows

    docker run basex/basexhttp
    touch: cannot touch ‘/root/.m2/copy_reference_file.log’: Permission
    denied
    Can not write to /root/.m2/copy_reference_file.log. Wrong volume
    permissions?

On startup.

This patch fixes that behaviour and _hopefully_ doesn't change anything
substantial apart from that.