### PR TITLE
Avoid long value overflow in position range

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/Pos.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Pos.java
@@ -69,11 +69,11 @@ final class Pos extends Single {
           minMax = new Expr[] { ps, ps };
           break;
         case GE:
-          minMax = new Expr[] { ps, Int.MAX };
+          minMax = new Expr[] { cc.function(Function.MAX, ii, new List(ii, Int.ONE, ps).optimize(cc)), Int.MAX };
           break;
         case GT:
-          minMax = new Expr[] { new Arith(ii, type.instanceOf(AtomType.INTEGER) ? ps :
-            cc.function(Function.FLOOR, ii, ps), Int.ONE, Calc.PLUS).optimize(cc), Int.MAX };
+          minMax = new Expr[] { cc.function(Function.MAX, ii, new List(ii, Int.ONE, new Arith(ii, type.instanceOf(AtomType.INTEGER) ? ps :
+            cc.function(Function.FLOOR, ii, ps), Int.ONE, Calc.PLUS))).optimize(cc), Int.MAX };
           break;
         case LE:
           minMax = new Expr[] { Int.ONE, ps };

--- a/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
@@ -412,6 +412,10 @@ public final class RewritingsTest extends QueryPlanTest {
         "<b/>", root(CElem.class));
     check("(<a/>, <b/>[. = ''])[position() > 1 and position() < 4]",
         "<b/>", empty(List.class), root(IterFilter.class));
+    check("<a/>[position() >= last() - 1]",
+        "<a/>", exists(MAX));
+    check("<a/>[position() > last() - 2]",
+        "<a/>", exists(CmpSimpleG.class));
   }
 
   /** Predicates. */


### PR DESCRIPTION
An XQuery positional filter for the last one or two elements of a sequence,
```xquery
    <a/>[position() >= last() - 1]
```
failed with this result, when there is just a single item in the context:
```
    [FOAR0002] Value out of range: 9223372036854775807.
```
This is caused by [Pos.get](https://github.com/BaseXdb/basex/blob/73986c1c4c156eea9c236e432d011fd00162bd8d/basex-core/src/main/java/org/basex/query/expr/Pos.java#L71-L77) transforming the filter predicate to a range ending in Long.MAX_VALUE,
```java
        case GE:
          minMax = new Expr[] { ps, Int.MAX };
          break;
        case GT:
          minMax = new Expr[] { new Arith(ii, type.instanceOf(AtomType.INTEGER) ? ps :
            cc.function(Function.FLOOR, ii, ps), Int.ONE, Calc.PLUS).optimize(cc), Int.MAX };
          break;
```
and [Range.value](https://github.com/BaseXdb/basex/blob/73986c1c4c156eea9c236e432d011fd00162bd8d/basex-core/src/main/java/org/basex/query/expr/Range.java#L72-L75) producing a long overflow while calculating the range size,
```java
    final long size = mx - mn + 1;
    if(size > 0) return RangeSeq.get(mn, size, true);
    // overflow of long value
    throw RANGE_X.get(info, mx);
```
where `mn == 0` and `mx == Long.MAX_VALUE`.

Actually the lower bound of the position range never needs to be less than 1, so the idea of this fix is to rewrite 
```xquery
    <a/>[position() >= last() - 1]
```
to
```xquery
    <a/>[position() >= max((1, last() - 1)]
```