### PR TITLE
improve Unix startup scripts to use exec, not fork

### DIFF
--- a/basex-api/etc/basexhttp
+++ b/basex-api/etc/basexhttp
@@ -17,4 +17,4 @@ CP=$MAIN/target/classes:$MAIN/lib/*:$CORE/lib/*:$MAIN/lib/custom/*:$CLASSPATH
 BASEX_JVM="-Xmx2g $BASEX_JVM"
 
 # Run code
-java -cp "$CP" $BASEX_JVM org.basex.BaseXHTTP "$@"
+exec java -cp "$CP" $BASEX_JVM org.basex.BaseXHTTP "$@"

--- a/basex-api/etc/basexhttpstop
+++ b/basex-api/etc/basexhttpstop
@@ -14,4 +14,4 @@ CORE="$( cd -P "$MAIN/../basex-core" && pwd )"
 CP=$MAIN/target/classes:$MAIN/lib/*:$CORE/lib/*:$MAIN/lib/custom/*:$CLASSPATH
 
 # Run code
-java -cp "$CP" $BASEX_JVM org.basex.BaseXHTTP "$@" stop
+exec java -cp "$CP" $BASEX_JVM org.basex.BaseXHTTP "$@" stop


### PR DESCRIPTION
- minor fix to Unix provided startup/shutdown scripts
- previous versions just called another process (fork)
- current version replaces the running process (exec)
- advantage: for various process supervisors it is better to use exec, not
  fork, since the shell script PID becomes the real process PID
- new (current) script can be used with
  supervisor (http://supervisord.org/) without any change, exec-ing the
  process means the supervisor can correctly track the started server