### PR TITLE
[FIX] Reenables 'About' & 'Preferences' on macOS w/ Java9 or greater

### DIFF
--- a/basex-core/src/main/java/org/basex/gui/GUIMacOSX9.java
+++ b/basex-core/src/main/java/org/basex/gui/GUIMacOSX9.java
@@ -27,9 +27,10 @@ public final class GUIMacOSX9 extends GUIMacOS implements InvocationHandler {
     final Object proxy = Proxy.newProxyInstance(getClass().getClassLoader(),
         new Class<?>[] { aboutHandler, prefHandler }, this);
 
-    final Class<?> d = Desktop.getDesktop().getClass();
-    d.getDeclaredMethod("setAboutHandler", aboutHandler).invoke(d, proxy);
-    d.getDeclaredMethod("setPreferencesHandler", prefHandler).invoke(d, proxy);
+    final Desktop d = Desktop.getDesktop();
+    final Class<?> dc = d.getClass();
+    dc.getDeclaredMethod("setAboutHandler", aboutHandler).invoke(d, proxy);
+    dc.getDeclaredMethod("setPreferencesHandler", prefHandler).invoke(d, proxy);
 
     //tb = Taskbar.isTaskbarSupported() ? Taskbar.getTaskbar() : null;
     final Class<?> tbClass = Class.forName("java.awt.Taskbar");


### PR DESCRIPTION
Refactoring in

https://github.com/BaseXdb/basex/commit/aad721d3#diff-a92349d39f7a7491805f1a4856fd1aa8R31

led to method invocation using a class reference where an object is required.

```
    final Class<?> d = Desktop.getDesktop().getClass();
    d.getDeclaredMethod("setAboutHandler", aboutHandler).invoke(d, proxy);
    ^- class                                                    ^- class (object required)
```