### PR TITLE
#1405

### DIFF
--- a/basex-core/src/main/java/org/basex/build/xml/CatalogWrapper.java
+++ b/basex-core/src/main/java/org/basex/build/xml/CatalogWrapper.java
@@ -39,6 +39,41 @@ public final class CatalogWrapper {
   }
 
   /**
+   * Returns the resolver, which could be of any class that implements the
+   * CatalogManager interface.
+   */
+  public static Object getCM() {
+    return get(CRP, CM);
+  }
+
+  public static void setDefaults(final String path) {
+    if(CM == null) return;
+
+    // IgnoreMissingProperties - default is to print a warning if properties
+    // are unset; this is not usually what we want, but can be overridden
+    // for debugging. Not all resolvers produce errors even if this is false,
+    // so better to set it to true.
+    invoke(method(CMP, "setIgnoreMissingProperties", boolean.class), CM, true);
+
+    // CatalogFiles - semicolon-separated list of files
+    invoke(method(CMP, "setCatalogFiles", String.class), CM, path);
+
+    // StaticCatalog:
+    // If this manager uses static catalogs, the same static catalog will
+    // always be returned.   Otherwise a new catalog will be returned.
+    // We would probably get better performance by using true here. You get a
+    // new catalogmanager instance if you change PATH.
+    invoke(method(CMP, "setUseStaticCatalog", boolean.class), CM, false);
+
+    // You can also set Verbosity, but that's best left for the properties file,
+    // CatalogManager.propertie,  or system property, to help debugging.
+    // The higher the number, the more messages.
+    // NOTE messages go to output, not err stream!
+    // invoke(method(CMP, "setVerbosity", int.class), CM, 0);
+
+  }
+
+  /**
    * Decorates the {@link XMLReader} with the catalog resolver if it is found in the classpath.
    * Does nothing otherwise.
    * @param reader XML reader
@@ -46,11 +81,9 @@ public final class CatalogWrapper {
    */
   static void set(final XMLReader reader, final String path) {
     if(CM == null) return;
-    invoke(method(CMP, "setIgnoreMissingProperties", boolean.class), CM, true);
-    invoke(method(CMP, "setCatalogFiles", String.class), CM, path);
-    invoke(method(CMP, "setPreferPublic", boolean.class), CM, true);
-    invoke(method(CMP, "setUseStaticCatalog", boolean.class), CM, false);
-    invoke(method(CMP, "setVerbosity", int.class), CM, 0);
+
+    setDefaults(path);
+
     reader.setEntityResolver((EntityResolver) get(CRP, CM));
   }
 }


### PR DESCRIPTION
#1405 [ADD] XML Catalog files in xslt:transform()

Patch submitted by: Liam Quin, thank you!

This patch makes `xslt:transform()` aware of XML catalog files, as other XML parsing
already is. The same CATFILE preference is used (via the query
context).

---

Todos: 

- [ ] Documentation
- [ ] Tests
- [ ] Changelog

Am 26.02.2019 um 22:29 schrieb Liam R. E. Quin <liam@fromoldbooks.org>:

> I refactored CatalogWrapper slightly so it could be reused. I also took
> away the line that sets verbosity to 0, as without it you can control
> verbosity via a system property, or using the CatalogManager.properties
> file.
> 
> I tested this with xml-commons-resolver-1.2/resolver.jar and with the
> built-in resolver and both seem to work.
> 
> I have not added tests. In addition, it'd be worth adding something to
> the documentation, especially about the xml.catalog.verbosity property
> (just verbosity in the .properties file).
> 
> Possible breaking change: i also removed the line that sets
> prefer=public. I spent ages trying to get catalogs working before i
> dicovered this, as i was using a system identifier!  The code could
> check to see if the corresponding system property is set (users can't
> override the API with system properties, frustratingly), but since
> catalogs already say prefer=public or prefer=system in them, and it'd
> have needed to have been the same to work, i don't think this change
> breaks anythign in practice. It may make some catalogs start to work
> that had not been working, so maybe it's worth a line in the release
> notes.
