### PR TITLE
Fixed Passsword typo

### DIFF
--- a/basex-api/src/main/webapp/dba/users/user-create.xqm
+++ b/basex-api/src/main/webapp/dba/users/user-create.xqm
@@ -57,7 +57,7 @@ function dba:user-create(
               </td>
             </tr>
             <tr>
-              <td>Passsword:</td>
+              <td>Password:</td>
               <td>
                 <input type='password' name='pw' value='{ $pw }' id='pw'
                   autocomplete='new-password'/>

--- a/basex-api/src/main/webapp/dba/users/user.xqm
+++ b/basex-api/src/main/webapp/dba/users/user.xqm
@@ -70,7 +70,7 @@ function dba:user(
                 </tr>
               ),
               <tr>
-                <td>Passsword:</td>
+                <td>Password:</td>
                 <td>
                   <input type="password" name="pw" value="{ $pw }" id="pw"/> &#xa0;
                   <span class='note'>


### PR DESCRIPTION
Fixed typo on login screen where 'Passsword' should be spelled 'Password'