### PR TITLE
changes for latest version of openssl

### DIFF
--- a/basex-api/src/main/c/basexdbc.c
+++ b/basex-api/src/main/c/basexdbc.c
@@ -12,8 +12,6 @@
 #include <err.h>
 #include <errno.h>
 #include <netdb.h>
-#include <openssl/evp.h>
-#include <openssl/md5.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -163,13 +161,13 @@ basex_authenticate(int sfd, const char *user, const char *passwd)
             int user_len = strlen(user);
             int pass_len = strlen(passwd);
             int realm_len = p - ts;
-            char codewd[user_len + realm_len + pass_len + 2];
+            char codewd[user_len + realm_len + pass_len + 3];
             strncpy(codewd, user, user_len);
             codewd[user_len] = ':';
             strncpy(codewd + user_len + 1, ts, realm_len);
             codewd[user_len + 1 + realm_len] = ':';
             strncpy(codewd + user_len + 1 + realm_len + 1, passwd, pass_len);
-            
+            codewd[user_len + 1 + realm_len + 1 + pass_len] = '\0';
             md5_pwd = md5(codewd);
             if (md5_pwd == NULL) {
                     warnx("md5 computation for password failed.");

--- a/basex-api/src/main/c/md5.c
+++ b/basex-api/src/main/c/md5.c
@@ -41,7 +41,7 @@ md5toa(unsigned char *md_value, unsigned int md_len, char **md5_string)
 static char *
 md5_digest(int n, ...)
 {
-	EVP_MD_CTX mdctx;
+	EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
 	const EVP_MD *md;
 	unsigned char md_value[EVP_MAX_MD_SIZE];
 	unsigned int md_len = 0;
@@ -55,17 +55,17 @@ md5_digest(int n, ...)
 	if(!md)
 		err(1, "Unknown message digest");
 
-	EVP_MD_CTX_init(&mdctx);
-	EVP_DigestInit_ex(&mdctx, md, NULL);
+	EVP_MD_CTX_init(mdctx);
+	EVP_DigestInit_ex(mdctx, md, NULL);
 	va_list argPtr;
 	va_start(argPtr, n);
 	for (i = 0; i < n; i++) {
 		string = va_arg(argPtr, char *);
-		EVP_DigestUpdate(&mdctx, string, strlen(string));
+		EVP_DigestUpdate(mdctx, string, strlen(string));
 	}
 	va_end(argPtr);
-	EVP_DigestFinal_ex(&mdctx, md_value, &md_len);
-	EVP_MD_CTX_cleanup(&mdctx);
+	EVP_DigestFinal_ex(mdctx, md_value, &md_len);
+	EVP_MD_CTX_free(mdctx);
 	EVP_cleanup();
 
 	rc = md5toa(md_value, md_len, &md5_result);


### PR DESCRIPTION
Changes to work with type changes in newer version of openssl v1.1.0
- also compatible with older openssl v1.0.1
- this has been tested and works
- this newer version of openssl/crytpo library is installed on latest Ubuntu 18.04 LTS