### PR TITLE
[MOD] add clob handling

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/sql/SqlExecute.java
+++ b/basex-core/src/main/java/org/basex/query/func/sql/SqlExecute.java
@@ -104,6 +104,10 @@ public class SqlExecute extends SqlFn {
                   Util.debug(ex);
                   col.add(xml);
                 }
+              } else if(value instanceof Clob) {
+                // add huge string from clob
+                final Clob clob = ((Clob) value);
+                col.add(clob.getSubString(1, (int) clob.length()));
               } else {
                 // add string representation of other values
                 col.add(value.toString());


### PR DESCRIPTION
Hi,

in case of an Oracle CLOB column only a "pointer"-value will returned by toString. 
So here some special handling for clobs is need. Beside Clob.getSubString also RecordSet.getString() will work in this Situation. But we followed the way as xmltype was handled here.

BTW: In case of execute-prepared big clob works fine, because the PreparedStatement.setString the counterpart of RecordSet.getString is used.

Best Regards

Jan