### PR TITLE
Ignorehostnameverification

### DIFF
--- a/basex-core/src/main/java/org/basex/core/StaticOptions.java
+++ b/basex-core/src/main/java/org/basex/core/StaticOptions.java
@@ -63,7 +63,7 @@ public final class StaticOptions extends Options {
   /** Ignore missing certificates. */
   public static final BooleanOption IGNORECERT = new BooleanOption("IGNORECERT", false);
   /** Ignore verification of hostname in certificates. */
-  public static final BooleanOption IGNORECERTHOSTNAME = new BooleanOption("IGNORECERTHOSTNAME", false);
+  public static final BooleanOption IGNOREHOSTNAME = new BooleanOption("IGNOREHOSTNAME", false);
   
   /** Timeout (seconds) for processing client requests; deactivated if set to 0. */
   public static final NumberOption TIMEOUT = new NumberOption("TIMEOUT", 30);
@@ -136,7 +136,7 @@ public final class StaticOptions extends Options {
       Prop.setSystem("http.nonProxyHosts", nph);
     }
     if(get(IGNORECERT)) IOUrl.ignoreCert();
-    if(get(IGNORECERTHOSTNAME)) IOUrl.ignoreHostnameVerification();
+    if(get(IGNOREHOSTNAME)) IOUrl.ignoreHostname();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/core/StaticOptions.java
+++ b/basex-core/src/main/java/org/basex/core/StaticOptions.java
@@ -136,6 +136,7 @@ public final class StaticOptions extends Options {
       Prop.setSystem("http.nonProxyHosts", nph);
     }
     if(get(IGNORECERT)) IOUrl.ignoreCert();
+    if(get(IGNORECERTHOSTNAME)) IOUrl.ignoreHostnameVerification();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/core/StaticOptions.java
+++ b/basex-core/src/main/java/org/basex/core/StaticOptions.java
@@ -62,7 +62,9 @@ public final class StaticOptions extends Options {
   public static final StringOption NONPROXYHOSTS = new StringOption("NONPROXYHOSTS", "");
   /** Ignore missing certificates. */
   public static final BooleanOption IGNORECERT = new BooleanOption("IGNORECERT", false);
-
+  /** Ignore verification of hostname in certificates. */
+  public static final BooleanOption IGNORECERTHOSTNAME = new BooleanOption("IGNORECERTHOSTNAME", false);
+  
   /** Timeout (seconds) for processing client requests; deactivated if set to 0. */
   public static final NumberOption TIMEOUT = new NumberOption("TIMEOUT", 30);
   /** Keep alive time (seconds) for clients; deactivated if set to 0. */

--- a/basex-core/src/main/java/org/basex/io/IOUrl.java
+++ b/basex-core/src/main/java/org/basex/io/IOUrl.java
@@ -137,11 +137,19 @@ public final class IOUrl extends IO {
   }
 
   /**
+   * Ignore Hostname verification.
+   */
+  public static void ignoreHostnameVerification() {
+    // http://www.rgagnon.com/javadetails/java-fix-certificate-problem-in-HTTPS.html
+    HttpsURLConnection.setDefaultHostnameVerifier((hostname, session) -> true);
+  }
+  
+  /**
    * Ignore certificates.
    */
   public static void ignoreCert() {
-    // http://www.rgagnon.com/javadetails/java-fix-certificate-problem-in-HTTPS.html
-    HttpsURLConnection.setDefaultHostnameVerifier((hostname, session) -> true);
+    
+    ignoreHostnameVerification();
 
     final TrustManager[] tm = { new X509TrustManager() {
       @Override

--- a/basex-core/src/main/java/org/basex/io/IOUrl.java
+++ b/basex-core/src/main/java/org/basex/io/IOUrl.java
@@ -139,7 +139,7 @@ public final class IOUrl extends IO {
   /**
    * Ignore Hostname verification.
    */
-  public static void ignoreHostnameVerification() {
+  public static void ignoreHostname() {
     // http://www.rgagnon.com/javadetails/java-fix-certificate-problem-in-HTTPS.html
     HttpsURLConnection.setDefaultHostnameVerifier((hostname, session) -> true);
   }
@@ -148,8 +148,7 @@ public final class IOUrl extends IO {
    * Ignore certificates.
    */
   public static void ignoreCert() {
-    
-    ignoreHostnameVerification();
+    ignoreHostname();
 
     final TrustManager[] tm = { new X509TrustManager() {
       @Override


### PR DESCRIPTION
as discussed in email exchange a patch for separating lax hostname verification from igrnoring certs altogether in HTTPS.