### PR TITLE
Fixes for failing regex tests (fixes #2240)

### DIFF
--- a/basex-core/src/main/java/org/basex/query/util/regex/BackRef.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/BackRef.java
@@ -9,17 +9,21 @@ package org.basex.query.util.regex;
 public final class BackRef extends RegExp {
   /** Capture group number. */
   private final int num;
+  /** Flags reference to group in different branch. If true, backref must not be serialized. */
+  private final boolean isDifferentBranch;
 
   /**
    * Constructor.
    * @param num capture group number
+   * @param isDifferentBranch the different-branch flag
    */
-  public BackRef(final int num) {
+  public BackRef(final int num, final boolean isDifferentBranch) {
     this.num = num;
+    this.isDifferentBranch = isDifferentBranch;
   }
 
   @Override
   void toRegEx(final StringBuilder sb) {
-    sb.append('\\').append(num);
+    if (!isDifferentBranch) sb.append('\\').append(num);
   }
 }

--- a/basex-core/src/main/java/org/basex/query/util/regex/Group.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/Group.java
@@ -11,6 +11,8 @@ public final class Group extends RegExp {
   private final RegExp encl;
   /** Capture flag. */
   private final boolean capture;
+  /** Back-reference flag. */
+  private boolean hasBackRef;
 
   /**
    * Constructor.
@@ -20,6 +22,30 @@ public final class Group extends RegExp {
   public Group(final RegExp encl, final boolean capture) {
     this.encl = encl;
     this.capture = capture;
+    this.hasBackRef = false;
+  }
+
+  /**
+   * Return the enclosed expression.
+   * @return the expression.
+   */
+  public RegExp getEncl() {
+    return encl;
+  }
+
+  /**
+   * Set the back-reference flag.
+   */
+  public void setHasBackRef() {
+    this.hasBackRef = true;
+  }
+
+  /**
+   * Get the back-reference flag.
+   * @return the flag value.
+   */
+  public boolean hasBackRef() {
+    return hasBackRef;
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/util/regex/Group.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/Group.java
@@ -13,16 +13,20 @@ public final class Group extends RegExp {
   private final boolean capture;
   /** Back-reference flag. */
   private boolean hasBackRef;
+  /** Atom path of this group: sequence numbers of ancestor branches and atoms. */
+  private final Integer[] atomPath;
 
   /**
    * Constructor.
    * @param encl enclosed expression
    * @param capture capture flag
+   * @param atomPath atom path of this group
    */
-  public Group(final RegExp encl, final boolean capture) {
+  public Group(final RegExp encl, final boolean capture, final Integer[] atomPath) {
     this.encl = encl;
     this.capture = capture;
     this.hasBackRef = false;
+    this.atomPath = atomPath;
   }
 
   /**
@@ -46,6 +50,14 @@ public final class Group extends RegExp {
    */
   public boolean hasBackRef() {
     return hasBackRef;
+  }
+
+  /**
+   * Get the atom path of this group.
+   * @return the atom path.
+   */
+  public Integer[] getAtomPath() {
+    return atomPath;
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/util/regex/Piece.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/Piece.java
@@ -24,7 +24,18 @@ public final class Piece extends RegExp {
 
   @Override
   void toRegEx(final StringBuilder sb) {
-    atom.toRegEx(sb);
-    quant.toRegEx(sb);
+    if (quant.getMin() == 0 && atom instanceof Group && ((Group) atom).hasBackRef()) {
+      // #2240: replace an optional capturing group by a mandatory one, and wrap its content
+      // into an optional non-capturing group
+      sb.append("((?:");
+      ((Group) atom).getEncl().toRegEx(sb);
+      sb.append(')');
+      quant.toRegEx(sb);
+      sb.append(')');
+    }
+    else {
+      atom.toRegEx(sb);
+      quant.toRegEx(sb);
+    }
   }
 }

--- a/basex-core/src/main/java/org/basex/query/util/regex/Quantifier.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/Quantifier.java
@@ -26,6 +26,14 @@ public final class Quantifier extends RegExp {
     this.lazy = lazy;
   }
 
+  /**
+   * Get minimum number of occurences.
+   * @return the minimum.
+   */
+  public int getMin() {
+    return min;
+  }
+
   @Override
   void toRegEx(final StringBuilder sb) {
     sb.append(string()).append(lazy ? "?" : "");

--- a/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParser.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParser.java
@@ -4,6 +4,7 @@ package org.basex.query.util.regex.parse;
 
 import static org.basex.query.QueryError.*;
 
+import java.util.*;
 import java.util.regex.*;
 
 import org.basex.query.*;
@@ -22,10 +23,8 @@ import static java.util.regex.Pattern.*;
 public class RegExParser implements RegExParserConstants {
   /** Group counter. */
   private int groups;
-  /** Current backref's number. */
-  private int backref;
   /** Closed groups. */
-  private final BitArray closed = new BitArray();
+  private final Map<Integer, Group> closed = new HashMap<Integer, Group>();
   /** If the wildcard {@code .} matches any character. */
   private boolean dotAll;
   /** Multi-line matching mode, {@code ^} and {@code $} match on line bounds. */
@@ -270,8 +269,9 @@ nd = new Group(nd, false);
 final int grp = ++groups;
       nd = regExp();
       jj_consume_token(PAR_CLOSE);
-closed.set(grp);
-        nd = new Group(nd, true);
+final Group g = new Group(nd, true);
+        closed.put(grp, g);
+        nd = g;
       break;
       }
     case BACK_REF:{
@@ -316,8 +316,8 @@ closed.set(grp);
    * @return expression
    * @throws ParseException parsing exception
    */
-  final public   BackRef backReference() throws ParseException {Token tok;
-    tok = jj_consume_token(BACK_REF);
+  final public   BackRef backReference() throws ParseException {int backref;
+    jj_consume_token(BACK_REF);
 backref = token.image.charAt(1) - '0';
     label_3:
     while (true) {
@@ -329,8 +329,10 @@ backref = token.image.charAt(1) - '0';
       jj_consume_token(DIGIT);
 backref = 10 * backref + token.image.charAt(0) - '0';
     }
-if(!closed.get(backref))
+final Group g = closed.get(backref);
+      if(g == null)
         {if (true) throw new ParseException("Illegal back-reference: \\" + backref);}
+      g.setHasBackRef();
       {if ("" != null) return new BackRef(backref);}
     throw new Error("Missing return statement in function");
 }
@@ -615,11 +617,11 @@ cp = Escape.getCp(token.image);
 
   private boolean jj_3_2()
  {
-    if (jj_3R_posCharGroup_301_5_5()) return true;
+    if (jj_3R_posCharGroup_303_5_5()) return true;
     return false;
   }
 
-  private boolean jj_3R_XmlChar_353_5_11()
+  private boolean jj_3R_XmlChar_355_5_11()
  {
     Token xsp;
     xsp = jj_scanpos;
@@ -630,7 +632,7 @@ cp = Escape.getCp(token.image);
     return false;
   }
 
-  private boolean jj_3R_posCharGroup_302_7_7()
+  private boolean jj_3R_posCharGroup_304_7_7()
  {
     Token xsp;
     xsp = jj_scanpos;
@@ -646,7 +648,7 @@ cp = Escape.getCp(token.image);
 
   private boolean jj_3_3()
  {
-    if (jj_3R_charRange_318_5_6()) return true;
+    if (jj_3R_charRange_320_5_6()) return true;
     return false;
   }
 
@@ -656,18 +658,18 @@ cp = Escape.getCp(token.image);
     xsp = jj_scanpos;
     if (jj_3_3()) {
     jj_scanpos = xsp;
-    if (jj_3R_posCharGroup_302_7_7()) return true;
+    if (jj_3R_posCharGroup_304_7_7()) return true;
     }
     return false;
   }
 
-  private boolean jj_3R_charRange_323_7_9()
+  private boolean jj_3R_charRange_325_7_9()
  {
-    if (jj_3R_XmlChar_353_5_11()) return true;
+    if (jj_3R_XmlChar_355_5_11()) return true;
     return false;
   }
 
-  private boolean jj_3R_posCharGroup_301_5_5()
+  private boolean jj_3R_posCharGroup_303_5_5()
  {
     Token xsp;
     if (jj_3_4()) return true;
@@ -678,54 +680,54 @@ cp = Escape.getCp(token.image);
     return false;
   }
 
-  private boolean jj_3R_charOrEsc_341_7_13()
+  private boolean jj_3R_charOrEsc_343_7_13()
  {
     if (jj_scan_token(SINGLE_ESC)) return true;
     return false;
   }
 
-  private boolean jj_3R_charRange_318_7_8()
+  private boolean jj_3R_charRange_320_7_8()
  {
-    if (jj_3R_charOrEsc_340_5_10()) return true;
+    if (jj_3R_charOrEsc_342_5_10()) return true;
     if (jj_scan_token(CHAR)) return true;
-    if (jj_3R_charOrEsc_340_5_10()) return true;
+    if (jj_3R_charOrEsc_342_5_10()) return true;
     return false;
   }
 
-  private boolean jj_3R_charOrEsc_340_7_12()
+  private boolean jj_3R_charOrEsc_342_7_12()
  {
-    if (jj_3R_XmlChar_353_5_11()) return true;
+    if (jj_3R_XmlChar_355_5_11()) return true;
     return false;
   }
 
-  private boolean jj_3_1()
- {
-    if (jj_scan_token(DIGIT)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_charRange_318_5_6()
+  private boolean jj_3R_charRange_320_5_6()
  {
     Token xsp;
     xsp = jj_scanpos;
     jj_lookingAhead = true;
     jj_semLA = getToken(2).kind == CHAR && "-".equals(getToken(2).image) && getToken(3).kind != BR_CLOSE;
     jj_lookingAhead = false;
-    if (!jj_semLA || jj_3R_charRange_318_7_8()) {
+    if (!jj_semLA || jj_3R_charRange_320_7_8()) {
     jj_scanpos = xsp;
-    if (jj_3R_charRange_323_7_9()) return true;
+    if (jj_3R_charRange_325_7_9()) return true;
     }
     return false;
   }
 
-  private boolean jj_3R_charOrEsc_340_5_10()
+  private boolean jj_3R_charOrEsc_342_5_10()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_charOrEsc_340_7_12()) {
+    if (jj_3R_charOrEsc_342_7_12()) {
     jj_scanpos = xsp;
-    if (jj_3R_charOrEsc_341_7_13()) return true;
+    if (jj_3R_charOrEsc_343_7_13()) return true;
     }
+    return false;
+  }
+
+  private boolean jj_3_1()
+ {
+    if (jj_scan_token(DIGIT)) return true;
     return false;
   }
 

--- a/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParser.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParser.java
@@ -25,6 +25,8 @@ public class RegExParser implements RegExParserConstants {
   private int groups;
   /** Closed groups. */
   private final Map<Integer, Group> closed = new HashMap<Integer, Group>();
+  /** Path of current atom: sequence numbers of branches and atoms currently being processed. */
+  private Stack<Integer> atomPath = new Stack<Integer>();
   /** If the wildcard {@code .} matches any character. */
   private boolean dotAll;
   /** Multi-line matching mode, {@code ^} and {@code $} match on line bounds. */
@@ -70,7 +72,10 @@ public class RegExParser implements RegExParserConstants {
    * @throws ParseException parsing exception
    */
   final public   RegExp regExp() throws ParseException {final RegExpList brs = new RegExpList();
-brs.add(branch());
+    RegExp br;
+    atomPath.push(0);
+    br = branch();
+brs.add(br);
     label_1:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -83,9 +88,12 @@ brs.add(branch());
         break label_1;
       }
       jj_consume_token(OR);
-brs.add(branch());
+atomPath.push(atomPath.pop() + 1);
+      br = branch();
+brs.add(br);
     }
-{if ("" != null) return brs.size() == 1 ? brs.get(0) : new Disjunction(brs.finish());}
+atomPath.pop();
+      {if ("" != null) return brs.size() == 1 ? brs.get(0) : new Disjunction(brs.finish());}
     throw new Error("Missing return statement in function");
 }
 
@@ -98,6 +106,7 @@ brs.add(branch());
   final public   RegExp branch() throws ParseException {RegExp atom;
     final RegExpList pieces = new RegExpList();
     Quantifier qu = null;
+    atomPath.push(0);
     label_2:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -135,8 +144,10 @@ brs.add(branch());
       }
 pieces.add(qu == null ? atom : new Piece(atom, qu));
         qu = null;
+        atomPath.push(atomPath.pop() + 1);
     }
-{if ("" != null) return pieces.size() == 1 ? pieces.get(0) : new Branch(pieces.finish());}
+atomPath.pop();
+      {if ("" != null) return pieces.size() == 1 ? pieces.get(0) : new Branch(pieces.finish());}
     throw new Error("Missing return statement in function");
 }
 
@@ -261,7 +272,7 @@ try {
       jj_consume_token(NPAR_OPEN);
       nd = regExp();
       jj_consume_token(PAR_CLOSE);
-nd = new Group(nd, false);
+nd = new Group(nd, false, atomPath.toArray(new Integer[atomPath.size()]));
       break;
       }
     case PAR_OPEN:{
@@ -269,7 +280,7 @@ nd = new Group(nd, false);
 final int grp = ++groups;
       nd = regExp();
       jj_consume_token(PAR_CLOSE);
-final Group g = new Group(nd, true);
+final Group g = new Group(nd, true, atomPath.toArray(new Integer[atomPath.size()]));
         closed.put(grp, g);
         nd = g;
       break;
@@ -333,7 +344,15 @@ final Group g = closed.get(backref);
       if(g == null)
         {if (true) throw new ParseException("Illegal back-reference: \\" + backref);}
       g.setHasBackRef();
-      {if ("" != null) return new BackRef(backref);}
+      int diff = 0;
+      while (atomPath.get(diff) == g.getAtomPath()[diff]) {
+        ++diff;
+      }
+      // If the atom paths of group and backref differ in a branch (even index), the backref is in
+      // a different branch than the group, so the backref can be flagged accordingly, and later be
+      // omitted at serialization time.
+      final boolean isDifferentBranch = (diff & 1) == 0;
+      {if ("" != null) return new BackRef(backref, isDifferentBranch);}
     throw new Error("Missing return statement in function");
 }
 
@@ -615,13 +634,64 @@ cp = Escape.getCp(token.image);
     finally { jj_save(3, xla); }
   }
 
-  private boolean jj_3_2()
+  private boolean jj_3R_charOrEsc_360_7_13()
  {
-    if (jj_3R_posCharGroup_303_5_5()) return true;
+    if (jj_scan_token(SINGLE_ESC)) return true;
     return false;
   }
 
-  private boolean jj_3R_XmlChar_355_5_11()
+  private boolean jj_3R_charRange_337_7_8()
+ {
+    if (jj_3R_charOrEsc_359_5_10()) return true;
+    if (jj_scan_token(CHAR)) return true;
+    if (jj_3R_charOrEsc_359_5_10()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_charOrEsc_359_7_12()
+ {
+    if (jj_3R_XmlChar_372_5_11()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_charRange_337_5_6()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    jj_lookingAhead = true;
+    jj_semLA = getToken(2).kind == CHAR && "-".equals(getToken(2).image) && getToken(3).kind != BR_CLOSE;
+    jj_lookingAhead = false;
+    if (!jj_semLA || jj_3R_charRange_337_7_8()) {
+    jj_scanpos = xsp;
+    if (jj_3R_charRange_342_7_9()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_charOrEsc_359_5_10()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_charOrEsc_359_7_12()) {
+    jj_scanpos = xsp;
+    if (jj_3R_charOrEsc_360_7_13()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3_2()
+ {
+    if (jj_3R_posCharGroup_320_5_5()) return true;
+    return false;
+  }
+
+  private boolean jj_3_1()
+ {
+    if (jj_scan_token(DIGIT)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_XmlChar_372_5_11()
  {
     Token xsp;
     xsp = jj_scanpos;
@@ -632,7 +702,7 @@ cp = Escape.getCp(token.image);
     return false;
   }
 
-  private boolean jj_3R_posCharGroup_304_7_7()
+  private boolean jj_3R_posCharGroup_321_7_7()
  {
     Token xsp;
     xsp = jj_scanpos;
@@ -648,7 +718,7 @@ cp = Escape.getCp(token.image);
 
   private boolean jj_3_3()
  {
-    if (jj_3R_charRange_320_5_6()) return true;
+    if (jj_3R_charRange_337_5_6()) return true;
     return false;
   }
 
@@ -658,18 +728,18 @@ cp = Escape.getCp(token.image);
     xsp = jj_scanpos;
     if (jj_3_3()) {
     jj_scanpos = xsp;
-    if (jj_3R_posCharGroup_304_7_7()) return true;
+    if (jj_3R_posCharGroup_321_7_7()) return true;
     }
     return false;
   }
 
-  private boolean jj_3R_charRange_325_7_9()
+  private boolean jj_3R_charRange_342_7_9()
  {
-    if (jj_3R_XmlChar_355_5_11()) return true;
+    if (jj_3R_XmlChar_372_5_11()) return true;
     return false;
   }
 
-  private boolean jj_3R_posCharGroup_303_5_5()
+  private boolean jj_3R_posCharGroup_320_5_5()
  {
     Token xsp;
     if (jj_3_4()) return true;
@@ -677,57 +747,6 @@ cp = Escape.getCp(token.image);
       xsp = jj_scanpos;
       if (jj_3_4()) { jj_scanpos = xsp; break; }
     }
-    return false;
-  }
-
-  private boolean jj_3R_charOrEsc_343_7_13()
- {
-    if (jj_scan_token(SINGLE_ESC)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_charRange_320_7_8()
- {
-    if (jj_3R_charOrEsc_342_5_10()) return true;
-    if (jj_scan_token(CHAR)) return true;
-    if (jj_3R_charOrEsc_342_5_10()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_charOrEsc_342_7_12()
- {
-    if (jj_3R_XmlChar_355_5_11()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_charRange_320_5_6()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    jj_lookingAhead = true;
-    jj_semLA = getToken(2).kind == CHAR && "-".equals(getToken(2).image) && getToken(3).kind != BR_CLOSE;
-    jj_lookingAhead = false;
-    if (!jj_semLA || jj_3R_charRange_320_7_8()) {
-    jj_scanpos = xsp;
-    if (jj_3R_charRange_325_7_9()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_charOrEsc_342_5_10()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_charOrEsc_342_7_12()) {
-    jj_scanpos = xsp;
-    if (jj_3R_charOrEsc_343_7_13()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3_1()
- {
-    if (jj_scan_token(DIGIT)) return true;
     return false;
   }
 

--- a/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParser.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParser.java
@@ -456,7 +456,7 @@ group.negative = true;
     label_4:
     while (true) {
       if (jj_2_3(3)) {
-        sub = charRange();
+        sub = charRange(cg.isEmpty());
 cg.add(sub);
       } else {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -505,7 +505,7 @@ for(final RegExp re : Escape.inGroup(token.image)) cg.add(re);
    * @return expression
    * @throws ParseException parsing exception
    */
-  final public   RegExp charRange() throws ParseException {int a = -1, b = -1;
+  final public   RegExp charRange(boolean isBegin) throws ParseException {int a = -1, b = -1;
     if (getToken(2).kind == CHAR && "-".equals(getToken(2).image) && getToken(3).kind != BR_CLOSE) {
       a = charOrEsc();
       jj_consume_token(CHAR);
@@ -517,6 +517,8 @@ if(a > b) {if (true) throw new ParseException("Illegal range: " +
       case CHAR:
       case DIGIT:{
         a = XmlChar();
+if(a == '-' && ! (isBegin || getToken(1).kind == BR_CLOSE)) {if (true) throw new ParseException(
+          "The - character is a valid character range only at the beginning or end of a positive character group.");}
         break;
         }
       default:
@@ -611,30 +613,13 @@ cp = Escape.getCp(token.image);
     finally { jj_save(3, xla); }
   }
 
-  private boolean jj_3R_charOrEsc_337_7_12()
- {
-    if (jj_3R_XmlChar_350_5_11()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_charOrEsc_337_5_10()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_charOrEsc_337_7_12()) {
-    jj_scanpos = xsp;
-    if (jj_3R_charOrEsc_338_7_13()) return true;
-    }
-    return false;
-  }
-
   private boolean jj_3_2()
  {
     if (jj_3R_posCharGroup_301_5_5()) return true;
     return false;
   }
 
-  private boolean jj_3R_XmlChar_350_5_11()
+  private boolean jj_3R_XmlChar_353_5_11()
  {
     Token xsp;
     xsp = jj_scanpos;
@@ -678,7 +663,7 @@ cp = Escape.getCp(token.image);
 
   private boolean jj_3R_charRange_323_7_9()
  {
-    if (jj_3R_XmlChar_350_5_11()) return true;
+    if (jj_3R_XmlChar_353_5_11()) return true;
     return false;
   }
 
@@ -693,11 +678,23 @@ cp = Escape.getCp(token.image);
     return false;
   }
 
+  private boolean jj_3R_charOrEsc_341_7_13()
+ {
+    if (jj_scan_token(SINGLE_ESC)) return true;
+    return false;
+  }
+
   private boolean jj_3R_charRange_318_7_8()
  {
-    if (jj_3R_charOrEsc_337_5_10()) return true;
+    if (jj_3R_charOrEsc_340_5_10()) return true;
     if (jj_scan_token(CHAR)) return true;
-    if (jj_3R_charOrEsc_337_5_10()) return true;
+    if (jj_3R_charOrEsc_340_5_10()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_charOrEsc_340_7_12()
+ {
+    if (jj_3R_XmlChar_353_5_11()) return true;
     return false;
   }
 
@@ -721,9 +718,14 @@ cp = Escape.getCp(token.image);
     return false;
   }
 
-  private boolean jj_3R_charOrEsc_338_7_13()
+  private boolean jj_3R_charOrEsc_340_5_10()
  {
-    if (jj_scan_token(SINGLE_ESC)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_charOrEsc_340_7_12()) {
+    jj_scanpos = xsp;
+    if (jj_3R_charOrEsc_341_7_13()) return true;
+    }
     return false;
   }
 

--- a/basex-core/src/main/javacc/regex.jj
+++ b/basex-core/src/main/javacc/regex.jj
@@ -298,7 +298,7 @@ PARSER_END(RegExParser)
     final RegExpList cg = new RegExpList();
     RegExp sub = null;
   } {
-    ( LOOKAHEAD(3) sub = charRange() { cg.add(sub); }
+    ( LOOKAHEAD(3) sub = charRange(cg.isEmpty()) { cg.add(sub); }
     | (<SINGLE_ESC> | <MULTI_ESC>| <CAT_ESC>) {
         for(final RegExp re : Escape.inGroup(token.image)) cg.add(re);
       }
@@ -312,7 +312,7 @@ PARSER_END(RegExParser)
    * @return expression
    * @throws ParseException parsing exception
    */
-  RegExp charRange() : {
+  RegExp charRange(boolean isBegin) : {
     int a = -1, b = -1;
   } {
     ( LOOKAHEAD({ getToken(2).kind == CHAR && "-".equals(getToken(2).image) && getToken(3).kind != BR_CLOSE })
@@ -320,7 +320,10 @@ PARSER_END(RegExParser)
         if(a > b) throw new ParseException("Illegal range: " +
             Literal.escape(a) + " > " + Literal.escape(b));
       }
-    | a = XmlChar()
+    | a = XmlChar() {
+        if(a == '-' && ! (isBegin || getToken(1).kind == BR_CLOSE)) throw new ParseException(
+          "The - character is a valid character range only at the beginning or end of a positive character group.");
+      }
     ) {
       return b == -1 ? new Literal(a) : new CharRange(a, b);
     }

--- a/basex-core/src/main/javacc/regex.jj
+++ b/basex-core/src/main/javacc/regex.jj
@@ -33,6 +33,8 @@ public class RegExParser {
   private int groups;
   /** Closed groups. */
   private final Map<Integer, Group> closed = new HashMap<Integer, Group>();
+  /** Path of current atom: sequence numbers of branches and atoms currently being processed. */ 
+  private Stack<Integer> atomPath = new Stack<Integer>();
   /** If the wildcard {@code .} matches any character. */
   private boolean dotAll;
   /** Multi-line matching mode, {@code ^} and {@code $} match on line bounds. */
@@ -83,13 +85,17 @@ PARSER_END(RegExParser)
    */
   RegExp regExp() : {
     final RegExpList brs = new RegExpList();
+    RegExp br;
+    atomPath.push(0);
   } {
     (
-      { brs.add(branch()); }
+      br = branch() { brs.add(br); }
       (
-        <OR> { brs.add(branch()); }
+        <OR> { atomPath.push(atomPath.pop() + 1); }
+        br = branch() { brs.add(br); }
       )*
     ) {
+      atomPath.pop();
       return brs.size() == 1 ? brs.get(0) : new Disjunction(brs.finish());
     }
   }
@@ -104,13 +110,16 @@ PARSER_END(RegExParser)
     RegExp atom;
     final RegExpList pieces = new RegExpList();
     Quantifier qu = null;
+    atomPath.push(0);
   } {
     (
       ( atom = atom() [ qu = quantifier() ] ) {
         pieces.add(qu == null ? atom : new Piece(atom, qu));
         qu = null;
+        atomPath.push(atomPath.pop() + 1);
       }
     )* {
+      atomPath.pop();
       return pieces.size() == 1 ? pieces.get(0) : new Branch(pieces.finish());
     }
   }
@@ -182,12 +191,12 @@ PARSER_END(RegExParser)
     ( nd = Char()
     | nd = charClass()
     | (<NPAR_OPEN> nd = regExp() <PAR_CLOSE>) {
-        nd = new Group(nd, false);
+        nd = new Group(nd, false, atomPath.toArray(new Integer[atomPath.size()]));
       }
     | (<PAR_OPEN> { final int grp = ++groups; }
         nd = regExp()
       <PAR_CLOSE>) {
-        final Group g = new Group(nd, true);
+        final Group g = new Group(nd, true, atomPath.toArray(new Integer[atomPath.size()]));
         closed.put(grp, g);
         nd = g;
       }
@@ -231,7 +240,15 @@ PARSER_END(RegExParser)
       if(g == null)
         throw new ParseException("Illegal back-reference: \\" + backref);
       g.setHasBackRef();
-      return new BackRef(backref);
+      int diff = 0;
+      while (atomPath.get(diff) == g.getAtomPath()[diff]) {
+        ++diff;
+      }
+      // If the atom paths of group and backref differ in a branch (even index), the backref is in
+      // a different branch than the group, so the backref can be flagged accordingly, and later be
+      // omitted at serialization time.
+      final boolean isDifferentBranch = (diff & 1) == 0;
+      return new BackRef(backref, isDifferentBranch);
     }
   }
 

--- a/basex-core/src/main/javacc/regex.jj
+++ b/basex-core/src/main/javacc/regex.jj
@@ -12,6 +12,7 @@ package org.basex.query.util.regex.parse;
 
 import static org.basex.query.QueryError.*;
 
+import java.util.*;
 import java.util.regex.*;
 
 import org.basex.query.*;
@@ -30,10 +31,8 @@ import static java.util.regex.Pattern.*;
 public class RegExParser {
   /** Group counter. */
   private int groups;
-  /** Current backref's number. */
-  private int backref;
   /** Closed groups. */
-  private final BitArray closed = new BitArray();
+  private final Map<Integer, Group> closed = new HashMap<Integer, Group>();
   /** If the wildcard {@code .} matches any character. */
   private boolean dotAll;
   /** Multi-line matching mode, {@code ^} and {@code $} match on line bounds. */
@@ -188,8 +187,9 @@ PARSER_END(RegExParser)
     | (<PAR_OPEN> { final int grp = ++groups; }
         nd = regExp()
       <PAR_CLOSE>) {
-        closed.set(grp);
-        nd = new Group(nd, true);
+        final Group g = new Group(nd, true);
+        closed.put(grp, g);
+        nd = g;
       }
     | nd = backReference()
     ) {
@@ -216,9 +216,9 @@ PARSER_END(RegExParser)
    * @throws ParseException parsing exception
    */
   BackRef backReference() : {
-    Token tok;
+    int backref;
   } {
-    tok = <BACK_REF> {
+      <BACK_REF> {
       backref = token.image.charAt(1) - '0';
     }
     (
@@ -227,8 +227,10 @@ PARSER_END(RegExParser)
         backref = 10 * backref + token.image.charAt(0) - '0';
       }
     )* {
-      if(!closed.get(backref))
+      final Group g = closed.get(backref);
+      if(g == null)
         throw new ParseException("Illegal back-reference: \\" + backref);
+      g.setHasBackRef();
       return new BackRef(backref);
     }
   }

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -1274,6 +1274,7 @@ public final class FnModuleTest extends QueryPlanTest {
     query(func.args("\\", "[A-\\\\]"), true);
 
     query(func.args("babadad", "^((.)?a\\2)+$"), true);
+    query(func.args("x", "(a)|\\1"), true);
 
     error(func.args("a", "+"), REGINVALID_X);
     error(func.args("a", "+", "j"), REGINVALID_X);

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -1276,6 +1276,7 @@ public final class FnModuleTest extends QueryPlanTest {
     error(func.args("a", "+"), REGINVALID_X);
     error(func.args("a", "+", "j"), REGINVALID_X);
     error(func.args("a", "[a-\\\\]"), REGINVALID_X);
+    error(func.args("-", "([\\d-z]+)"), REGINVALID_X);
   }
 
   /** Test method. */

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -1273,6 +1273,8 @@ public final class FnModuleTest extends QueryPlanTest {
     query(func.args("a", "[A-\\\\]"), false);
     query(func.args("\\", "[A-\\\\]"), true);
 
+    query(func.args("babadad", "^((.)?a\\2)+$"), true);
+
     error(func.args("a", "+"), REGINVALID_X);
     error(func.args("a", "+", "j"), REGINVALID_X);
     error(func.args("a", "[a-\\\\]"), REGINVALID_X);


### PR DESCRIPTION
This PR contains three changes addressing three problems:

1. eb1394b0188025129021b6495018a1d334efbfaf: a literal dash was allowed in a regex when it followed a MultiCharEsc, violating the restriction that it is only allowed at the begin or end of its charGroup. An extra check has been added verifying this. This fixes tests p888-p891.
2. cce82a319f2d57a5bc97acf14360370acd2158cc: backrefs where not considered to match, when the corresponding group is optional and did not match anything - this is the JRE's regex engine's way of handling this. It was changed by making the group mandatory and wrapping its content in an optional non-capturing group. This fixes tests p295 and p303.
3. 8769b7db98d0449fb3ac57cb7a3e05530d7ab492: backrefs were not considered to match, when they are in a different branch of the same set of alternatives as the corresponding group. They are expected to match empty in this case, though. This has been fixed by just omitting such backrefs while serializing the parsed expression into a Java pattern. This fixes test p294.

While these changes fix the corresponding tests, we are operating here close to the borders of what can be done with translating to Java regexes. There may be more cases where the match-empty restriction for backref'ed groups produces unexpected results. On the other hand, all of those are most likely corner cases of minor importance.
If you'd prefer to solve this by a using a different (new?) regex implementation, please let me  know.