### PR TITLE
[MOD] releasing non-snapshots to maven central works for me now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,40 @@
               <appendAssemblyId>false</appendAssemblyId>
             </configuration>
           </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>
@@ -534,20 +568,6 @@
           </configuration>
         </plugin>
 
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-gpg-plugin</artifactId>
-          <version>1.6</version>
-          <executions>
-            <execution>
-              <id>sign-artifacts</id>
-              <phase>verify</phase>
-              <goals>
-                <goal>sign</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
Ok, so I finally managed to find time for a follow-up on https://github.com/BaseXdb/basex/pull/1489 .... I guess thanks Martin Luther for the additional public holiday :+1: 

So, I basically didn't change anything: The part with `doclint-java8-disable` is only because I use java8 and the JavaDoc is incorrect (see https://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete for more info. Of course it would be better to fix the actual issue...)

The other plugin just moved to the `release` profile.

However, I now tried this: So running 

    mvn clean deploy -DskipTests -P release

deploys the stuff to osshr. But after that it is still not deployed: For this you have to login in the Nexus and search here https://oss.sonatype.org/#stagingRepositories for basex. When the deploy was successful you should see a new repository, something in the format `orgbasex-1010` (artifactId without the dots and a number starting at 1000). In the web interface you can then release it with the "Close" Button (who named this???).

Of course, this can be automated. But I am unsure what you currently use and I also don't want to accidentally release some crap... If you use the release plugin and do something like 

    mvn release:clean release:prepare
    mvn release:perform

Otherwise, if you don't use it and stick with the deploy phase after runnign deploy the following

    mvn nexus-staging:release

should do the same as the web interface "Close" button.