### PR TITLE
File open dialog opening in background (at least on Mac OS)

### DIFF
--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogExport.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogExport.java
@@ -72,7 +72,7 @@ public final class DialogExport extends BaseXDialog {
    * Opens a file dialog to choose an XML document or directory.
    */
   private void choose() {
-    final IOFile io = new BaseXFileChooser(CHOOSE_DIR, path.getText(), gui).select(Mode.DOPEN);
+    final IOFile io = new BaseXFileChooser(CHOOSE_DIR, path.getText(), gui, this).select(Mode.DOPEN);
     if(io != null) path.setText(io.path());
   }
 

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogFT.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogFT.java
@@ -115,7 +115,7 @@ final class DialogFT extends DialogIndex {
   private void chooseStop() {
     final GUIOptions gopts = dialog.gui.gopts;
     final BaseXFileChooser fc = new BaseXFileChooser(FILE_OR_DIR, gopts.get(GUIOptions.DATAPATH),
-        dialog.gui);
+        dialog.gui, dialog);
     final IO file = fc.select(Mode.FOPEN);
     if(file != null) {
       swpath.setText(file.path());

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogGeneralPrefs.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogGeneralPrefs.java
@@ -76,14 +76,14 @@ final class DialogGeneralPrefs extends BaseXBack {
     dbButton = new BaseXButton(BROWSE_D, d);
     dbButton.addActionListener(e -> {
       final String path = dbPath.getText();
-      final IOFile dir = new BaseXFileChooser(CHOOSE_DIR, path, gui).select(Mode.DOPEN);
+      final IOFile dir = new BaseXFileChooser(CHOOSE_DIR, path, gui, this).select(Mode.DOPEN);
       if(dir != null) dbPath.setText(dir.path());
     });
 
     repoButton = new BaseXButton(BROWSE_D, d);
     repoButton.addActionListener(e -> {
       final String path = repoPath.getText();
-      final IOFile dir = new BaseXFileChooser(CHOOSE_DIR, path, gui).select(Mode.DOPEN);
+      final IOFile dir = new BaseXFileChooser(CHOOSE_DIR, path, gui, this).select(Mode.DOPEN);
       if(dir != null) repoPath.setText(dir.path());
     });
 

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogImport.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogImport.java
@@ -139,7 +139,7 @@ final class DialogImport extends BaseXBack {
    */
   private IOFile inputFile() {
     final String path = gui.gopts.get(GUIOptions.INPUTPATH);
-    final BaseXFileChooser fc = new BaseXFileChooser(FILE_OR_DIR, path, gui);
+    final BaseXFileChooser fc = new BaseXFileChooser(FILE_OR_DIR, path, gui, this);
     fc.textFilters();
     fc.filter(ZIP_ARCHIVES, IO.ZIPSUFFIXES);
     final IOFile file = fc.select(Mode.FDOPEN);

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogPackages.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogPackages.java
@@ -119,7 +119,7 @@ public final class DialogPackages extends BaseXDialog {
 
     } else if(cmp == install) {
       final String pp = gui.gopts.get(GUIOptions.WORKPATH);
-      final BaseXFileChooser fc = new BaseXFileChooser(FILE_OR_DIR, pp, gui);
+      final BaseXFileChooser fc = new BaseXFileChooser(FILE_OR_DIR, pp, gui, this);
       fc.filter(XML_ARCHIVES, IO.XARSUFFIX);
       fc.filter(JAVA_ARCHIVES, IO.JARSUFFIX);
       fc.filter(XQUERY_FILES, IO.XQSUFFIXES);

--- a/basex-core/src/main/java/org/basex/gui/dialog/DialogXmlParser.java
+++ b/basex-core/src/main/java/org/basex/gui/dialog/DialogXmlParser.java
@@ -79,7 +79,7 @@ final class DialogXmlParser extends DialogParser {
     browsec.addActionListener(e -> {
       final GUIOptions gopts = dialog.gui.gopts;
       final BaseXFileChooser fc = new BaseXFileChooser(FILE_OR_DIR,
-        gopts.get(GUIOptions.INPUTPATH), dialog.gui).filter(XML_DOCUMENTS, IO.XMLSUFFIX);
+        gopts.get(GUIOptions.INPUTPATH), dialog.gui, dialog).filter(XML_DOCUMENTS, IO.XMLSUFFIX);
 
       final IO file = fc.select(Mode.FDOPEN);
       if(file != null) cfile.setText(file.path());

--- a/basex-core/src/main/java/org/basex/gui/layout/BaseXFileChooser.java
+++ b/basex-core/src/main/java/org/basex/gui/layout/BaseXFileChooser.java
@@ -31,12 +31,15 @@ public final class BaseXFileChooser {
 
   /** Reference to main window. */
   private GUI gui;
+  /** Reference to the parent window. */
+  private Component parent;
   /** Swing file chooser. */
   private JFileChooser fc;
   /** Simple file dialog. */
   private FileDialog fd;
   /** File suffix. */
   private String suffix;
+
 
   /**
    * Default constructor.
@@ -45,6 +48,18 @@ public final class BaseXFileChooser {
    * @param main reference to main window
    */
   public BaseXFileChooser(final String title, final String path, final GUI main) {
+    this(title, path, main, null);
+  }
+
+  /**
+   * Default constructor.
+   * @param title dialog title
+   * @param path initial path
+   * @param main reference to main window
+   * @param parent parent for this file choose dialog
+   */
+  public BaseXFileChooser(final String title, final String path, final GUI main, final Component parent) {
+    this.parent = parent == null ? main : parent;
     final IOFile file = new IOFile(path);
     if(main.gopts.get(GUIOptions.SIMPLEFD)) {
       fd = new FileDialog(main, title);
@@ -136,19 +151,19 @@ public final class BaseXFileChooser {
     int state = 0;
     switch(mode) {
       case FOPEN:
-        state = fc.showOpenDialog(gui);
+        state = fc.showOpenDialog(parent);
         break;
       case FDOPEN:
         fc.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
-        state = fc.showOpenDialog(gui);
+        state = fc.showOpenDialog(parent);
         break;
       case FSAVE:
-        state = fc.showSaveDialog(gui);
+        state = fc.showSaveDialog(parent);
         break;
       case DOPEN:
       case DSAVE:
         fc.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-        state = fc.showDialog(gui, null);
+        state = fc.showDialog(parent, null);
         break;
     }
     if(state != JFileChooser.APPROVE_OPTION) return new IOFile[0];


### PR DESCRIPTION
Hi Christian,

I noticed a minor bug in the GUI on this Mac OS I now use (and still loath...). When creating a new database and opening an input xml it would open the file chooser dialog in the background of the "New Database" dialog.

Then I remembered that I now write Java code for a living and though I could fix it myself ;). You see the result here. I can't remember seeing this bug on my lovely Linux OS, so I assume it might only materialize on Mac OS. However, I guess @micheee should be able to confirm/deny. But looking at the code it actually does make sense, because the parent window of the file chooser was always the main BaseX GUI. I would have liked to completely replace the `gui`variable, but there is this (weird, historic?) "Simple File Chooser" global option, which is needed. So I instead opted for another `parent`variable.

PS: Maven is still coming, but I am in a train with unstable internet (Schwarzwald!), so I couldn't work on it right now. Maybe in the next couple of days, but I am unfortunately still swamped.