### PR TITLE
Refactor PHP client

### DIFF
--- a/basex-api/src/main/php/AddExample.php
+++ b/basex-api/src/main/php/AddExample.php
@@ -6,7 +6,9 @@
  *
  * (C) BaseX Team 2005-12, BSD License
  */
-include("BaseXClient.php");
+include_once 'load.php';
+
+use BaseXClient\Session;
 
 try {
     // create session

--- a/basex-api/src/main/php/AddExample.php
+++ b/basex-api/src/main/php/AddExample.php
@@ -9,33 +9,30 @@
 include("BaseXClient.php");
 
 try {
+    // create session
+    $session = new Session("localhost", 1984, "admin", "admin");
 
-  // create session
-  $session = new Session("localhost", 1984, "admin", "admin");
-  
-  // create new database
-  $session->execute("create db database");
-  print $session->info();
-  
-  // add document
-  $session->add("world/World.xml", "<x>Hello World!</x>");
-  print "<br/>".$session->info();
-  
-  // add document
-  $session->add("Universe.xml", "<x>Hello Universe!</x>");
-  print "<br/>".$session->info();
-  
-  // run query on database
-  print "<br/>".$session->execute("xquery /");
-  
-  // drop database
-  $session->execute("drop db database");
+    // create new database
+    $session->execute("create db database");
+    print $session->info();
 
-  // close session
-  $session->close();
+    // add document
+    $session->add("world/World.xml", "<x>Hello World!</x>");
+    print "<br/>".$session->info();
 
+    // add document
+    $session->add("Universe.xml", "<x>Hello Universe!</x>");
+    print "<br/>".$session->info();
+
+    // run query on database
+    print "<br/>".$session->execute("xquery /");
+
+    // drop database
+    $session->execute("drop db database");
+
+    // close session
+    $session->close();
 } catch (Exception $e) {
-  // print exception
-  print $e->getMessage();
+    // print exception
+    print $e->getMessage();
 }
-?>

--- a/basex-api/src/main/php/AddExample.php
+++ b/basex-api/src/main/php/AddExample.php
@@ -8,6 +8,7 @@
  */
 include_once 'load.php';
 
+use BaseXClient\BaseXException;
 use BaseXClient\Session;
 
 try {
@@ -34,7 +35,7 @@ try {
 
     // close session
     $session->close();
-} catch (Exception $e) {
+} catch (BaseXException $e) {
     // print exception
     print $e->getMessage();
 }

--- a/basex-api/src/main/php/BaseXClient.php
+++ b/basex-api/src/main/php/BaseXClient.php
@@ -7,184 +7,220 @@
  *
  * (C) BaseX Team 2005-15, BSD License
  */
-class Session {
-  // class variables.
-  var $socket, $info, $buffer, $bpos, $bsize;
+class Session
+{
+    // class variables.
+    public $socket;
+    public $info;
+    public $buffer;
+    public $bpos;
+    public $bsize;
 
-  function __construct($h, $p, $user, $pw) {
-    // create server connection
-    $this->socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
-    if(!socket_connect($this->socket, $h, $p)) {
-      throw new Exception("Can't communicate with server.");
+    public function __construct($h, $p, $user, $pw)
+    {
+        // create server connection
+        $this->socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        if (!socket_connect($this->socket, $h, $p)) {
+            throw new Exception("Can't communicate with server.");
+        }
+
+        // receive timestamp
+        $ts = $this->readString();
+        // Hash container
+        if (false !== strpos($ts, ':')) {
+            // digest-auth
+            $challenge = explode(':', $ts, 2);
+            $md5 = hash("md5", hash("md5", $user . ':' . $challenge[0] . ':' . $pw) . $challenge[1]);
+        } else {
+            // Legacy: cram-md5
+            $md5 = hash("md5", hash("md5", $pw) . $ts);
+        }
+
+        // send username and hashed password/timestamp
+        socket_write($this->socket, $user . chr(0) . $md5 . chr(0));
+
+        // receives success flag
+        if (socket_read($this->socket, 1) != chr(0)) {
+            throw new Exception("Access denied.");
+        }
     }
 
-    // receive timestamp
-    $ts = $this->readString();
-	  // Hash container
-    if (false !== strpos($ts, ':')) {
-      // digest-auth
-      $challenge = explode(':', $ts, 2);
-      $md5 = hash("md5", hash("md5", $user . ':' . $challenge[0] . ':' . $pw) . $challenge[1]);
-    } else {
-      // Legacy: cram-md5
-      $md5 = hash("md5", hash("md5", $pw) . $ts);
+    public function execute($com)
+    {
+        // send command to server
+        socket_write($this->socket, $com.chr(0));
+
+        // receive result
+        $result = $this->receive();
+        $this->info = $this->readString();
+        if ($this->ok() != true) {
+            throw new Exception($this->info);
+        }
+        return $result;
     }
 
-    // send username and hashed password/timestamp
-    socket_write($this->socket, $user . chr(0) . $md5 . chr(0));
-
-    // receives success flag
-    if(socket_read($this->socket, 1) != chr(0)) {
-      throw new Exception("Access denied.");
+    public function query($q)
+    {
+        return new Query($this, $q);
     }
-  }
 
-  public function execute($com) {
-    // send command to server
-    socket_write($this->socket, $com.chr(0));
-
-    // receive result
-    $result = $this->receive();
-    $this->info = $this->readString();
-    if($this->ok() != True) {
-      throw new Exception($this->info);
+    public function create($name, $input)
+    {
+        $this->sendCmd(8, $name, $input);
     }
-    return $result;
-  }
 
-  public function query($q) {
-    return new Query($this, $q);
-  }
-
-  public function create($name, $input) {
-    $this->sendCmd(8, $name, $input);
-  }
-
-  public function add($path, $input) {
-    $this->sendCmd(9, $path, $input);
-  }
-
-  public function replace($path, $input) {
-    $this->sendCmd(12, $path, $input);
-  }
-
-  public function store($path, $input) {
-    $this->sendCmd(13, $path, $input);
-  }
-
-  public function info() {
-    return $this->info;
-  }
-
-  public function close() {
-    socket_write($this->socket, "exit".chr(0));
-    socket_close($this->socket);
-  }
-
-  private function init() {
-    $this->bpos = 0;
-    $this->bsize = 0;
-  }
-
-  public function readString() {
-    $com = "";
-    while(($d = $this->read()) != chr(0)) {
-      $com .= $d;
+    public function add($path, $input)
+    {
+        $this->sendCmd(9, $path, $input);
     }
-    return $com;
-  }
 
-  private function read() {
-    if($this->bpos == $this->bsize) {
-      $this->bsize = socket_recv($this->socket, $this->buffer, 4096, 0);
-      $this->bpos = 0;
+    public function replace($path, $input)
+    {
+        $this->sendCmd(12, $path, $input);
     }
-    return $this->buffer[$this->bpos++];
-  }
 
-  private function sendCmd($code, $arg, $input) {
-    socket_write($this->socket, chr($code).$arg.chr(0).$input.chr(0));
-    $this->info = $this->receive();
-    if($this->ok() != True) {
-      throw new Exception($this->info);
+    public function store($path, $input)
+    {
+        $this->sendCmd(13, $path, $input);
     }
-  }
 
-  public function send($str) {
-    socket_write($this->socket, $str.chr(0));
-  }
+    public function info()
+    {
+        return $this->info;
+    }
 
-  public function ok() {
-    return $this->read() == chr(0);
-  }
+    public function close()
+    {
+        socket_write($this->socket, "exit".chr(0));
+        socket_close($this->socket);
+    }
 
-  public function receive() {
-    $this->init();
-    return $this->readString();
-  }
+    private function init()
+    {
+        $this->bpos = 0;
+        $this->bsize = 0;
+    }
+
+    public function readString()
+    {
+        $com = "";
+        while (($d = $this->read()) != chr(0)) {
+            $com .= $d;
+        }
+        return $com;
+    }
+
+    private function read()
+    {
+        if ($this->bpos == $this->bsize) {
+            $this->bsize = socket_recv($this->socket, $this->buffer, 4096, 0);
+            $this->bpos = 0;
+        }
+        return $this->buffer[$this->bpos++];
+    }
+
+    private function sendCmd($code, $arg, $input)
+    {
+        socket_write($this->socket, chr($code).$arg.chr(0).$input.chr(0));
+        $this->info = $this->receive();
+        if ($this->ok() != true) {
+            throw new Exception($this->info);
+        }
+    }
+
+    public function send($str)
+    {
+        socket_write($this->socket, $str.chr(0));
+    }
+
+    public function ok()
+    {
+        return $this->read() == chr(0);
+    }
+
+    public function receive()
+    {
+        $this->init();
+        return $this->readString();
+    }
 }
 
-class Query {
-  var $session, $id, $open, $cache;
+class Query
+{
+    public $session;
+    public $id;
+    public $open;
+    public $cache;
 
-  public function __construct($s, $q) {
-    $this->session = $s;
-    $this->id = $this->exec(chr(0), $q);
-  }
-
-  public function bind($name, $value, $type = "") {
-    $this->exec(chr(3), $this->id.chr(0).$name.chr(0).$value.chr(0).$type);
-  }
-
-  public function context($value, $type = "") {
-    $this->exec(chr(14), $this->id.chr(0).$value.chr(0).$type);
-  }
-
-  public function execute() {
-    return $this->exec(chr(5), $this->id);
-  }
-
-  public function more() {
-    if($this->cache == NULL) {
-      $this->pos = 0;
-      $this->session->send(chr(4).$this->id.chr(0));
-      while(!$this->session->ok()) {
-        $this->cache[] = $this->session->readString();
-      }
-      if(!$this->session->ok()) {
-        throw new Exception($this->session->readString());
-      }
+    public function __construct($s, $q)
+    {
+        $this->session = $s;
+        $this->id = $this->exec(chr(0), $q);
     }
-    if($this->pos < count($this->cache)) return true;
-    $this->cache = NULL;
-    return false;
-  }
 
-  public function next() {
-    if($this->more()) {
-      return $this->cache[$this->pos++];
+    public function bind($name, $value, $type = "")
+    {
+        $this->exec(chr(3), $this->id.chr(0).$name.chr(0).$value.chr(0).$type);
     }
-  }
 
-  public function info() {
-    return $this->exec(chr(6), $this->id);
-  }
-
-  public function options() {
-    return $this->exec(chr(7), $this->id);
-  }
-
-  public function close() {
-    $this->exec(chr(2), $this->id);
-  }
-
-  public function exec($cmd, $arg) {
-    $this->session->send($cmd.$arg);
-    $s = $this->session->receive();
-    if($this->session->ok() != True) {
-      throw new Exception($this->session->readString());
+    public function context($value, $type = "")
+    {
+        $this->exec(chr(14), $this->id.chr(0).$value.chr(0).$type);
     }
-    return $s;
-  }
+
+    public function execute()
+    {
+        return $this->exec(chr(5), $this->id);
+    }
+
+    public function more()
+    {
+        if ($this->cache == null) {
+            $this->pos = 0;
+            $this->session->send(chr(4).$this->id.chr(0));
+            while (!$this->session->ok()) {
+                $this->cache[] = $this->session->readString();
+            }
+            if (!$this->session->ok()) {
+                throw new Exception($this->session->readString());
+            }
+        }
+        if ($this->pos < count($this->cache)) {
+            return true;
+        }
+        $this->cache = null;
+        return false;
+    }
+
+    public function next()
+    {
+        if ($this->more()) {
+            return $this->cache[$this->pos++];
+        }
+    }
+
+    public function info()
+    {
+        return $this->exec(chr(6), $this->id);
+    }
+
+    public function options()
+    {
+        return $this->exec(chr(7), $this->id);
+    }
+
+    public function close()
+    {
+        $this->exec(chr(2), $this->id);
+    }
+
+    public function exec($cmd, $arg)
+    {
+        $this->session->send($cmd.$arg);
+        $s = $this->session->receive();
+        if ($this->session->ok() != true) {
+            throw new Exception($this->session->readString());
+        }
+        return $s;
+    }
 }
-?>

--- a/basex-api/src/main/php/BaseXClient/BaseXException.php
+++ b/basex-api/src/main/php/BaseXClient/BaseXException.php
@@ -10,5 +10,5 @@
 
 namespace BaseXClient;
 
-class Exception extends \RuntimeException
+class BaseXException extends \RuntimeException
 {}

--- a/basex-api/src/main/php/BaseXClient/Exception.php
+++ b/basex-api/src/main/php/BaseXClient/Exception.php
@@ -1,0 +1,14 @@
+<?php
+/*
+ * PHP client for BaseX.
+ * Works with BaseX 7.0 and later
+ *
+ * Documentation: https://docs.basex.org/wiki/Clients
+ *
+ * (C) BaseX Team 2005-15, BSD License
+ */
+
+namespace BaseXClient;
+
+class Exception extends \RuntimeException
+{}

--- a/basex-api/src/main/php/BaseXClient/Query.php
+++ b/basex-api/src/main/php/BaseXClient/Query.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ * PHP client for BaseX.
+ * Works with BaseX 7.0 and later
+ *
+ * Documentation: https://docs.basex.org/wiki/Clients
+ *
+ * (C) BaseX Team 2005-15, BSD License
+ */
+
+namespace BaseXClient;
+
+class Query
+{
+    public $session;
+    public $id;
+    public $open;
+    public $cache;
+
+    public function __construct($s, $q)
+    {
+        $this->session = $s;
+        $this->id = $this->exec(chr(0), $q);
+    }
+
+    public function bind($name, $value, $type = "")
+    {
+        $this->exec(chr(3), $this->id.chr(0).$name.chr(0).$value.chr(0).$type);
+    }
+
+    public function context($value, $type = "")
+    {
+        $this->exec(chr(14), $this->id.chr(0).$value.chr(0).$type);
+    }
+
+    public function execute()
+    {
+        return $this->exec(chr(5), $this->id);
+    }
+
+    public function more()
+    {
+        if ($this->cache == null) {
+            $this->pos = 0;
+            $this->session->send(chr(4).$this->id.chr(0));
+            while (!$this->session->ok()) {
+                $this->cache[] = $this->session->readString();
+            }
+            if (!$this->session->ok()) {
+                throw new Exception($this->session->readString());
+            }
+        }
+        if ($this->pos < count($this->cache)) {
+            return true;
+        }
+        $this->cache = null;
+        return false;
+    }
+
+    public function next()
+    {
+        if ($this->more()) {
+            return $this->cache[$this->pos++];
+        }
+    }
+
+    public function info()
+    {
+        return $this->exec(chr(6), $this->id);
+    }
+
+    public function options()
+    {
+        return $this->exec(chr(7), $this->id);
+    }
+
+    public function close()
+    {
+        $this->exec(chr(2), $this->id);
+    }
+
+    public function exec($cmd, $arg)
+    {
+        $this->session->send($cmd.$arg);
+        $s = $this->session->receive();
+        if ($this->session->ok() != true) {
+            throw new Exception($this->session->readString());
+        }
+        return $s;
+    }
+}

--- a/basex-api/src/main/php/BaseXClient/Query.php
+++ b/basex-api/src/main/php/BaseXClient/Query.php
@@ -12,15 +12,21 @@ namespace BaseXClient;
 
 class Query
 {
-    public $session;
-    public $id;
-    public $open;
-    public $cache;
+    protected $session;
+    protected $id;
+    protected $cache;
+    protected $pos;
 
-    public function __construct($s, $q)
+    /**
+     * Query constructor.
+     *
+     * @param Session $session
+     * @param string $query
+     */
+    public function __construct($session, $query)
     {
-        $this->session = $s;
-        $this->id = $this->exec(chr(0), $q);
+        $this->session = $session;
+        $this->id = $this->exec(chr(0), $query);
     }
 
     public function bind($name, $value, $type = "")
@@ -40,7 +46,7 @@ class Query
 
     public function more()
     {
-        if ($this->cache == null) {
+        if ($this->cache === null) {
             $this->pos = 0;
             $this->session->send(chr(4).$this->id.chr(0));
             while (!$this->session->ok()) {
@@ -83,7 +89,7 @@ class Query
     {
         $this->session->send($cmd.$arg);
         $s = $this->session->receive();
-        if ($this->session->ok() != true) {
+        if ($this->session->ok() !== true) {
             throw new Exception($this->session->readString());
         }
         return $s;

--- a/basex-api/src/main/php/BaseXClient/Query.php
+++ b/basex-api/src/main/php/BaseXClient/Query.php
@@ -53,7 +53,7 @@ class Query
                 $this->cache[] = $this->session->readString();
             }
             if (!$this->session->ok()) {
-                throw new Exception($this->session->readString());
+                throw new BaseXException($this->session->readString());
             }
         }
         if ($this->pos < count($this->cache)) {
@@ -90,7 +90,7 @@ class Query
         $this->session->send($cmd.$arg);
         $s = $this->session->receive();
         if ($this->session->ok() !== true) {
-            throw new Exception($this->session->readString());
+            throw new BaseXException($this->session->readString());
         }
         return $s;
     }

--- a/basex-api/src/main/php/BaseXClient/Query.php
+++ b/basex-api/src/main/php/BaseXClient/Query.php
@@ -10,7 +10,7 @@
 
 namespace BaseXClient;
 
-class Query
+class Query implements \Iterator
 {
     protected $session;
     protected $id;
@@ -93,5 +93,24 @@ class Query
             throw new BaseXException($this->session->readString());
         }
         return $s;
+    }
+
+    public function current()
+    {
+        return $this->cache[$this->pos];
+    }
+
+    public function key()
+    {
+        return $this->pos;
+    }
+
+    public function valid()
+    {
+        return $this->more();
+    }
+
+    public function rewind()
+    {
     }
 }

--- a/basex-api/src/main/php/BaseXClient/Session.php
+++ b/basex-api/src/main/php/BaseXClient/Session.php
@@ -7,6 +7,9 @@
  *
  * (C) BaseX Team 2005-15, BSD License
  */
+
+namespace BaseXClient;
+
 class Session
 {
     // class variables.
@@ -142,85 +145,5 @@ class Session
     {
         $this->init();
         return $this->readString();
-    }
-}
-
-class Query
-{
-    public $session;
-    public $id;
-    public $open;
-    public $cache;
-
-    public function __construct($s, $q)
-    {
-        $this->session = $s;
-        $this->id = $this->exec(chr(0), $q);
-    }
-
-    public function bind($name, $value, $type = "")
-    {
-        $this->exec(chr(3), $this->id.chr(0).$name.chr(0).$value.chr(0).$type);
-    }
-
-    public function context($value, $type = "")
-    {
-        $this->exec(chr(14), $this->id.chr(0).$value.chr(0).$type);
-    }
-
-    public function execute()
-    {
-        return $this->exec(chr(5), $this->id);
-    }
-
-    public function more()
-    {
-        if ($this->cache == null) {
-            $this->pos = 0;
-            $this->session->send(chr(4).$this->id.chr(0));
-            while (!$this->session->ok()) {
-                $this->cache[] = $this->session->readString();
-            }
-            if (!$this->session->ok()) {
-                throw new Exception($this->session->readString());
-            }
-        }
-        if ($this->pos < count($this->cache)) {
-            return true;
-        }
-        $this->cache = null;
-        return false;
-    }
-
-    public function next()
-    {
-        if ($this->more()) {
-            return $this->cache[$this->pos++];
-        }
-    }
-
-    public function info()
-    {
-        return $this->exec(chr(6), $this->id);
-    }
-
-    public function options()
-    {
-        return $this->exec(chr(7), $this->id);
-    }
-
-    public function close()
-    {
-        $this->exec(chr(2), $this->id);
-    }
-
-    public function exec($cmd, $arg)
-    {
-        $this->session->send($cmd.$arg);
-        $s = $this->session->receive();
-        if ($this->session->ok() != true) {
-            throw new Exception($this->session->readString());
-        }
-        return $s;
     }
 }

--- a/basex-api/src/main/php/BaseXClient/Session.php
+++ b/basex-api/src/main/php/BaseXClient/Session.php
@@ -24,7 +24,7 @@ class Session
         // create server connection
         $this->socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
         if (!socket_connect($this->socket, $hostname, $port)) {
-            throw new Exception("Can't communicate with server.");
+            throw new BaseXException("Can't communicate with server.");
         }
 
         // receive timestamp
@@ -44,7 +44,7 @@ class Session
 
         // receives success flag
         if (socket_read($this->socket, 1) != chr(0)) {
-            throw new Exception("Access denied.");
+            throw new BaseXException("Access denied.");
         }
     }
 
@@ -63,7 +63,7 @@ class Session
         $result = $this->receive();
         $this->info = $this->readString();
         if ($this->ok() != true) {
-            throw new Exception($this->info);
+            throw new BaseXException($this->info);
         }
         return $result;
     }
@@ -169,7 +169,7 @@ class Session
         socket_write($this->socket, chr($code).$arg.chr(0).$input.chr(0));
         $this->info = $this->receive();
         if ($this->ok() != true) {
-            throw new Exception($this->info);
+            throw new BaseXException($this->info);
         }
     }
 

--- a/basex-api/src/main/php/CreateExample.php
+++ b/basex-api/src/main/php/CreateExample.php
@@ -6,7 +6,9 @@
  *
  * (C) BaseX Team 2005-12, BSD License
  */
-include("BaseXClient.php");
+include_once 'load.php';
+
+use BaseXClient\Session;
 
 try {
     // create session

--- a/basex-api/src/main/php/CreateExample.php
+++ b/basex-api/src/main/php/CreateExample.php
@@ -9,25 +9,22 @@
 include("BaseXClient.php");
 
 try {
+    // create session
+    $session = new Session("localhost", 1984, "admin", "admin");
 
-  // create session
-  $session = new Session("localhost", 1984, "admin", "admin");
-  
-  // create new database
-  $session->create("database", "<x>Hello World!</x>");
-  print $session->info();
-  
-  // run query on database
-  print "<br/>".$session->execute("xquery /");
-  
-  // drop database
-  $session->execute("drop db database");
+    // create new database
+    $session->create("database", "<x>Hello World!</x>");
+    print $session->info();
 
-  // close session
-  $session->close();
+    // run query on database
+    print "<br/>".$session->execute("xquery /");
 
+    // drop database
+    $session->execute("drop db database");
+
+    // close session
+    $session->close();
 } catch (Exception $e) {
-  // print exception
-  print $e->getMessage();
+    // print exception
+    print $e->getMessage();
 }
-?>

--- a/basex-api/src/main/php/CreateExample.php
+++ b/basex-api/src/main/php/CreateExample.php
@@ -8,6 +8,7 @@
  */
 include_once 'load.php';
 
+use BaseXClient\BaseXException;
 use BaseXClient\Session;
 
 try {
@@ -26,7 +27,7 @@ try {
 
     // close session
     $session->close();
-} catch (Exception $e) {
+} catch (BaseXException $e) {
     // print exception
     print $e->getMessage();
 }

--- a/basex-api/src/main/php/Example.php
+++ b/basex-api/src/main/php/Example.php
@@ -8,6 +8,7 @@
  */
 include_once 'load.php';
 
+use BaseXClient\BaseXException;
 use BaseXClient\Session;
 
 try {
@@ -26,7 +27,7 @@ try {
     // print time needed
     $time = (microtime(true) - $start) * 1000;
     print "\n$time ms\n";
-} catch (Exception $e) {
+} catch (BaseXException $e) {
     // print exception
     print $e->getMessage();
 }

--- a/basex-api/src/main/php/Example.php
+++ b/basex-api/src/main/php/Example.php
@@ -6,7 +6,9 @@
  *
  * (C) BaseX Team 2005-12, BSD License
  */
-include("BaseXClient.php");
+include_once 'load.php';
+
+use BaseXClient\Session;
 
 try {
     // initialize timer

--- a/basex-api/src/main/php/Example.php
+++ b/basex-api/src/main/php/Example.php
@@ -9,24 +9,22 @@
 include("BaseXClient.php");
 
 try {
-  // initialize timer
-  $start = microtime(true);
+    // initialize timer
+    $start = microtime(true);
 
-  // create session
-  $session = new Session("localhost", 1984, "admin", "admin");
-  
-  // perform command and print returned string
-  print $session->execute("xquery 1 to 10");
+    // create session
+    $session = new Session("localhost", 1984, "admin", "admin");
 
-  // close session
-  $session->close();
+    // perform command and print returned string
+    print $session->execute("xquery 1 to 10");
 
-  // print time needed
-  $time = (microtime(true) - $start) * 1000;
-  print "\n$time ms\n";
+    // close session
+    $session->close();
 
+    // print time needed
+    $time = (microtime(true) - $start) * 1000;
+    print "\n$time ms\n";
 } catch (Exception $e) {
-  // print exception
-  print $e->getMessage();
+    // print exception
+    print $e->getMessage();
 }
-?>

--- a/basex-api/src/main/php/QueryBindExample.php
+++ b/basex-api/src/main/php/QueryBindExample.php
@@ -6,7 +6,9 @@
  *
  * (C) BaseX Team 2005-12, BSD License
  */
-include("BaseXClient.php");
+include_once 'load.php';
+
+use BaseXClient\Session;
 
 try {
     // create session

--- a/basex-api/src/main/php/QueryBindExample.php
+++ b/basex-api/src/main/php/QueryBindExample.php
@@ -8,6 +8,7 @@
  */
 include_once 'load.php';
 
+use BaseXClient\BaseXException;
 use BaseXClient\Session;
 
 try {
@@ -27,14 +28,14 @@ try {
 
         // close query instance
         $query->close();
-    } catch (Exception $e) {
+    } catch (BaseXException $e) {
         // print exception
         print $e->getMessage();
     }
 
     // close session
     $session->close();
-} catch (Exception $e) {
+} catch (BaseXException $e) {
     // print exception
     print $e->getMessage();
 }

--- a/basex-api/src/main/php/QueryBindExample.php
+++ b/basex-api/src/main/php/QueryBindExample.php
@@ -9,33 +9,30 @@
 include("BaseXClient.php");
 
 try {
-  // create session
-  $session = new Session("localhost", 1984, "admin", "admin");
-  
-  try {
-    // create query instance
-    $input = 'declare variable $name external; for $i in 1 to 10 return element { $name } { $i }';
-    $query = $session->query($input);
+    // create session
+    $session = new Session("localhost", 1984, "admin", "admin");
 
-    // bind variable
-    $query->bind("name", "number");
+    try {
+        // create query instance
+        $input = 'declare variable $name external; for $i in 1 to 10 return element { $name } { $i }';
+        $query = $session->query($input);
 
-    // print results
-    print $query->execute()."\n";
+        // bind variable
+        $query->bind("name", "number");
 
-    // close query instance
-    $query->close();
+        // print results
+        print $query->execute()."\n";
 
-  } catch (Exception $e) {
+        // close query instance
+        $query->close();
+    } catch (Exception $e) {
+        // print exception
+        print $e->getMessage();
+    }
+
+    // close session
+    $session->close();
+} catch (Exception $e) {
     // print exception
     print $e->getMessage();
-  }
-
-  // close session
-  $session->close();
-
-} catch (Exception $e) {
-  // print exception
-  print $e->getMessage();
 }
-?>

--- a/basex-api/src/main/php/QueryExample.php
+++ b/basex-api/src/main/php/QueryExample.php
@@ -9,6 +9,7 @@
  */
 include_once 'load.php';
 
+use BaseXClient\BaseXException;
 use BaseXClient\Session;
 
 try {
@@ -27,14 +28,14 @@ try {
 
         // close query instance
         $query->close();
-    } catch (Exception $e) {
+    } catch (BaseXException $e) {
         // print exception
         print $e->getMessage();
     }
 
     // close session
     $session->close();
-} catch (Exception $e) {
+} catch (BaseXException $e) {
     // print exception
     print $e->getMessage();
 }

--- a/basex-api/src/main/php/QueryExample.php
+++ b/basex-api/src/main/php/QueryExample.php
@@ -7,7 +7,9 @@
  *
  * (C) BaseX Team 2005-12, BSD License
  */
-include("BaseXClient.php");
+include_once 'load.php';
+
+use BaseXClient\Session;
 
 try {
     // create session

--- a/basex-api/src/main/php/QueryExample.php
+++ b/basex-api/src/main/php/QueryExample.php
@@ -22,8 +22,8 @@ try {
         $query = $session->query($input);
 
         // loop through all results
-        while ($query->more()) {
-            print $query->next()."\n";
+        foreach ($query as $resultItem) {
+            print $resultItem."\n";
         }
 
         // close query instance

--- a/basex-api/src/main/php/QueryExample.php
+++ b/basex-api/src/main/php/QueryExample.php
@@ -10,32 +10,29 @@
 include("BaseXClient.php");
 
 try {
-  // create session
-  $session = new Session("localhost", 1984, "admin", "admin");
-  
-  try {
-    // create query instance
-    $input = 'for $i in 1 to 10 return <xml>Text { $i }</xml>';
-    $query = $session->query($input);
+    // create session
+    $session = new Session("localhost", 1984, "admin", "admin");
 
-    // loop through all results
-    while($query->more()) {
-      print $query->next()."\n";
+    try {
+        // create query instance
+        $input = 'for $i in 1 to 10 return <xml>Text { $i }</xml>';
+        $query = $session->query($input);
+
+        // loop through all results
+        while ($query->more()) {
+            print $query->next()."\n";
+        }
+
+        // close query instance
+        $query->close();
+    } catch (Exception $e) {
+        // print exception
+        print $e->getMessage();
     }
 
-    // close query instance
-    $query->close();
-
-  } catch (Exception $e) {
+    // close session
+    $session->close();
+} catch (Exception $e) {
     // print exception
     print $e->getMessage();
-  }
-
-  // close session
-  $session->close();
-
-} catch (Exception $e) {
-  // print exception
-  print $e->getMessage();
 }
-?>

--- a/basex-api/src/main/php/load.php
+++ b/basex-api/src/main/php/load.php
@@ -10,4 +10,4 @@
 
 include_once 'BaseXClient/Session.php';
 include_once 'BaseXClient/Query.php';
-include_once 'BaseXClient/Exception.php';
+include_once 'BaseXClient/BaseXException.php';

--- a/basex-api/src/main/php/load.php
+++ b/basex-api/src/main/php/load.php
@@ -1,0 +1,12 @@
+<?php
+/*
+ * This script loads all code of the PHP BaseXClient library for use in the example scripts.
+ * Usually the library won't be used like this, but copied to a project and loaded by PSR-4 autoload.
+ *
+ * Documentation: https://docs.basex.org/wiki/Clients
+ *
+ * (C) BaseX Team 2005-12, BSD License
+ */
+
+include_once 'BaseXClient/Session.php';
+include_once 'BaseXClient/Query.php';

--- a/basex-api/src/main/php/load.php
+++ b/basex-api/src/main/php/load.php
@@ -10,3 +10,4 @@
 
 include_once 'BaseXClient/Session.php';
 include_once 'BaseXClient/Query.php';
+include_once 'BaseXClient/Exception.php';


### PR DESCRIPTION
Code of the PHP client has to be modified for use in modern PHP projects, so I tried to fix this.

* directory structure adjusted with [PSR-4 autoloading](https://www.php-fig.org/psr/psr-4/) in mind, namespace added
  -- i.e. the code as is does not use autoloading, but the `basex-api/src/main/php/BaseXClient` can be copy-pasted to a project with PSR-4 autoloading enabled and with a small bit of configuration in `composer.json` will work fine

Then I added some more improvements and updated some of the most archaic code features, while trying not to break compatibility with "reasonably old" outdated PHP versions.

* code style according to the [PSR-2](https://www.php-fig.org/psr/psr-2/) community standard enforced by [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer)
* various code smells fixed (see commit messages)
* `Query` implements the `Iterator` interface