### PR TITLE
Removed outdated Checkstyle module

### DIFF
--- a/basex-api/.settings/checkstyle.xml
+++ b/basex-api/.settings/checkstyle.xml
@@ -90,10 +90,6 @@
       <property name="illegalPattern" value="true"/>
     </module>
     <module name="OuterTypeFilename"/>
-    <module name="StrictDuplicateCode">
-      <property name="severity" value="ignore"/>
-      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
-    </module>
     <module name="AnnotationUseStyle"/>
     <module name="MissingOverride"/>
     <module name="PackageAnnotation"/>

--- a/basex-core/.settings/checkstyle.xml
+++ b/basex-core/.settings/checkstyle.xml
@@ -90,10 +90,6 @@
       <property name="illegalPattern" value="true"/>
     </module>
     <module name="OuterTypeFilename"/>
-    <module name="StrictDuplicateCode">
-      <property name="severity" value="ignore"/>
-      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
-    </module>
     <module name="AnnotationUseStyle"/>
     <module name="MissingOverride"/>
     <module name="PackageAnnotation"/>

--- a/basex-examples/.settings/checkstyle.xml
+++ b/basex-examples/.settings/checkstyle.xml
@@ -89,10 +89,6 @@
       <property name="illegalPattern" value="true"/>
     </module>
     <module name="OuterTypeFilename"/>
-    <module name="StrictDuplicateCode">
-      <property name="severity" value="ignore"/>
-      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
-    </module>
     <module name="AnnotationUseStyle"/>
     <module name="MissingOverride"/>
     <module name="PackageAnnotation"/>

--- a/basex-tests/.settings/checkstyle.xml
+++ b/basex-tests/.settings/checkstyle.xml
@@ -90,10 +90,6 @@
       <property name="illegalPattern" value="true"/>
     </module>
     <module name="OuterTypeFilename"/>
-    <module name="StrictDuplicateCode">
-      <property name="severity" value="ignore"/>
-      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
-    </module>
     <module name="AnnotationUseStyle"/>
     <module name="MissingOverride"/>
     <module name="PackageAnnotation"/>


### PR DESCRIPTION
Running `mvn checkstyle:checkstyle` currently crashes because the configuration files have the module `StrictDuplicateCode` which is outdated. This PR removes the outdated module from the configuration files so that `mvn checkstyle:checkstyle` now does not crash.