### PR TITLE
fix in EQNAME regexp

### DIFF
--- a/basex-core/src/main/java/org/basex/query/value/item/QNm.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/QNm.java
@@ -33,7 +33,7 @@ public final class QNm extends Item {
   public static final QNm REST_ERROR = new QNm(ERROR, REST_URI);
 
   /** URL pattern (matching Clark and EQName notation). */
-  public static final Pattern EQNAME = Pattern.compile("^Q?\\{(.*?)}(.+)$");
+  public static final Pattern EQNAME = Pattern.compile("^Q?\\{(.*?)\\}(.+)$");
 
   /** Name with optional prefix. */
   private final byte[] name;


### PR DESCRIPTION
In EQNAME the closing brace also needs to be escaped.
Found out while using BaseX in android which gave a Pattern syntax error