### PR TITLE
Fix compilation with Java 9

### DIFF
--- a/basex-core/pom.xml
+++ b/basex-core/pom.xml
@@ -19,6 +19,22 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jp.sourceforge.igo</groupId>
       <artifactId>igo</artifactId>
       <optional>true</optional>

--- a/basex-core/src/main/java/org/basex/gui/GUIInput.java
+++ b/basex-core/src/main/java/org/basex/gui/GUIInput.java
@@ -220,7 +220,8 @@ public final class GUIInput extends BaseXTextField {
       return;
     }
     if(comboChanged(sl)) {
-      box.setModel(new DefaultComboBoxModel<>(sl.toArray()));
+      final Object[] strings = sl.toArray();
+      box.setModel(new DefaultComboBoxModel<>(strings));
       box.setSelectedIndex(-1);
       pop = new GUIInputPopup(box);
     }
@@ -249,7 +250,7 @@ public final class GUIInput extends BaseXTextField {
      * Constructor.
      * @param combo combobox reference
      */
-    GUIInputPopup(final JComboBox<String> combo) {
+    GUIInputPopup(final JComboBox<Object> combo) {
       super(combo);
       final int h = combo.getMaximumRowCount();
       setPreferredSize(new Dimension(getPreferredSize().width, getPopupHeightForRowCount(h) + 2));

--- a/basex-core/src/main/java/org/basex/gui/layout/BaseXCombo.java
+++ b/basex-core/src/main/java/org/basex/gui/layout/BaseXCombo.java
@@ -14,7 +14,7 @@ import org.basex.util.options.*;
  * @author BaseX Team 2005-17, BSD License
  * @author Christian Gruen
  */
-public final class BaseXCombo extends JComboBox<String> {
+public final class BaseXCombo extends JComboBox<Object> {
   /** Options. */
   private Options options;
   /** Option. */
@@ -105,7 +105,7 @@ public final class BaseXCombo extends JComboBox<String> {
   public void setSelectedItem(final Object object) {
     if(object == null) return;
     final String value = object.toString();
-    final ComboBoxModel<String> m = getModel();
+    final ComboBoxModel<Object> m = getModel();
     final int s = m.getSize();
     for(int i = 0; i < s; i++) {
       if(m.getElementAt(i).equals(value)) {

--- a/basex-core/src/main/java/org/basex/gui/view/plot/PlotView.java
+++ b/basex-core/src/main/java/org/basex/gui/view/plot/PlotView.java
@@ -163,7 +163,7 @@ public final class PlotView extends View {
           plotChanged = true;
           markingChanged = true;
 
-          final String[] keys = plotData.getCategories(token(item)).toStringArray();
+          final Object[] keys = plotData.getCategories(token(item)).toStringArray();
           xCombo.setModel(new DefaultComboBoxModel<>(keys));
           yCombo.setModel(new DefaultComboBoxModel<>(keys));
           if(keys.length > 0) {
@@ -809,7 +809,7 @@ public final class PlotView extends View {
 
     plotData = new PlotData(gui.context);
 
-    final String[] items = plotData.getItems().toStringArray();
+    final Object[] items = plotData.getItems().toStringArray();
     itemCombo.setModel(new DefaultComboBoxModel<>(items));
 
     // set first item and trigger assignment of axis assignments

--- a/basex-core/src/main/java/org/basex/query/QueryContext.java
+++ b/basex-core/src/main/java/org/basex/query/QueryContext.java
@@ -23,6 +23,7 @@ import org.basex.query.expr.Expr.*;
 import org.basex.query.func.*;
 import org.basex.query.iter.*;
 import org.basex.query.scope.*;
+import org.basex.query.scope.Module;
 import org.basex.query.up.*;
 import org.basex.query.util.collation.*;
 import org.basex.query.util.ft.*;

--- a/basex-core/src/main/java/org/basex/query/func/crypto/MyKeySelector.java
+++ b/basex-core/src/main/java/org/basex/query/func/crypto/MyKeySelector.java
@@ -48,7 +48,7 @@ final class MyKeySelector extends KeySelector {
 
     final SignatureMethod sm = (SignatureMethod) m;
     @SuppressWarnings("unchecked")
-    final List<Object> list = ki.getContent();
+    final List<?> list = ki.getContent();
 
     for(final Object l : list) {
       final XMLStructure s = (XMLStructure) l;

--- a/basex-core/src/main/java/org/basex/query/func/inspect/Inspect.java
+++ b/basex-core/src/main/java/org/basex/query/func/inspect/Inspect.java
@@ -11,7 +11,7 @@ import org.basex.core.*;
 import org.basex.io.*;
 import org.basex.query.*;
 import org.basex.query.ann.*;
-import org.basex.query.scope.*;
+import org.basex.query.scope.Module;
 import org.basex.query.util.list.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.node.*;

--- a/basex-core/src/main/java/org/basex/query/func/xquery/XQueryParse.java
+++ b/basex-core/src/main/java/org/basex/query/func/xquery/XQueryParse.java
@@ -5,6 +5,7 @@ import static org.basex.util.Token.*;
 import org.basex.query.*;
 import org.basex.query.func.*;
 import org.basex.query.scope.*;
+import org.basex.query.scope.Module;
 import org.basex.query.value.node.*;
 import org.basex.util.*;
 import org.basex.util.options.*;

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,30 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>javax.activation</groupId>
+        <artifactId>activation</artifactId>
+        <version>1.1</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.2.12</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.2.11</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>2.2.11</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>net.xqj</groupId>
         <artifactId>basex-xqj</artifactId>
         <version>8.6</version>


### PR DESCRIPTION
In Java 9, to be released in 30 days, some of basex ceases to compile or work:

 * `java.lang.Module` has been added, causing star imports of classes named `Module` to fail: fixed by adding explicit imports.
 * swing's `BasicComboPopup` constructor type has been changed. This is probably a JDK bug, but it's probably a bit late to fix it.
 * An unchecked cast has become invalid, replaced with wildcards.
 * A single test depends on some JAXB implementation, which has been removed from the JDK in 9. I've added one from Maven Central, at `test` scope. The state of JAXB implementations in Maven is a bit of a disaster. I doubt the test cares about a specific implementation; it's a very small use. Maybe there are some parts of the application which need these jars not a test scope? I don't know how you want to handle this.

All the tests pass, except ProfModuleTest#human, which was broken anyway. (170a3e2eaf3b099304d3cff951fb53e65e5192eb?)