### PR TITLE
Supply encoding when constructing String from byte array

### DIFF
--- a/basex-core/src/main/java/org/basex/io/in/TarEntry.java
+++ b/basex-core/src/main/java/org/basex/io/in/TarEntry.java
@@ -1,5 +1,7 @@
 package org.basex.io.in;
 
+import java.nio.charset.*;
+
 import org.basex.util.*;
 import org.basex.util.list.*;
 
@@ -94,7 +96,7 @@ public final class TarEntry {
    */
   static String name(final ByteList result) {
     try {
-      return new String(result.toArray());
+      return new String(result.toArray(), StandardCharsets.UTF_8);
     } catch(final Exception ex) {
       // fallback: UTF8
       Util.debug(ex);

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnDecodeFromUri.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnDecodeFromUri.java
@@ -1,5 +1,7 @@
 package org.basex.query.func.fn;
 
+import java.nio.charset.*;
+
 import org.basex.query.*;
 import org.basex.query.func.*;
 import org.basex.query.value.item.*;
@@ -14,6 +16,6 @@ import org.basex.util.*;
 public final class FnDecodeFromUri extends StandardFunc {
   @Override
   public Str item(final QueryContext qc, final InputInfo ii) throws QueryException {
-    return Str.get(new String(XMLToken.decodeUri(toZeroToken(arg(0), qc), true)));
+    return Str.get(new String(XMLToken.decodeUri(toZeroToken(arg(0), qc), true), StandardCharsets.UTF_8));
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnParseUri.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnParseUri.java
@@ -2,6 +2,7 @@ package org.basex.query.func.fn;
 
 import static org.basex.query.QueryError.*;
 
+import java.nio.charset.*;
 import java.util.*;
 import java.util.regex.*;
 
@@ -206,7 +207,7 @@ public class FnParseUri extends FnJsonDoc {
    * @return decoded string
    */
   static String decode(final String string) {
-    return new String(XMLToken.decodeUri(Token.token(string), true));
+    return new String(XMLToken.decodeUri(Token.token(string), true), StandardCharsets.UTF_8);
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/util/XMLToken.java
+++ b/basex-core/src/main/java/org/basex/util/XMLToken.java
@@ -2,6 +2,8 @@ package org.basex.util;
 
 import static org.basex.util.Token.*;
 
+import java.nio.charset.*;
+
 import org.basex.util.hash.*;
 import org.basex.util.list.*;
 import org.basex.util.similarity.*;
@@ -316,7 +318,7 @@ public final class XMLToken {
       else tb.addByte((byte) b);
     }
 
-    final byte[] decoded = Token.token(new String(tb.toArray()));
+    final byte[] decoded = Token.token(new String(tb.toArray(), StandardCharsets.UTF_8));
     tb.reset();
     final int dl = decoded.length;
     for(int d = 0; d < dl; d += cl(decoded, d)) {


### PR DESCRIPTION
When running `mvn test` from command line, I noticed a failing test with this report:

```text
[ERROR]   FnModuleTest.decodeFromUri:338->Sandbox.query:105->Sandbox.compare:122
 fn:decode-from-uri("%F0%9F%92%A1")
 ==> expected: <💡> but was: <Ã°Å¸â€™Â¡>
```
	
The same did not happen when running that test from within Eclipse.

Some further research revealed that the tests are running with different default encodings, command line execution with Windows-1252, and Eclipse with UTF-8.

In this case the different encodings helped to find the cause: the implementation of function `fn:decode-from-uri` uses the `String(byte[])` constructor, which depends on the default encoding. I presume that this constructor should not be used at all, so I have replaced all references by using a constructor supplying an encoding of `UTF-8`.



