### PR TITLE
Avoid OOME in SimpleTest 

### DIFF
--- a/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java
+++ b/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java
@@ -227,8 +227,6 @@ public final class SimpleTest extends QueryTest {
       { "Limits 8", "-9223372036854775808 idiv -1" },
       { "Limits 9", "-9223372036854775807 - 1024" },
       { "Limits 10", "-9223372036854775808 - 1" },
-      { "Limits 11", "0 to 9223372036854775807" },
-      { "Limits 11", "-9223372036854775807 to 9223372036854775807" },
 
       { "Empty 1", strings(""), "format-integer(let $x := " + _RANDOM_INTEGER.args() +
         " return (), '0')" },


### PR DESCRIPTION
Sorry for coming back to this, but there are two test cases in [SimpleTest](https://github.com/BaseXdb/basex/blob/main/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java#L230-L231) that are now causing out-of-memory after the recent changes with respect to ranges:
```java
      { "Limits 11", "0 to 9223372036854775807" },
      { "Limits 11", "-9223372036854775807 to 9223372036854775807" },
```
I guess these just have to go now.