### PR TITLE
updated C API for newer authentication method

### DIFF
--- a/basex-api/src/main/c/basexdbc.c
+++ b/basex-api/src/main/c/basexdbc.c
@@ -127,7 +127,10 @@ basex_authenticate(int sfd, const char *user, const char *passwd)
 #endif
 
 	/* BaseX Server expects an authentification sequence:
- 	 * {username}\0{md5(md5(password) + timestamp)}\0 */
+           {username}\0{md5(md5(user:realm:password) + timestamp)}\0 */
+ 	/* legacy - 
+        /* {username}\0{md5(md5(password) + timestamp)}\0 */
+        
 
 	/* Send {username}\0 */
 	int user_len = strlen(user) + 1;
@@ -136,19 +139,47 @@ basex_authenticate(int sfd, const char *user, const char *passwd)
 		warnx("Sending username failed. %d != %d", rc, user_len);
 		return -1;
 	}
-
-	/* Compute md5 for passwd. */
-	md5_pwd = md5(passwd);
-	if (md5_pwd == NULL) {
-		warnx("md5 computation for password failed.");
-		return -1;
-	}
-	int md5_pwd_len = strlen(md5_pwd);
+        
+        char* p = strchr(ts,':');
+        char* t;
+        if (!p) {
+            /* legacy login */
+            t = ts;
+            /* Compute md5 for passwd. */
+            md5_pwd = md5(passwd);
+            if (md5_pwd == NULL) {
+                    warnx("md5 computation for password failed.");
+                    return -1;
+            }  
+        }
+        else {
+            /* v8.0+ login */
+            t = p + 1;
+            /* Compute md5 for codeword. */
+            int user_len = strlen(user);
+            int pass_len = strlen(passwd);
+            int realm_len = p - ts;
+            char codewd[user_len + realm_len + pass_len + 2];
+            strncpy(codewd, user, user_len);
+            codewd[user_len] = ':';
+            strncpy(codewd + user_len + 1, ts, realm_len);
+            codewd[user_len + 1 + realm_len] = ':';
+            strncpy(codewd + user_len + 1 + realm_len + 1, passwd, pass_len);
+            
+            md5_pwd = md5(codewd);
+            if (md5_pwd == NULL) {
+                    warnx("md5 computation for password failed.");
+                    return -1;
+            }
+            ts_len = ts_len - realm_len -1;
+        }
+        int md5_pwd_len = strlen(md5_pwd);
+        
 #if DEBUG
 	warnx("md5(pwd)        : %s (%d)", md5_pwd, md5_pwd_len);
 #endif
 	
-	/* Concat md5'ed passwd string and timestamp string. */
+	/* Concat md5'ed codewd string and timestamp/nonce string. */
 	int pwdts_len = md5_pwd_len + ts_len + 1;
 	char pwdts[pwdts_len];
 	memset(pwdts, 0, sizeof(pwdts));
@@ -156,13 +187,13 @@ basex_authenticate(int sfd, const char *user, const char *passwd)
 		pwdts[i] = md5_pwd[i];
 	int j = md5_pwd_len;
 	for (i = 0; i < ts_len; i++,j++)
-		pwdts[j] = ts[i];
+		pwdts[j] = t[i];
 	pwdts[pwdts_len - 1] = '\0';
 #if DEBUG
 	warnx("md5(pwd)+ts     : %s (%d)", pwdts, strlen(pwdts));
 #endif
 
-	/* Compute md5 for md5'ed password + timestamp */
+	/* Compute md5 for md5'ed codeword + timestamp */
 	char *md5_pwdts = md5(pwdts);
 	if (md5_pwdts == NULL) {
 		warnx("md5 computation for password + timestamp failed.");
@@ -173,7 +204,7 @@ basex_authenticate(int sfd, const char *user, const char *passwd)
 	warnx("md5(md5(pwd)+ts): %s (%d)", md5_pwdts, md5_pwdts_len);
 #endif
 
-	/* Send md5'ed(md5'ed password + timestamp) to basex. */
+	/* Send md5'ed(md5'ed codeword + timestamp) to basex. */
 	rc = send_db(sfd, md5_pwdts, md5_pwdts_len + 1);  // also send '\0'
 	if (rc == -1) {
 		warnx("Sending credentials failed.");

--- a/basex-api/src/main/c/basexdbc.h
+++ b/basex-api/src/main/c/basexdbc.h
@@ -4,6 +4,9 @@
  * Copyright (c) 2005-12, Alexander Holupirek <alex@holupirek.de>, BSD license
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* Connect to BaseX server and open session. Returns socket file descriptor. */
 int basex_connect(const char *host, const char *port);
 
@@ -25,3 +28,6 @@ int basex_execute(int sfd, const char *command, char **result, char **info);
 
 /* Close session with descriptor sfd. */
 void basex_close(int sfd);
+#ifdef __cplusplus
+}
+#endif

--- a/basex-api/src/main/c/md5.h
+++ b/basex-api/src/main/c/md5.h
@@ -1,5 +1,7 @@
 /* Copyright (c) 2005-12, Alexander Holupirek <alex@holupirek.de>, BSD license */
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * Compute 128bit MD5 digest for string.
  *
@@ -8,3 +10,6 @@
  * returned. It should be passed to free(3). On failure NULL is returned.
  */
 char *md5(const char *string);
+#ifdef __cplusplus
+}
+#endif

--- a/basex-api/src/main/c/readstring.h
+++ b/basex-api/src/main/c/readstring.h
@@ -1,3 +1,9 @@
 /* Copyright (c) 2005-12, Alexander Holupirek <alex@holupirek.de>, BSD license */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 ssize_t readstring(int fd, char **str);
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
updated C API, so it works with v8.0+ of basex
this was tested with the example code and worked
should also work with older versions
and I have extern "C"'d the headers so this API
can be compiled with a c or c++ compiler