### PR TITLE
Prevent typeswitch optimization from selecting supertype branches

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/TypeswitchGroup.java
+++ b/basex-core/src/main/java/org/basex/query/expr/TypeswitchGroup.java
@@ -163,15 +163,16 @@ public final class TypeswitchGroup extends Single {
   }
 
   /**
-   * Checks if the given sequence type matches this group.
-   * @param seqType sequence type
-   * @return result of check
+   * Find the matching types from this group for the given sequence types.
+   * @param types sequence types
+   * @return the matching types from this group
    */
-  boolean instance(final SeqType seqType) {
-    for(final SeqType st : seqTypes) {
-      if(seqType.instanceOf(st)) return true;
-    }
-    return false;
+  SeqType[] matchingTypes(final SeqType... types) {
+    return Arrays.stream(seqTypes)
+        .filter(seqType -> Arrays.stream(types)
+            .anyMatch(type -> type.instanceOf(seqType))
+        )
+        .toArray(SeqType[]::new);
   }
 
   /**

--- a/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java
+++ b/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java
@@ -182,6 +182,16 @@ public final class SimpleTest extends QueryTest {
         "typeswitch(<a>1</a>) case $a as xs:string return 1 default return 1" },
       { "Typeswitch 3", integers(1, 2),
         "typeswitch(<a>1</a>) case $a as xs:string return (1, 2) default return (1, 2)" },
+      { "Typeswitch 4", integers(1, 2, 3, 4, 5),
+        "(xs:byte(0), xs:short(0), xs:int(0), xs:long(0), 0)!"
+        + "(typeswitch (.)"
+        + " case xs:byte return 1"
+        + " case xs:short return 2"
+        + " case xs:int return 3"
+        + " case xs:long return 4"
+        + " case xs:decimal | xs:integer return 5"
+        + " default return 6\r\n"
+        + ")" },
 
       { "FunctionContext 0", "declare function local:x() { /x }; local:x()" },
 


### PR DESCRIPTION
An XQuery typeswitch returned a wrong value, e.g.
```xquery
for $value in (0, 0.0)
return
  typeswitch ($value)
  case xs:integer return 'integer'
  case xs:decimal return 'decimal'
  default return 'neither'
```
returned `('decimal', 'decimal')`, where it should have been `('integer', 'decimal')`.

This is caused by [Typeswitch.optimize](https://github.com/BaseXdb/basex/blob/5e1ec7605d368aa214b3cf2e3865cf4b0ccd0443/basex-core/src/main/java/org/basex/query/expr/Typeswitch.java#L83-L89) selecting a branch based on the static type of the operand 
expression (in the example above, xs:decimal):
```java
    // check if always the same branch will be evaluated
    Expr expr = this;
    // choose branch that can be statically determined
    TypeswitchGroup tg = null;
    for(final TypeswitchGroup group : groups) {
      if(tg == null && group.instance(ct)) tg = group;
    }
```
However this is not valid when the selected branch is preceded by some other branch, where a sequence type for that branch is a subtype of the sequence type of the selected branch.

This fix replaces TypeswitchGroup.instance by a method returning the matching types, and it matches those against sequence types of preceding branches. The optimization is then only applied in absence of any matches with preceding branches.