### PR TITLE
Allow running BaseX from a fat jar

### DIFF
--- a/basex-core/src/main/java/org/basex/io/IO.java
+++ b/basex-core/src/main/java/org/basex/io/IO.java
@@ -59,6 +59,8 @@ public abstract class IO {
   public static final String IGNORESUFFIX = ".ignore";
   /** File prefix. */
   public static final String FILEPREF = "file:/";
+  /** Jar prefix. */
+  public static final String JARPREF = "jar:";
 
   /** XQuery suffixes. */
   public static final String[] XQSUFFIXES =

--- a/basex-core/src/main/java/org/basex/io/IO.java
+++ b/basex-core/src/main/java/org/basex/io/IO.java
@@ -4,6 +4,7 @@ import static org.basex.util.Token.*;
 import static org.basex.util.FTToken.*;
 
 import java.io.*;
+import java.net.*;
 import java.util.*;
 
 import javax.xml.transform.stream.*;
@@ -240,7 +241,14 @@ public abstract class IO {
   public final IO merge(final String path) {
     if(path.isEmpty()) return this;
     final IO io = get(path);
-    return io.isAbsolute() ? io : get((Strings.endsWith(pth, '/') ? pth : dir()) + path);
+    if(io.isAbsolute()) return io;
+    if(IOUrl.isJarURL(pth))
+      try {
+        return get(new URL(new URL(pth), path).toString());
+      }
+      catch (@SuppressWarnings("unused") MalformedURLException ex) {
+      }
+    return get((Strings.endsWith(pth, '/') ? pth : dir()) + path);
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/io/IOUrl.java
+++ b/basex-core/src/main/java/org/basex/io/IOUrl.java
@@ -124,7 +124,9 @@ public final class IOUrl extends IO {
 
   @Override
   public InputStream inputStream() throws IOException {
-    return response().body();
+    return isJarURL(pth)
+        ? new URL(pth).openStream()
+        : response().body();
   }
 
 
@@ -198,7 +200,7 @@ public final class IOUrl extends IO {
   static boolean isValid(final String url) {
     final int ul = url.length();
     int u = url.indexOf(':');
-    if(u < 2 || u + 1 == ul || url.charAt(u + 1) != '/') return false;
+    if(u < 2 || u + 1 == ul) return false;
     while(--u >= 0) {
       final char c = url.charAt(u);
       if(!(c >= 'a' && c <= 'z' || c == '+' || c == '-' || c == '.' || c == '_')) return false;
@@ -229,6 +231,15 @@ public final class IOUrl extends IO {
    */
   static boolean isFileURL(final String url) {
     return url.startsWith(FILEPREF);
+  }
+
+  /**
+   * Checks if the specified string is a jar URL.
+   * @param url url to be tested
+   * @return result of check
+   */
+  static boolean isJarURL(final String url) {
+    return url.startsWith(JARPREF);
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/util/pkg/ModuleLoader.java
+++ b/basex-core/src/main/java/org/basex/query/util/pkg/ModuleLoader.java
@@ -49,7 +49,7 @@ public final class ModuleLoader {
    * implementing {@link QueryResource}.
    */
   public void close() {
-    if(loader instanceof URLClassLoader) {
+    if(loader != LOADER) {
       try {
         ((URLClassLoader) loader).close();
       } catch(final IOException ex) {

--- a/basex-core/src/main/java/org/basex/util/Prop.java
+++ b/basex-core/src/main/java/org/basex/util/Prop.java
@@ -109,7 +109,7 @@ public final class Prop {
    */
   private static String applicationDir(final URL location) {
     try {
-      if(location != null) return new IOFile(Paths.get(location.toURI()).toString()).dir();
+      if(location != null && "file".equals(location.getProtocol())) return new IOFile(Paths.get(location.toURI()).toString()).dir();
     } catch(final Exception ex) {
       Util.stack(ex);
     }


### PR DESCRIPTION
While trying to use BaseX in an application that is packaged as a fat jar, I found a few problems:

- Prop.applicationDir assumes that it is passed a file URL, which in this setup does not hold for Prop.LOCATION (which is something like "rsrc:basex-10.5-SNAPSHOT.jar"). This causes a FileSystemNotFoundException stack to be logged
- ModuleLoader.close closes the classloader when it is an URLClassLoader. However in this setup, the default classloader is an URLClassLoader and it must not be closed
- an XQuery module URL, in this setup, might be something like "jar:rsrc:xquery-module-test-plain.jar!/m0.xqm". This however not accepted by IOURL.isValid, because it insists on a '/' character following the protocol
- IOURL.inputStream use an HTTP connection, which does not work for jar URLs. For those it is sufficient to use URL.openStream
- when resolving a module URI containing a parent step, e.g. "../m4/m4.xqm", the parent step must be resolved as well. This can be accomplished by using the URL(URL, String) constructor

I have created a test that demonstrates all of this here: https://github.com/GuntherRademacher/xquery-module-test

This PR contains fixes to make it work.