### PR TITLE
Move getTree invocation back into try block

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/FnInvisibleXml.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnInvisibleXml.java
@@ -110,8 +110,8 @@ public final class FnInvisibleXml extends StandardFunc {
             doc.getColumnNumber());
       }
       final ArrayOutput ao = new ArrayOutput();
-      doc.getTree(new PrintStream(ao, false, StandardCharsets.UTF_8));
       try {
+        doc.getTree(new PrintStream(ao, false, StandardCharsets.UTF_8));
         return new DBNode(new IOContent(ao.finish()));
       } catch(final IOException | IxmlException ex) {
         throw IXML_RESULT_X.get(ii, ex);


### PR DESCRIPTION
Sorry, my fault. The invocation of `getTree` had left the `try` block, but it must stay in there to have `IxmlException` caught and handled with `IXML_RESULT_X`. Obviously I had not run the tests...