### PR TITLE
Make fn:invisible-xml independent of default encoding

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/FnInvisibleXml.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnInvisibleXml.java
@@ -4,6 +4,7 @@ import static org.basex.query.QueryError.*;
 import static org.basex.query.value.type.SeqType.*;
 
 import java.io.*;
+import java.nio.charset.*;
 import java.util.*;
 
 import org.basex.io.*;
@@ -107,8 +108,17 @@ public final class FnInvisibleXml extends StandardFunc {
         throw IXML_INP_X_X_X.get(ii, result.getLastToken(), doc.getLineNumber(),
             doc.getColumnNumber());
       }
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      PrintStream stream;
       try {
-        return new DBNode(IO.get(doc.getTree()));
+        stream = new PrintStream(baos, false, StandardCharsets.UTF_8.name());
+      } catch (UnsupportedEncodingException ex) {
+        throw Util.notExpected(ex);
+      }
+      doc.getTree(stream);
+      String tree = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+      try {
+        return new DBNode(IO.get(tree));
       } catch(final IOException | IxmlException ex) {
         throw IXML_RESULT_X.get(ii, ex);
       }


### PR DESCRIPTION
`fn:invisible-xml` is dependent on the JVM's default encoding. This can be seen by running the following on Windows,

```sh
chcp 65001
java -Dfile.encoding=utf-8        org.basex.BaseX "invisible-xml('s: +#10D.')('')"
java -Dfile.encoding=windows-1252 org.basex.BaseX "invisible-xml('s: +#10D.')('')"
```

The first invocation correctly returns

```xml
<s>č</s>
```
while the second one comes up with

```xml
<s>?</s>
```
This is caused by a dependency of the default encoding in `org.nineml.coffeefilter.trees.StringTreeBuilder`. I have opened nineml/coffeefilter#82 for resolving it. Until it has been processed, this change provides a workaround.