### PR TITLE
Allow opaque URLs for jar: only (fixes BaseXdb/basex#2228)

### DIFF
--- a/basex-core/src/main/java/org/basex/io/IOUrl.java
+++ b/basex-core/src/main/java/org/basex/io/IOUrl.java
@@ -199,6 +199,7 @@ public final class IOUrl extends IO {
     final int ul = url.length();
     int u = url.indexOf(':');
     if(u < 2 || u + 1 == ul) return false;
+    if(!isJarURL(url) && url.charAt(u + 1) != '/') return false;
     while(--u >= 0) {
       final char c = url.charAt(u);
       if(!(c >= 'a' && c <= 'z' || c == '+' || c == '-' || c == '.' || c == '_')) return false;


### PR DESCRIPTION
The requirement of a slash following the URL scheme had been dropped for all URLs in 1e14f79 in order to allow `jar:` urls occurring when the code is packaged as a fat jar. This change reinstalls the previous state, except for `jar:` urls, which are still allowed without a slash.