### PR TITLE
[FIX] Dockerfile: set m2 config directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,18 @@ RUN cd /usr/src/basex && \
     cp -r /usr/src/basex/basex-api/src/main/webapp/WEB-INF /srv
 
 # Run as non-privileged user with fixed UID
-RUN adduser --system --home /srv --disabled-password --disabled-login --uid 1984 basex && \
-    mkdir /srv/BaseXData /srv/BaseXRepo /srv/BaseXWeb && \
+# $MAVEN_CONFIG is expected to point to a volume by the parent maven image
+RUN adduser --home /srv --disabled-password --disabled-login --uid 1984 basex && \
+    mkdir /srv/.m2 /srv/BaseXData /srv/BaseXRepo /srv/BaseXWeb && \
     chown -R basex /srv
 USER basex
+ENV MAVEN_CONFIG=/srv/.m2
 
 # 1984/tcp: API
 # 8984/tcp: HTTP
 # 8985/tcp: HTTP stop
 EXPOSE 1984 8984 8985
-VOLUME ["/srv/BaseXData"]
+VOLUME ["/srv/.m2", "/srv/BaseXData"]
 WORKDIR /srv
 
 # Run BaseX HTTP server by default, logging to STDOUT


### PR DESCRIPTION
The upstream maven Docker image copies some files into the Maven config
directory during container startup, to fix some issues for images using
Maven at container runtime (see carlossg/docker-maven#11).

This broke startup for child images that do not run as root user (we're
adding a basex user). The same issue was described in
carlossg/docker-maven#14.

Resolves #1345, replaces #1346.