### PR TITLE
Suppress indentation inside of (X)HTML formatted elements

### DIFF
--- a/basex-core/src/main/java/org/basex/io/serial/HTMLSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/HTMLSerializer.java
@@ -21,6 +21,8 @@ final class HTMLSerializer extends MarkupSerializer {
   static final TokenList EMPTIES = new TokenList();
   /** HTML5: elements with an empty content model. */
   static final TokenList EMPTIES5 = new TokenList();
+  /** (X)HTML: formatted elements. */
+  static final TokenList FORMATTEDS = new TokenList();
   /** (X)HTML: URI attributes. */
   static final TokenSet URIS = new TokenSet();
 
@@ -147,6 +149,20 @@ final class HTMLSerializer extends MarkupSerializer {
     }
   }
 
+  @Override
+  protected void indent() throws IOException {
+    if(atomic) {
+      atomic = false;
+    } else if(indent) {
+      for(final QNm qname : elems) {
+        byte[] lc = lc(qname.local());
+        if(eq(qname.uri(), EMPTY) && FORMATTEDS.contains(lc)) return;
+        if(html5 && eq(qname.uri(), XHTML_URI) && FORMATTEDS.contains(lc)) return;
+      }
+      super.indent();
+    }
+  }
+
   // HTML Serializer: cache elements
   static {
     // script elements
@@ -239,6 +255,12 @@ final class HTMLSerializer extends MarkupSerializer {
     EMPTIES5.add("source");
     EMPTIES5.add("track");
     EMPTIES5.add("wbr");
+    // formatted elements
+    FORMATTEDS.add("pre");
+    FORMATTEDS.add("script");
+    FORMATTEDS.add("style");
+    FORMATTEDS.add("title");
+    FORMATTEDS.add("textarea");
     // URI attributes
     URIS.add("a@href");
     URIS.add("a@name");

--- a/basex-core/src/main/java/org/basex/io/serial/XHTMLSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/XHTMLSerializer.java
@@ -70,4 +70,17 @@ final class XHTMLSerializer extends MarkupSerializer {
       printDoctype(type, docpub, docsys);
     }
   }
+
+  @Override
+  protected void indent() throws IOException {
+    if(atomic) {
+      atomic = false;
+    } else if(indent) {
+      for(final QNm qname : elems) {
+        if(eq(qname.uri(), XHTML_URI) && HTMLSerializer.FORMATTEDS.contains(qname.local())) return;
+        if(html5 && eq(qname.uri(), EMPTY) && HTMLSerializer.FORMATTEDS.contains(lc(qname.local()))) return;
+      }
+      super.indent();
+    }
+  }
 }

--- a/basex-core/src/test/java/org/basex/query/SerializerTest.java
+++ b/basex-core/src/test/java/org/basex/query/SerializerTest.java
@@ -7,6 +7,7 @@ import java.util.*;
 import static org.basex.io.serial.SerializerOptions.*;
 
 import org.basex.*;
+import org.basex.io.serial.*;
 import org.junit.jupiter.api.*;
 
 /**
@@ -31,6 +32,13 @@ public final class SerializerTest extends SandboxTest {
       query(option + "<html xmlns='http://www.w3.org/1999/xhtml'><" + e + "/></html>",
           "<html xmlns=\"http://www.w3.org/1999/xhtml\"><" + e + " /></html>");
     }
+    query(option + SerializerOptions.INDENT.arg("yes")
+        + "<html xmlns='http://www.w3.org/1999/xhtml'><body><pre><u>test</u></pre></body></html>",
+        "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+        + "<body>\n"
+        + "<pre><u>test</u></pre>\n"
+        + "</body>\n"
+        + "</html>");
   }
 
   /** method=xhtml, meta element. */
@@ -63,6 +71,14 @@ public final class SerializerTest extends SandboxTest {
 
     query(option + "<?x y?>", "<?x y>");
     error(option + "<?x > ?>", SERPI);
+
+    query(option + SerializerOptions.INDENT.arg("yes")
+        + "<html><body><PRE><u>test</u></PRE></body></html>",
+        "<html>\n"
+        + "<body>\n"
+        + "<PRE><u>test</u></PRE>\n"
+        + "</body>\n"
+        + "</html>");
   }
 
   /** Test: method=html, version=5.0. */


### PR DESCRIPTION
When using (X)HTML serialization with `indent=yes`, some unwanted whitespace appeared in a `pre` element, and in rendered content. E.g.

```xml
<html><body><pre><u>test</u></pre></body></html>
```
was serialized as

```xml
<html>
  <body>
    <pre>
      <u>test</u>
    </pre>
  </body>
</html>
```

While this OK with XML serialization, (X)HTML serialization must not modify whitespace inside of formatted elements, as specified in
* [6.1.4 XHTML Output Method: the indent and suppress-indentation Parameters](https://www.w3.org/TR/xslt-xquery-serialization-31/#XHTML_INDENT) 
* [7.4.3 HTML Output Method: the indent and suppress-indentation Parameters](https://www.w3.org/TR/xslt-xquery-serialization-31/#HTML_INDENT)

This fix overrides MarkupSerializer.indent in HTMLSerializer and XHTMLSerializer, in order to suppress indentation when a formatted element is on the path. According to the serialization spec, formatted elements are `pre`, `script`, `style`, `title`, and `textarea`.