### PR TITLE
Do not add indentation whitespace following empty (X)HTML inline elements

### DIFF
--- a/basex-core/src/main/java/org/basex/io/serial/Serializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/Serializer.java
@@ -187,6 +187,7 @@ public abstract class Serializer implements Closeable {
     if(opening) {
       finishEmpty();
       opening = false;
+      closed = elem;
     } else {
       elem = opened.peek();
       level--;

--- a/basex-core/src/test/java/org/basex/query/SerializerTest.java
+++ b/basex-core/src/test/java/org/basex/query/SerializerTest.java
@@ -47,14 +47,14 @@ public final class SerializerTest extends SandboxTest {
         + "</body>\n"
         + "</html>");
     query(option + INDENT.arg("yes") + HTML_VERSION.arg("5.0")
-        + "<html><body><a name='x'>x</a><p><hr/></p><a><hr/></a></body></html>",
+        + "<html><body><a name='x'>x</a><p><hr/></p><a><hr/></a><br/></body></html>",
         "<!DOCTYPE html>\n"
         + "<html>\n"
         + "<body><a name=\"x\">x</a><p>\n"
         + "<hr/>\n"
         + "</p><a>\n"
         + "<hr/>\n"
-        + "</a></body>\n"
+        + "</a><br/></body>\n"
         + "</html>");
   }
 
@@ -105,7 +105,7 @@ public final class SerializerTest extends SandboxTest {
         + "</body>\n"
         + "</html>");
     query(option + INDENT.arg("yes") + HTML_VERSION.arg("5.0")
-        + "<html><body><p><b>x</b><ul><li>1</li><li>2</li></ul></p></body></html>",
+        + "<html><body><p><b>x</b><ul><li>1</li><li>2</li></ul></p><br/></body></html>",
         "<!DOCTYPE html>\n"
         + "<html>\n"
         + "<body>\n"
@@ -113,8 +113,7 @@ public final class SerializerTest extends SandboxTest {
         + "<li>1</li>\n"
         + "<li>2</li>\n"
         + "</ul>\n"
-        + "</p>\n"
-        + "</body>\n"
+        + "</p><br></body>\n"
         + "</html>");
   }
 


### PR DESCRIPTION
After the recent changes of (X)HTML serialization for #2171, concerning inline elements, excess indentation whitespace could still be added following an empty tag of an inline element. This was caused by the empty tag not being remembered as the last closed tag.

This fix corrects the setting of `Serializer.closed` to that respect, and it extends HTML and XTHML serialization tests accordingly.