### PR TITLE
Ignore encoding from XML declaration when parsing a String value

### DIFF
--- a/basex-core/src/main/java/org/basex/build/xml/SAXWrapper.java
+++ b/basex-core/src/main/java/org/basex/build/xml/SAXWrapper.java
@@ -88,10 +88,33 @@ public final class SAXWrapper extends SingleParser {
    */
   @SuppressWarnings("resource")
   private InputSource inputSource() throws IOException {
+    length = source.length();
+
+    if (source.hasReader()) {
+      length = Math.max(0, length);
+      final Reader r = source.reader();
+      final InputSource rs = new InputSource(new Reader() {
+
+        @Override
+        public int read(final char[] cbuf, final int off, final int len) throws IOException {
+          final int i = r.read(cbuf, off, len);
+          if(i == '\n') ++lines;
+          ++bytes;
+          return i;
+        }
+
+        @Override
+        public void close() throws IOException {
+          r.close();
+        }
+      });
+      rs.setSystemId(source.url());
+      return rs;
+    }
+
     final InputStream input = source.inputStream();
 
     // retrieve/estimate number of bytes to be read
-    length = source.length();
     try {
       if(length <= 0) length = input.available();
     } catch(final IOException ex) {

--- a/basex-core/src/main/java/org/basex/build/xml/SAXWrapper.java
+++ b/basex-core/src/main/java/org/basex/build/xml/SAXWrapper.java
@@ -88,33 +88,10 @@ public final class SAXWrapper extends SingleParser {
    */
   @SuppressWarnings("resource")
   private InputSource inputSource() throws IOException {
-    length = source.length();
-
-    if (source.hasReader()) {
-      length = Math.max(0, length);
-      final Reader r = source.reader();
-      final InputSource rs = new InputSource(new Reader() {
-
-        @Override
-        public int read(final char[] cbuf, final int off, final int len) throws IOException {
-          final int i = r.read(cbuf, off, len);
-          if(i == '\n') ++lines;
-          ++bytes;
-          return i;
-        }
-
-        @Override
-        public void close() throws IOException {
-          r.close();
-        }
-      });
-      rs.setSystemId(source.url());
-      return rs;
-    }
-
     final InputStream input = source.inputStream();
 
     // retrieve/estimate number of bytes to be read
+    length = source.length();
     try {
       if(length <= 0) length = input.available();
     } catch(final IOException ex) {
@@ -142,6 +119,8 @@ public final class SAXWrapper extends SingleParser {
     };
 
     final InputSource is = new InputSource(wrapped);
+    if (source.encoding() != null)
+      is.setEncoding(source.encoding());
     is.setSystemId(source.url());
     return is;
   }

--- a/basex-core/src/main/java/org/basex/io/IO.java
+++ b/basex-core/src/main/java/org/basex/io/IO.java
@@ -234,6 +234,24 @@ public abstract class IO {
   public abstract InputStream inputStream() throws IOException;
 
   /**
+   * Returns a reader.
+   * @return reader
+   * @throws IOException I/O exception
+   */
+  @SuppressWarnings("unused")
+  public Reader reader() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns true, if the IO instance can supply a reader.
+   * @return true, if the IO instance can supply a reader
+   */
+  public boolean hasReader()  {
+    return false;
+  }
+
+  /**
    * Merges two paths.
    * @param path path to be merged
    * @return resulting reference

--- a/basex-core/src/main/java/org/basex/io/IO.java
+++ b/basex-core/src/main/java/org/basex/io/IO.java
@@ -237,7 +237,6 @@ public abstract class IO {
    * Returns the encoding, or null if unknown.
    * @return encoding
    */
-  @SuppressWarnings("unused")
   public String encoding() {
     return null;
   }

--- a/basex-core/src/main/java/org/basex/io/IO.java
+++ b/basex-core/src/main/java/org/basex/io/IO.java
@@ -234,21 +234,12 @@ public abstract class IO {
   public abstract InputStream inputStream() throws IOException;
 
   /**
-   * Returns a reader.
-   * @return reader
-   * @throws IOException I/O exception
+   * Returns the encoding, or null if unknown.
+   * @return encoding
    */
   @SuppressWarnings("unused")
-  public Reader reader() throws IOException {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
-   * Returns true, if the IO instance can supply a reader.
-   * @return true, if the IO instance can supply a reader
-   */
-  public boolean hasReader()  {
-    return false;
+  public String encoding() {
+    return null;
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/io/IOContent.java
+++ b/basex-core/src/main/java/org/basex/io/IOContent.java
@@ -1,8 +1,5 @@
 package org.basex.io;
 
-import java.io.*;
-import java.nio.charset.*;
-
 import javax.xml.transform.stream.*;
 
 import org.basex.io.in.*;
@@ -18,6 +15,8 @@ import org.xml.sax.*;
 public final class IOContent extends IO {
   /** Content. */
   private final byte[] content;
+  /** Encoding. */
+  private final String encoding;
 
   /**
    * Constructor.
@@ -32,7 +31,7 @@ public final class IOContent extends IO {
    * @param content content
    */
   public IOContent(final String content) {
-    this(Token.token(content));
+    this(Token.token(content), "", Strings.UTF8);
   }
 
   /**
@@ -41,7 +40,7 @@ public final class IOContent extends IO {
    * @param path content path
    */
   public IOContent(final String content, final String path) {
-    this(Token.token(content), path);
+    this(Token.token(content), path, Strings.UTF8);
   }
 
   /**
@@ -50,8 +49,19 @@ public final class IOContent extends IO {
    * @param path content path
    */
   public IOContent(final byte[] content, final String path) {
+    this(content, path, null);
+  }
+
+  /**
+   * Constructor.
+   * @param content content
+   * @param path content path
+   * @param encoding encoding
+   */
+  public IOContent(final byte[] content, final String path, final String encoding) {
     super(path);
     this.content = content;
+    this.encoding = encoding;
     len = content.length;
   }
 
@@ -78,13 +88,8 @@ public final class IOContent extends IO {
   }
 
   @Override
-  public boolean hasReader() {
-    return true;
-  }
-
-  @Override
-  public Reader reader() {
-    return new InputStreamReader(inputStream(), StandardCharsets.UTF_8);
+  public String encoding() {
+    return encoding;
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/io/IOContent.java
+++ b/basex-core/src/main/java/org/basex/io/IOContent.java
@@ -1,5 +1,8 @@
 package org.basex.io;
 
+import java.io.*;
+import java.nio.charset.*;
+
 import javax.xml.transform.stream.*;
 
 import org.basex.io.in.*;
@@ -72,6 +75,16 @@ public final class IOContent extends IO {
   @Override
   public ArrayInput inputStream() {
     return new ArrayInput(content);
+  }
+
+  @Override
+  public boolean hasReader() {
+    return true;
+  }
+
+  @Override
+  public Reader reader() {
+    return new InputStreamReader(inputStream(), StandardCharsets.UTF_8);
   }
 
   @Override

--- a/basex-core/src/test/java/org/basex/data/MemDataTest.java
+++ b/basex-core/src/test/java/org/basex/data/MemDataTest.java
@@ -7,7 +7,6 @@ import java.io.*;
 import org.basex.*;
 import org.basex.io.*;
 import org.basex.query.value.node.*;
-import org.basex.util.*;
 import org.junit.jupiter.api.*;
 
 /**
@@ -18,9 +17,8 @@ import org.junit.jupiter.api.*;
  */
 public class MemDataTest extends SandboxTest {
   /** XML document. */
-  static final String XMLSTR = "<a><b>test</b><c/><f>test1</f><f>test3</f></a>";
-  /** XML document. */
-  private static final byte[] XML = Token.token(XMLSTR);
+  static final String XMLSTR = "<?xml version='1.0' encoding='utf-16'?>"
+      + "<a><b>test</b><c/><f>test1</f><f>test3</f></a>";
   /** Tested {@link MemData} instance. */
   private Data data;
 
@@ -29,7 +27,7 @@ public class MemDataTest extends SandboxTest {
    * @throws IOException should never be thrown
    */
   @BeforeEach public void setUp() throws IOException {
-    data = new DBNode(new IOContent(XML)).data();
+    data = new DBNode(new IOContent(XMLSTR)).data();
     context.openDB(data);
   }
 


### PR DESCRIPTION
Some time ago I was using a Java tool (can't remember what it was) that generated XML in a Java string starting with an XML declaration of

```xml
    <?xml version="1.0" encoding="UTF-16"?>...
```

When passing that via `IO.get` to the `DBNode` constructor,

```java
    new DBNode(IO.get(xml))
```

it failed with a parsing error, because the string is internally encoded in UTF-8, the resulting byte stream is then passed to the XML parser, which decodes it per the encoding from the XML declaration. At the time I had fixed this in the application by omitting the XML declaration, but later I realized that the same is reproducible by a query like

```xquery
    parse-xml('<?xml version="1.0" encoding="utf-16"?><xml/>')
```

This PR is a proposal for fixing this, by making making `IOContent` supply a `Reader` that will decode the byte array as UTF-8, and have the XML parser ignore the encoding presented in the XML declaration.