### PR TITLE
Fix end-of-line handling of fn:invisible-xml

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/FnInvisibleXml.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnInvisibleXml.java
@@ -108,7 +108,7 @@ public final class FnInvisibleXml extends StandardFunc {
         throw IXML_INP_X_X_X.get(ii, result.getLastToken(), doc.getLineNumber(),
             doc.getColumnNumber());
       }
-      final MemBuilder builder = new MemBuilder(null, new Parser("", new MainOptions()) {
+      final MemBuilder builder = new MemBuilder("", new Parser((String) null, new MainOptions()) {
         @Override
         public void parse(final Builder build) {
           throw Util.notExpected();

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnInvisibleXml.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnInvisibleXml.java
@@ -3,12 +3,11 @@ package org.basex.query.func.fn;
 import static org.basex.query.QueryError.*;
 import static org.basex.query.value.type.SeqType.*;
 
-import java.io.*;
-import java.nio.charset.*;
 import java.util.*;
 
-import org.basex.io.*;
-import org.basex.io.out.*;
+import org.basex.build.*;
+import org.basex.build.xml.*;
+import org.basex.core.*;
 import org.basex.query.*;
 import org.basex.query.expr.*;
 import org.basex.query.func.*;
@@ -109,11 +108,17 @@ public final class FnInvisibleXml extends StandardFunc {
         throw IXML_INP_X_X_X.get(ii, result.getLastToken(), doc.getLineNumber(),
             doc.getColumnNumber());
       }
-      final ArrayOutput ao = new ArrayOutput();
+      final MemBuilder builder = new MemBuilder(null, new Parser("", new MainOptions()) {
+        @Override
+        public void parse(final Builder build) {
+          throw Util.notExpected();
+        }
+      });
+      builder.init();
       try {
-        doc.getTree(new PrintStream(ao, false, StandardCharsets.UTF_8));
-        return new DBNode(new IOContent(ao.finish()));
-      } catch(final IOException | IxmlException ex) {
+        doc.getTree(new SAXHandler(builder, false, false));
+        return new DBNode(builder.data());
+      } catch(final IxmlException ex) {
         throw IXML_RESULT_X.get(ii, ex);
       }
     }

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -856,6 +856,11 @@ public final class FnModuleTest extends QueryPlanTest {
         + "   \"(\", e, \")\".") + "('2*3+4')",
           "<e xmlns:ixml=\"http://invisiblexml.org/NS\" ixml:state=\"ambiguous\">"
         + "<e><e><f>2</f></e>*<e><f>3</f></e></e>+<e><f>4</f></e></e>");
+    // input with cr+lf
+    query("string-to-codepoints("
+        + func.args("s: ~[]*.")
+        + "(codepoints-to-string((9,13,10,9,10,13,9,10,9,13,9))))",
+        "9\n13\n10\n9\n10\n13\n9\n10\n9\n13\n9");
     // invalid grammar
     error(func.args("?%$"), IXML_GRM_X_X_X);
     // parser generation failure


### PR DESCRIPTION
`fn:invisible-xml` does not correctly handle carriage-return characters, they either disappear from the result or they are replaced by line-feed characters. This is caused by the implementation sending the result through XML serialization and parsing, where serialization (done by `InvisibleXmlDocument.getTree`) generates plain carriage-return characters and parsing has to normalize line endings to a single line-feed.

This fix replaces serialization and parsing by using a `ContentHandler` that directly builds the result tree.