### PR TITLE
External Unit Testing / Continuous Integration Frameworks running XQuery Unit Tests

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/unit/Suite.java
+++ b/basex-core/src/main/java/org/basex/query/func/unit/Suite.java
@@ -8,6 +8,9 @@ import java.util.*;
 import org.basex.core.*;
 import org.basex.core.jobs.*;
 import org.basex.io.*;
+import org.basex.query.QueryException;
+import org.basex.query.func.StaticFunc;
+import org.basex.query.value.item.QNm;
 import org.basex.query.value.node.*;
 import org.basex.util.*;
 
@@ -27,6 +30,19 @@ public final class Suite {
   /** Tests. */
   public int tests;
 
+  private final static TestEventListener NO_OP_LISTENER = new TestEventListener() {
+    @Override
+    public final void fireTestStarted(final StaticFunc f) { }
+    @Override
+    public final void fireTestFailure(final StaticFunc f, final byte[] prefixId) { }
+    @Override
+    public final void fireTestFailure(final StaticFunc f, final QueryException e, final QNm code) { }
+    @Override
+    public final void fireTestIgnored(final StaticFunc f, final byte[] ignore) { }
+    @Override
+    public final void fireTestFinished(final StaticFunc f, final byte[] time) { }
+  };
+
   /**
    * Tests all test functions in the specified path.
    * @param ctx database context
@@ -36,6 +52,19 @@ public final class Suite {
    * @throws IOException I/O exception
    */
   public FElem test(final IOFile root, final Context ctx, final Job job) throws IOException {
+    return test(root, ctx, job, NO_OP_LISTENER);
+  }
+
+  /**
+   * Tests all test functions in the specified path.
+   * @param ctx database context
+   * @param root path to test modules
+   * @param job calling job
+   * @param listener Object receiving events from fired tests in real time
+   * @return resulting value
+   * @throws IOException I/O exception
+   */
+  public FElem test(final IOFile root, final Context ctx, final Job job, final TestEventListener listener) throws IOException {
     final ArrayList<IOFile> files = new ArrayList<>();
 
     final Performance perf = new Performance();
@@ -51,7 +80,7 @@ public final class Suite {
 
     for(final IOFile file : files) {
       final Unit unit = new Unit(file, ctx, job);
-      unit.test(suites);
+      unit.test(suites, listener);
       errors += unit.errors;
       failures += unit.failures;
       skipped += unit.skipped;

--- a/basex-core/src/main/java/org/basex/query/func/unit/TestEventListener.java
+++ b/basex-core/src/main/java/org/basex/query/func/unit/TestEventListener.java
@@ -1,0 +1,58 @@
+package org.basex.query.func.unit;
+
+import org.basex.query.QueryException;
+import org.basex.query.func.StaticFunc;
+import org.basex.query.value.item.QNm;
+
+/**
+ * XQUnit tests: Trace Event Listener for Unit Tests
+ *
+ * Enable External Test Frameworks to listen in on the status of tests
+ * Enabling JUnit / ScalaTest and Continuous Integration Frameworks to add
+ * XQuery Tests as part of their build process
+ *
+ * @author Charles Foster
+ */
+
+public interface TestEventListener {
+
+  /**
+   * tell listeners that an atomic test is about to start.
+   * @param func XQuery Function Reference executing the test
+   */
+  void fireTestStarted(final StaticFunc func);
+
+  /**
+   * Tell listeners that an atomic test failed
+   * @param func XQuery Function Reference executing the test
+   * @param prefixId QName prefixId
+   */
+  void fireTestFailure(final StaticFunc func, byte[] prefixId);
+
+  /**
+   * Tell listeners that an atomic test failed due to an Exception
+   * @param func XQuery Function Reference executing the test
+   * @param e Query Exception which is ultimately the cause
+   * @param code QName code
+   */
+  void fireTestFailure(
+    final StaticFunc func,
+    final QueryException e,
+    final QNm code
+  );
+
+  /**
+   * Tell listeners that an atomic test was ignored.
+   * @param func XQuery Function Reference executing the test
+   * @ignoreArgs ignore arguments serialized as a byte array
+   */
+  void fireTestIgnored(StaticFunc func, byte[] ignoreArgs);
+
+  /**
+   * Tell listeners that an atomic test finished.
+   * @param func XQuery Function Reference executing the test
+   * @time time it took to execute the test serialized in a byte array
+   */
+  void fireTestFinished(StaticFunc func, byte[] time);
+
+}


### PR DESCRIPTION
Hi Christian, I hope you're well.

I am building a separate piece of software to allow the invocation of BaseX XQuery Unit tests, from within tools such as IntelliJ, sbt, Maven etc which can then also be added into CI Frameworks. Seeing individual tests running and completing in real time is nice for users, instead of having to wait for the entire suite to finish which is currently the case with the XML Output.

In order to get access to these events, I need to listen in with a listener, i've tried to keep it all as fast and as error free as possible for you.