### PR TITLE
Fix XXE vulnerability in XmlParser.java

### DIFF
--- a/basex-core/src/main/java/org/basex/io/parse/xml/XmlParser.java
+++ b/basex-core/src/main/java/org/basex/io/parse/xml/XmlParser.java
@@ -60,6 +60,7 @@ public final class XmlParser {
 
     final SAXParserFactory f = SAXParserFactory.newInstance();
     f.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", dtd);
+    f.setFeature("http://xml.org/sax/features/external-general-entities", dtd);
     f.setFeature("http://xml.org/sax/features/external-parameter-entities", dtd);
     f.setFeature("http://xml.org/sax/features/use-entity-resolver2", false);
     f.setNamespaceAware(true);


### PR DESCRIPTION
Thanks for your effort maintaining this library :)

In version 9.1 [this method](https://github.com/BaseXdb/basex/blob/9.1/basex-core/src/main/java/org/basex/io/parse/xml/XmlParser.java#L58) was added which cannot be configured safely to prevent XXE.

Regardless of the configured `dtd` bool, without control over the `external-general-entities` feature, external DTDs are evaluated leading to exploitation.

By my understanding of the library a user passing `false` to the `dtd` parameter would not want/expect external DTDs to be evaluated, therefore allowing the feature flag to be controlled by this method resolves the issue.