### PR TITLE
[ADD] crypto:hmac() allow bytestream as key

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/crypto/CryptoHmac.java
+++ b/basex-core/src/main/java/org/basex/query/func/crypto/CryptoHmac.java
@@ -14,7 +14,7 @@ import org.basex.util.*;
 public final class CryptoHmac extends StandardFunc {
   @Override
   public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
-    return new Encryption(info).hmac(toToken(exprs[0], qc), toToken(exprs[1], qc),
+    return new Encryption(info).hmac(toToken(exprs[0], qc), toBytes(exprs[1], qc),
         toToken(exprs[2], qc), exprs.length == 4 ? toToken(exprs[3], qc) : Token.EMPTY);
   }
 }


### PR DESCRIPTION
Currently `crypto:hmac()` only allows for strings to be the key.

In some circumstances it might be necessary to use sequences of bytes as a key, that do not necessarily resemble a valid string in any encoding.

The proposed change does not change the behaviour in case `$key` is of type `xs:string`.

```xquery
crypto:hmac("foo", "bar", "md5") eq
crypto:hmac("foo", xs:base64Binary("YmFy"), "md5")
```