### PR TITLE
Suppress indentation adjacent to (X)HTML inline elements

### DIFF
--- a/basex-core/src/main/java/org/basex/io/serial/HTMLSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/HTMLSerializer.java
@@ -23,6 +23,8 @@ final class HTMLSerializer extends MarkupSerializer {
   static final TokenSet EMPTIES5;
   /** (X)HTML: formatted elements. */
   static final TokenSet FORMATTEDS;
+  /** (X)HTML: inline elements. */
+  static final TokenSet INLINES;
   /** (X)HTML: URI attributes. */
   static final TokenSet URIS;
 
@@ -56,6 +58,14 @@ final class HTMLSerializer extends MarkupSerializer {
         "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr");
     // formatted elements
     FORMATTEDS = new TokenSet("pre", "script", "style", "textarea", "title");
+    // inline elements
+    INLINES = new TokenSet("a", "abbr", "acronym", "applet", "area", "audio", "b", "basefont",
+        "bdi", "bdo", "big", "br", "button", "canvas", "cite", "code", "data", "datalist", "del",
+        "dfn", "em", "embed", "font", "i", "iframe", "img", "input", "ins", "kbd", "label", "link",
+        "map", "mark", "math", "meta", "meter", "noscript", "object", "output", "picture",
+        "progress", "q", "ruby", "s", "samp", "script", "select", "slot", "small", "span", "strike",
+        "strong", "sub", "sup", "svg", "template", "textarea", "time", "tt", "u", "var", "video",
+        "wbr");
     // URI attributes
     URIS = new TokenSet("a@href", "a@name", "applet@codebase", "area@href",
         "base@href", "blockquote@cite", "body@background", "button@datasrc", "del@cite",
@@ -182,6 +192,13 @@ final class HTMLSerializer extends MarkupSerializer {
     } else if(html5) {
       printDoctype(type, null, null);
     }
+  }
+
+  @Override
+  boolean inline() {
+    return INLINES.contains(lc(closed.local())) ||
+        opening && INLINES.contains(lc(elem.local())) ||
+        super.inline();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/io/serial/MarkupSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/MarkupSerializer.java
@@ -328,6 +328,7 @@ abstract class MarkupSerializer extends StandardSerializer {
     if(atomic) {
       atomic = false;
     } else if(indent) {
+      if (inline()) return;
       for(final QNm qname : opened) {
         if(suppressIndentation(qname)) return;
       }
@@ -404,6 +405,15 @@ abstract class MarkupSerializer extends StandardSerializer {
       cdata = list;
     }
     return list;
+  }
+
+  /**
+   * Checks if the next element should be rendered inline with its context, i.e.
+   * without indentation adjacent to it.
+   * @return result of check
+   */
+  boolean inline() {
+    return false;
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/io/serial/Serializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/Serializer.java
@@ -36,6 +36,8 @@ public abstract class Serializer implements Closeable {
   protected int level;
   /** Current element name. */
   protected QNm elem;
+  /** Most recent tag, in case it was a closing tag. */
+  protected QNm closed = QNm.EMPTY;
   /** Indentation flag. */
   protected boolean indent;
 
@@ -51,7 +53,7 @@ public abstract class Serializer implements Closeable {
   /** Flag for skipping elements. */
   protected int skip;
   /** Indicates if an element is currently being opened. */
-  private boolean opening;
+  protected boolean opening;
 
   /**
    * Returns a default serializer.
@@ -172,6 +174,7 @@ public abstract class Serializer implements Closeable {
     opening = true;
     elem = name;
     startOpen(name);
+    closed = QNm.EMPTY;
     nstack.push(nspaces.size());
   }
 
@@ -188,7 +191,7 @@ public abstract class Serializer implements Closeable {
       elem = opened.peek();
       level--;
       finishClose();
-      opened.pop();
+      closed = opened.pop();
     }
   }
 

--- a/basex-core/src/main/java/org/basex/io/serial/XHTMLSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/XHTMLSerializer.java
@@ -7,6 +7,7 @@ import java.io.*;
 
 import org.basex.query.*;
 import org.basex.query.value.item.*;
+import org.basex.util.hash.*;
 
 /**
  * This class serializes items as XHTML.
@@ -73,10 +74,26 @@ final class XHTMLSerializer extends MarkupSerializer {
   }
 
   @Override
+  boolean inline() {
+    return contains(HTMLSerializer.INLINES, closed) ||
+        opening && contains(HTMLSerializer.INLINES, elem) ||
+        super.inline();
+  }
+
+  @Override
   boolean suppressIndentation(final QNm qname) throws QueryIOException {
-    final byte[] uri = qname.uri(), local = qname.local();
-    return eq(uri, XHTML_URI) && HTMLSerializer.FORMATTEDS.contains(local) ||
-        html5 && eq(uri, EMPTY) && HTMLSerializer.FORMATTEDS.contains(lc(local)) ||
-        super.suppressIndentation(qname);
+    return contains(HTMLSerializer.FORMATTEDS, qname) || super.suppressIndentation(qname);
+  }
+
+  /**
+   * Checks whether the tokenset contains the specified element
+   * @param elements the tokenset of element local names
+   * @param element the element QName
+   * @return true, if the element is contained in the tokenset.
+   */
+  private boolean contains(TokenSet elements, final QNm element) {
+    final byte[] uri = element.uri(), local = element.local();
+    return eq(uri, XHTML_URI) && elements.contains(local) ||
+        html5 && eq(uri, EMPTY) && elements.contains(lc(local));
   }
 }

--- a/basex-core/src/test/java/org/basex/query/SerializerTest.java
+++ b/basex-core/src/test/java/org/basex/query/SerializerTest.java
@@ -46,6 +46,16 @@ public final class SerializerTest extends SandboxTest {
         + "<PRE><u>test</u></PRE>\n"
         + "</body>\n"
         + "</html>");
+    query(option + INDENT.arg("yes") + HTML_VERSION.arg("5.0")
+        + "<html><body><a name='x'>x</a><p><hr/></p><a><hr/></a></body></html>",
+        "<!DOCTYPE html>\n"
+        + "<html>\n"
+        + "<body><a name=\"x\">x</a><p>\n"
+        + "<hr/>\n"
+        + "</p><a>\n"
+        + "<hr/>\n"
+        + "</a></body>\n"
+        + "</html>");
   }
 
   /** method=xhtml, meta element. */
@@ -92,6 +102,18 @@ public final class SerializerTest extends SandboxTest {
         + "<html>\n"
         + "<body>\n"
         + "<PRE><u>test</u></PRE>\n"
+        + "</body>\n"
+        + "</html>");
+    query(option + INDENT.arg("yes") + HTML_VERSION.arg("5.0")
+        + "<html><body><p><b>x</b><ul><li>1</li><li>2</li></ul></p></body></html>",
+        "<!DOCTYPE html>\n"
+        + "<html>\n"
+        + "<body>\n"
+        + "<p><b>x</b><ul>\n"
+        + "<li>1</li>\n"
+        + "<li>2</li>\n"
+        + "</ul>\n"
+        + "</p>\n"
         + "</body>\n"
         + "</html>");
   }


### PR DESCRIPTION
More unwanted whitespace was found using (X)HTML serialization with `indent=yes`. An example of this is

```xml
<html><style type="text/css"><!--
body {font-size: 48px}
a {background: #CCC}
--></style><body><p><a name="x"><b>X</b></a> <a name="y"><b>X</b></a></p></body></html>
```
As is, browsers show it as

![image](https://user-images.githubusercontent.com/24464731/218494517-b6c07bf2-d0ac-4815-8fad-2889789d86da.png)

But when serialized with `method=html` and `indent=yes`, it becomes

```html
<html>
  <style type="text/css">
    <!--
body {font-size: 48px}
a {background: #CCC}
-->
  </style>
  <body>
    <p>
      <a name="x">
        <b>X</b>
      </a>
      <a name="y">
        <b>X</b>
      </a>
    </p>
  </body>
</html>
```

and browsers show it as

![image](https://user-images.githubusercontent.com/24464731/218494642-f2eb1213-29ce-47f8-a217-4ff07bf0bbcc.png)

The difference in this case is caused by the indentation whitespace that was added between the closing tags for `b` and `a`. According to the serialization spec, that whitespace should not be there, because `a` and `b` are "inline" elements - see

* [6.1.4 XHTML Output Method: the indent and suppress-indentation Parameters](https://www.w3.org/TR/xslt-xquery-serialization-31/#XHTML_INDENT) 
* [7.4.3 HTML Output Method: the indent and suppress-indentation Parameters](https://www.w3.org/TR/xslt-xquery-serialization-31/#HTML_INDENT)

This fix keeps track of the most recent tag, in case it is a closing tag. When adding indentation, that and a following opening tag are checked for being inline elements. In case either of them is, the whitespace is suppressed.

As the spec suggests, the list of inline elements is taken from HTML and XHTML DTDs, and from HTML 5. Different lists could be used for HTML and XHTML, and in contrast to the implementation here, `ins` and `del` could additionally be checked for child elements before suppressing the whitespace. However for the sake of simplicity, I thought it is acceptable to use a single list and omit those extra checks. This would in the worst case add slightly less indentation whitespace than could be.