### PR TITLE
[MIN] Fixed markdown syntax issues in README (fixes #1448)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,5 @@ You are as well invited to contribute to our [bug tracker].
 All the best,  
 BaseX Team
 
-[documentation]: (https://docs.basex.org)
-[bug tracker]: (https://github.com/BaseXdb/BaseX/issues)
+[documentation]: https://docs.basex.org
+[bug tracker]: https://github.com/BaseXdb/BaseX/issues


### PR DESCRIPTION
The `README.md` file has some minor markdown syntax issues, which result in a broken link on the Docker hub (#1448).