### PR TITLE
macOS: Adjust apple system property

### DIFF
--- a/basex-core/src/main/java/org/basex/BaseXGUI.java
+++ b/basex-core/src/main/java/org/basex/BaseXGUI.java
@@ -88,8 +88,6 @@ public final class BaseXGUI extends Main {
    */
   private static void init(final GUIOptions opts) {
     try {
-      // Mac: move main menu bar from application window into default menu at the top of the screen
-      System.setProperty("apple.laf.useScreenMenuBar", "true");
       // refresh views when windows are resized
       Toolkit.getDefaultToolkit().setDynamicLayout(true);
       // set look and feel

--- a/basex-core/src/main/java/org/basex/gui/GUIMacOS.java
+++ b/basex-core/src/main/java/org/basex/gui/GUIMacOS.java
@@ -18,6 +18,8 @@ import org.basex.util.*;
 public abstract class GUIMacOS {
   /** Reference to the main UI. */
   final GUI main;
+  /** System property identifier. */
+  private static final String P_SCREEN_MENU_BAR = "apple.laf.useScreenMenuBar";
 
   /**
    * Creates a Java-specific instance of this class.
@@ -26,6 +28,8 @@ public abstract class GUIMacOS {
    */
   static GUIMacOS get(final GUI main) {
     try {
+      // show menu in the screen menu instead of inside the application window
+      System.setProperty(P_SCREEN_MENU_BAR, "true");
       return Prop.JAVA8 ? new GUIMacOSX(main) : new GUIMacOSX9(main);
     } catch(final Exception ex) {
       Util.errln("Failed to initialize native Mac OS X interface:");

--- a/basex-core/src/main/java/org/basex/gui/GUIMacOSX.java
+++ b/basex-core/src/main/java/org/basex/gui/GUIMacOSX.java
@@ -23,8 +23,6 @@ public final class GUIMacOSX extends GUIMacOS {
 
   /** System property identifier. */
   private static final String P_ABOUT_NAME = "com.apple.mrj.application.apple.menu.about.name";
-  /** System property identifier. */
-  private static final String P_SCREEN_MENU_BAR = "apple.laf.useScreenMenuBar";
 
   /** Empty class array. */
   private static final Class<?>[] EC = {};
@@ -44,8 +42,6 @@ public final class GUIMacOSX extends GUIMacOS {
 
     // name for the dock icon and the application menu
     System.setProperty(P_ABOUT_NAME, Prop.NAME);
-    // show menu in the screen menu instead of inside the application window
-    System.setProperty(P_SCREEN_MENU_BAR, "true");
 
     // load native java classes...
     /* Reference to the loaded 'Application' class. */


### PR DESCRIPTION
Move Apple specific system properties to OSX classes.
Set useScreenMenuBar property for all JDKs.