### PR TITLE
Add serialization option 'indent-attributes'

### DIFF
--- a/basex-core/src/main/java/org/basex/io/out/EncoderOutput.java
+++ b/basex-core/src/main/java/org/basex/io/out/EncoderOutput.java
@@ -46,6 +46,7 @@ public final class EncoderOutput extends PrintOutput {
       Util.debug(ex);
       throw SERENC_X_X.getIO(Integer.toHexString(ch), encoding);
     }
+    lineLength = ch == '\n' ? 0 : lineLength + 1;
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/io/out/NewlineOutput.java
+++ b/basex-core/src/main/java/org/basex/io/out/NewlineOutput.java
@@ -29,8 +29,10 @@ public final class NewlineOutput extends PrintOutput {
   public void print(final int cp) throws IOException {
     if(cp == '\n') {
       for(final byte b : newline) po.print(b);
+      lineLength = 0;
     } else {
       po.print(cp);
+      ++lineLength;
     }
   }
 

--- a/basex-core/src/main/java/org/basex/io/out/PrintOutput.java
+++ b/basex-core/src/main/java/org/basex/io/out/PrintOutput.java
@@ -19,6 +19,8 @@ public class PrintOutput extends OutputStream {
   protected long max = Long.MAX_VALUE;
   /** Number of bytes written. */
   protected long size;
+  /** Number of codepoints in the current line. */
+  protected long lineLength;
 
   /**
    * Constructor, given a filename.
@@ -64,13 +66,14 @@ public class PrintOutput extends OutputStream {
   }
 
   /**
-   * Prints a single codepoint.
+   * Prints a single codepoint, and keeps track of the current line length.
    * @param cp codepoint to be printed
    * @throws IOException I/O exception
    */
   public void print(final int cp) throws IOException {
     if(cp <= 0x7F) {
       write(cp);
+      lineLength = cp == '\n' ? 0 : lineLength + 1;
     } else {
       if(cp <= 0x7FF) {
         write(cp >>  6 & 0x1F | 0xC0);
@@ -84,6 +87,7 @@ public class PrintOutput extends OutputStream {
         write(cp >>  6 & 0x3F | 0x80);
       }
       write(cp & 0x3F | 0x80);
+      ++lineLength;
     }
   }
 
@@ -132,6 +136,14 @@ public class PrintOutput extends OutputStream {
    */
   public final long size() {
     return size;
+  }
+
+  /**
+   * Returns the length of the current line in codepoints.
+   * @return the number of codepoints in the current line
+   */
+  public long lineLength() {
+    return lineLength;
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/io/serial/HTMLSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/HTMLSerializer.java
@@ -90,7 +90,7 @@ final class HTMLSerializer extends MarkupSerializer {
   protected void attribute(final byte[] name, final byte[] value, final boolean standalone)
       throws IOException {
 
-    if(!standalone) out.print(' ');
+    if(!standalone) delimitAttribute();
     out.print(name);
 
     // don't append value for boolean attributes
@@ -152,6 +152,7 @@ final class HTMLSerializer extends MarkupSerializer {
     if(sep) indent();
     out.print(ELEM_O);
     out.print(name.string());
+    indAttrLength = out.lineLength();
     sep = indent;
     script = SCRIPTS.contains(lc(name.local()));
     if(content && eq(lc(elem.local()), HEAD)) skip++;

--- a/basex-core/src/main/java/org/basex/io/serial/MarkupSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/MarkupSerializer.java
@@ -51,6 +51,10 @@ abstract class MarkupSerializer extends StandardSerializer {
   private QNmSet suppress;
   /** Media type. */
   private final String media;
+  /** Indent attributes. */
+  private final boolean indAttr;
+  /** Attribute indentation length. */
+  protected long indAttrLength;
 
   /**
    * Constructor.
@@ -79,6 +83,7 @@ abstract class MarkupSerializer extends StandardSerializer {
     escuri  = sopts.yes(ESCAPE_URI_ATTRIBUTES);
     content = sopts.yes(INCLUDE_CONTENT_TYPE);
     undecl  = sopts.yes(UNDECLARE_PREFIXES);
+    indAttr = sopts.yes(INDENT_ATTRIBUTES);
 
     if(docsys.isEmpty()) docsys = null;
     if(docpub.isEmpty()) docpub = null;
@@ -129,7 +134,7 @@ abstract class MarkupSerializer extends StandardSerializer {
   protected void attribute(final byte[] name, final byte[] value, final boolean standalone)
       throws IOException {
 
-    if(!standalone) out.print(' ');
+    if(!standalone) delimitAttribute();
     out.print(name);
     out.print(ATT1);
     final byte[] val = normalize(value, form);
@@ -145,6 +150,20 @@ abstract class MarkupSerializer extends StandardSerializer {
       }
     }
     out.print(ATT2);
+  }
+
+  /**
+   * Print the delimiter preceding an attribute inside of an opening or empty
+   * tag. This is attribute indentation, if enabled, for all but the first
+   * attribute, but at least a single space.
+   * @throws IOException I/O exception
+   */
+  protected void delimitAttribute() throws IOException {
+    if (indAttr && out.lineLength() > indAttrLength) {
+      out.print('\n');
+      for (int i = 0; i < indAttrLength; ++i) out.print(' ');
+    }
+    out.print(' ');
   }
 
   @Override
@@ -220,6 +239,7 @@ abstract class MarkupSerializer extends StandardSerializer {
     if(sep) indent();
     out.print(ELEM_O);
     out.print(name.string());
+    indAttrLength = out.lineLength();
     sep = true;
   }
 

--- a/basex-core/src/main/java/org/basex/io/serial/SerializerOptions.java
+++ b/basex-core/src/main/java/org/basex/io/serial/SerializerOptions.java
@@ -116,6 +116,9 @@ public final class SerializerOptions extends Options {
   /** Specific serialization parameter: binary serialization. */
   public static final EnumOption<YesNo> BINARY =
       new EnumOption<>("binary", YesNo.YES);
+  /** Specific serialization parameter: attribute indentation. */
+  public static final EnumOption<YesNo> INDENT_ATTRIBUTES =
+      new EnumOption<>("indent-attributes", YesNo.NO);
 
   /** Newlines. */
   public enum Newline {

--- a/basex-core/src/test/java/org/basex/query/SerializerTest.java
+++ b/basex-core/src/test/java/org/basex/query/SerializerTest.java
@@ -19,6 +19,10 @@ public final class SerializerTest extends SandboxTest {
   /** Test: method=xml. */
   @Test public void xml() {
     query(METHOD.arg("xml") + "<html/>", "<html/>");
+    query(METHOD.arg("xml") + INDENT_ATTRIBUTES.arg("yes") + "<x a='1' b='2' c='3'/>",
+        "<x a=\"1\"\n"
+        + "b=\"2\"\n"
+        + "c=\"3\"/>");
   }
 
   /** Test: method=xhtml. */
@@ -55,6 +59,24 @@ public final class SerializerTest extends SandboxTest {
         + "</p><a>\n"
         + "<hr/>\n"
         + "</a></body>\n"
+        + "</html>");
+    query(option + MEDIA_TYPE.arg("application/xhtml+xml")
+        + INDENT.arg("yes")
+        + INDENT_ATTRIBUTES.arg("yes")
+        + "<html xmlns='http://www.w3.org/1999/xhtml' xmlns:svg='http://www.w3.org/2000/svg'>"
+        + "<head/><body><div id='a' name='b' class='c' style='width: 42px'/></body></html>",
+        "<html xmlns:svg=\"http://www.w3.org/2000/svg\"\n"
+        + "xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+        + "<head>\n"
+        + "<meta http-equiv=\"Content-Type\"\n"
+        + "content=\"application/xhtml+xml; charset=UTF-8\" />\n"
+        + "</head>\n"
+        + "<body>\n"
+        + "<div id=\"a\"\n"
+        + "name=\"b\"\n"
+        + "class=\"c\"\n"
+        + "style=\"width: 42px\"></div>\n"
+        + "</body>\n"
         + "</html>");
   }
 
@@ -116,6 +138,10 @@ public final class SerializerTest extends SandboxTest {
         + "</p>\n"
         + "</body>\n"
         + "</html>");
+    query(option + INDENT_ATTRIBUTES.arg("yes")
+        + "<html><body onload='alert(\"loaded\")' style='background: black'/></html>",
+        "<html><body onload=\"alert(&quot;loaded&quot;)\"\n"
+        + "style=\"background: black\"></body></html>");
   }
 
   /** Test: method=html, version=5.0. */


### PR DESCRIPTION
Here are the changes that implement #2174. A new serialization option is added to control indentation of attributes. The option name and the new layout are the same as in [HTML Tidy](https://api.html-tidy.org/tidy/quickref_5.8.0.html#indent-attributes):
- the name is `indent-attributes`, with a default value of `no`.
- the layout that is achieved by `indent-attributes=yes` puts the first attribute following the element name on the same line, while every subsequent attribute starts a new line, indented to align with the first attribute.

The order of attributes is unchanged. `indent-attributes` is ignored when processing serialization methods other than `xml`, `xhtml`, or `html`. It may not make much sense to use this option without using `indent=yes` as well, but the implementation here does neither enforce nor require that.

The following has been changed:

- the new option is added as `SerializerOptions.INDENT_ATTRIBUTES` for	 parameter `indent-attributes` with default value `no`.
- a new member `Printoutput.lineLength` keeps track of the length of the current line in codepoints.
- maintaining `lineLength` is an additional task for `PrintOutput.print(int cp)`. This must be done in `PrintOutput`, as well as in subclasses `EncoderOutput` and `NewlineOutput`.
- `MarkupSerializer.startOpen` now remembers the current line length, after printing the element name, in new member `indAttrLength`. Again, this must also be done in subclasses.
- the whitespace preceding an attribute is now printed in `MarkupSerializer.delimitAttribute`, and any indentation whitespace is added there, if asked for by the new option, plus the remembered line length has already increased, i.e. we are working on an attribute beyond the first one.

If this PR should be accepted, the documentation must be adapted, at least in these two locations:

- [https://docs.basex.org/wiki/Serialization#Custom_Parameters](https://docs.basex.org/wiki/Serialization#Custom_Parameters)
- [https://docs.basex.org/wiki/Serialization#Changelog](https://docs.basex.org/wiki/Serialization#Changelog)