### PR TITLE
Signature resilient to missing query

### DIFF
--- a/basex-api/src/main/webapp/dba/databases/resources/db-query.xqm
+++ b/basex-api/src/main/webapp/dba/databases/resources/db-query.xqm
@@ -24,7 +24,7 @@ declare
 function dba:db-query(
   $name      as xs:string,
   $resource  as xs:string,
-  $query     as xs:string
+  $query     as xs:string?
 ) as xs:string {
   util:query(if($query) then $query else '.', db:open($name, $resource))
 };


### PR DESCRIPTION
We've found out (but not clearly identified) that with some combinations of browsers/proxies the body is not an empty string "" but rather an empty sequence. This is causing error when opening the database view of the dba. ("_Request body must be xs:string, supplied ()_")
We propose to make the query parameter optional.
