### PR TITLE
improved consistency of Base64 class name usage (using full class name)

### DIFF
--- a/basex-core/src/main/java/org/basex/util/http/HttpClient.java
+++ b/basex-core/src/main/java/org/basex/util/http/HttpClient.java
@@ -259,7 +259,7 @@ public final class HttpClient {
         if(base64) {
           writeHeader(CONTENT_TRANSFER_ENCODING, BASE64, out);
           out.write(CRLF);
-          contents = Base64.encode(contents);
+          contents = org.basex.util.Base64.encode(contents);
           final int bl = contents.length;
           for(int b = 0; b < bl; b += 76) {
             out.write(contents, b, Math.min(76, bl - b));

--- a/basex-core/src/main/java/org/basex/util/http/HttpPayload.java
+++ b/basex-core/src/main/java/org/basex/util/http/HttpPayload.java
@@ -181,7 +181,7 @@ public final class HttpPayload {
 
     byte[] payload = extractPart(sep, end, type.parameters().get(CHARSET));
     if(payloads != null) {
-      if(base64) payload = Base64.decode(payload);
+      if(base64) payload = org.basex.util.Base64.decode(payload);
       payloads.add(parse(payload, type));
     }
     return true;


### PR DESCRIPTION
Hi,

I was trying to build BaseX locally (using OpenJDK 8) and I've bumped into the following maven build error:

    [INFO] ------------------------------------------------------------------------
    [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.5.1:compile (default-compile) on project basex: Compilation failure: Compilation failure:
    [ERROR] /home/user/sources/basex/basex-core/src/main/java/org/basex/util/http/HttpPayload.java:[184,28] reference to Base64 is ambiguous
    [ERROR] both class org.basex.util.Base64 in org.basex.util and class java.util.Base64 in java.util match
    [ERROR] /home/user/sources/basex/basex-core/src/main/java/org/basex/util/http/HttpClient.java:[262,22] reference to Base64 is ambiguous
    [ERROR] both class org.basex.util.Base64 in org.basex.util and class java.util.Base64 in java.util match

The way I read this is: the `Base64` class is imported from two places,
and it's used as `Base64` so there's an ambiguity between which class is
meant. There are two available options (because they're the imported classes that
are imported and match the name):
- `org.basex.util.Base64`
- `java.util.Base64`

From looking at the code, it seems like `org.basex.util.Base64` is meant here.
I'm sending this patch to clarify which class is meant so the build can complete without
errors.

Best regards,
Stefan

P.S. I acknowledge that `java.util.Base64` is available [with Java8](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html) and [not with Java7](https://docs.oracle.com/javase/7/docs/api/java/util/Base64.html). The README.md says JDK 1.7 should be used to build BaseX. Still, I think the patch might be helpful for other people building on JDK 1.8