### PR TITLE
Fix some typos in comments and messages

### DIFF
--- a/basex-api/src/main/c/basexdbc.c
+++ b/basex-api/src/main/c/basexdbc.c
@@ -230,7 +230,7 @@ basex_authenticate(int sfd, const char *user, const char *passwd)
 	}
 
 #if DEBUG
-	warnx("Authentification succeded.");
+	warnx("Authentification succeeded.");
 #endif
 	return 0;
 }

--- a/basex-api/src/main/c/example.c
+++ b/basex-api/src/main/c/example.c
@@ -44,7 +44,7 @@ main(void)
 	char *info;
 	rc = basex_execute(sfd, command, &result, &info);
 	if (rc == -1) { // general (i/o or the like) error
-		warnx("An error occured during execution of '%s'.", command);
+		warnx("An error occurred during execution of '%s'.", command);
 		goto free_and_out;		
 	}
 	if (rc == 1) { // database error while processing command

--- a/basex-api/src/main/java/org/expath/ns/GeoErrors.java
+++ b/basex-api/src/main/java/org/expath/ns/GeoErrors.java
@@ -39,7 +39,7 @@ final class GeoErrors {
    * @return query exception
    */
   static QueryException geoType(final byte[] name, final String geo) {
-    return thrw(3, "% is not an appropiate geometry for this function. "
+    return thrw(3, "% is not an appropriate geometry for this function. "
               + "The input geometry should be a %.", name, geo);
   }
 

--- a/basex-api/src/main/qt/example.xml
+++ b/basex-api/src/main/qt/example.xml
@@ -83,7 +83,7 @@
       <genre>Science Fiction</genre>
       <price>6.95</price>
       <publish_date>2000-11-02</publish_date>
-      <description>After an inadvertant trip through a Heisenberg
+      <description>After an inadvertent trip through a Heisenberg
       Uncertainty Device, James Salway discovers the problems 
       of being quantum.</description>
    </book>

--- a/basex-core/src/test/java/org/basex/core/locks/LockingTest.java
+++ b/basex-core/src/test/java/org/basex/core/locks/LockingTest.java
@@ -484,7 +484,7 @@ public final class LockingTest extends SandboxTest {
     th3.start();
     th1.release();
     assertTrue(
-        "One of the threads should be able to aquire its locks now.",
+        "One of the threads should be able to acquire its locks now.",
         test2.await(WAIT, TimeUnit.MILLISECONDS)
             || test3.await(WAIT, TimeUnit.MILLISECONDS));
     boolean which = false;

--- a/basex-core/src/test/java/org/basex/index/ValueIndexTest.java
+++ b/basex-core/src/test/java/org/basex/index/ValueIndexTest.java
@@ -86,7 +86,7 @@ public final class ValueIndexTest extends SandboxTest {
     tokens.put("3", 3);
     tokens.put("3.4", 1);
     tokens.put("text in child", 1);
-    tokens.put("nonexistant", 0);
+    tokens.put("nonexistent", 0);
     tokens.put("", 0);
 
     valueIndexTest(IndexType.TEXT, tokens, paramSet);
@@ -104,7 +104,7 @@ public final class ValueIndexTest extends SandboxTest {
     tokens.put("bar", 0);
     tokens.put("blu", 0);
     tokens.put("", 0);
-    tokens.put("nonexistant", 0);
+    tokens.put("nonexistent", 0);
     valueIndexTest(IndexType.ATTRIBUTE, tokens, paramSet);
   }
 
@@ -122,7 +122,7 @@ public final class ValueIndexTest extends SandboxTest {
     tokens.put("bar", 1);
     tokens.put("blu", 1);
     tokens.put("", 0);
-    tokens.put("nonexistant", 0);
+    tokens.put("nonexistent", 0);
     valueIndexTest(IndexType.TOKEN, tokens, paramSet);
   }
 

--- a/basex-core/src/test/resources/xqdoc.xsd
+++ b/basex-core/src/test/resources/xqdoc.xsd
@@ -74,7 +74,7 @@
   </xsd:simpleType>
   
   <!-- Simple type for defining the names associated
-       with things such as functions, paramters, module name, etc. -->
+       with things such as functions, parameters, module name, etc. -->
   <xsd:simpleType name="name">
     <xsd:restriction base="xsd:string"/>
   </xsd:simpleType>


### PR DESCRIPTION
All of them were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>