### PR TITLE
proposed change for timeout in http:send-request()

### DIFF
--- a/basex-core/src/main/java/org/basex/util/http/HttpClient.java
+++ b/basex-core/src/main/java/org/basex/util/http/HttpClient.java
@@ -168,7 +168,11 @@ public final class HttpClient {
       conn.setDoOutput(true);
 
       final String timeout = request.attribute(TIMEOUT);
-      if(timeout != null) conn.setConnectTimeout(Strings.toInt(timeout) * 1000);
+      if(timeout != null) {
+        // timeouts may occur while waiting for the connection or the response
+        conn.setConnectTimeout(Strings.toInt(timeout) * 1000);
+        conn.setReadTimeout(Strings.toInt(timeout) * 1000);
+      }
       final String redirect = request.attribute(FOLLOW_REDIRECT);
       if(redirect != null) setFollowRedirects(Strings.yes(redirect));
 


### PR DESCRIPTION
Right now, the timeout only sets the connect timeout that is active
while a connection is established, but not the read timeout while
waiting for a response.

The EXPath HTTP Client Module specification does not clearly state the
semantics of the parameter "timeout", but if the read timeout is not
considered in the implementation, a send-request() may hang forever
even though a timeout parameter has been provided.