### PR TITLE
Adapt fn:invisible-xml to draft specification

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -796,13 +796,13 @@ public enum QueryError {
   FTDUP_X(FTST, 19, "Match option '%' is declared twice."),
 
   /** Error code. */
-  IXML_GRM_X_X_X(IXML, 1, "Failed to parse ixml grammar: cannot match % at line %, column %."),
+  IXML_GRM_X_X_X(FOIX, 1, "Failed to parse ixml grammar: cannot match % at line %, column %."),
   /** Error code. */
-  IXML_GEN_X(IXML, 2, "Failed to generate ixml parser: %"),
+  IXML_GEN_X(FOIX, 1, "Failed to generate ixml parser: %"),
   /** Error code. */
-  IXML_INP_X_X_X(IXML, 3, "Failed to parse ixml input: cannot match % at line %, column %."),
+  IXML_INP_X_X_X(FOIX, 2, "Failed to parse ixml input: cannot match % at line %, column %."),
   /** Error code. */
-  IXML_RESULT_X(IXML, 4, "Failed to process ixml parser result: %"),
+  IXML_RESULT_X(FOIX, 2, "Failed to process ixml parser result: %"),
 
   /** Error code. */
   SERATTR_X(SENR, 1, "Attributes cannot be serialized:%."),
@@ -1538,6 +1538,7 @@ public enum QueryError {
     /** Error type. */ FODT,
     /** Error type. */ FOFD,
     /** Error type. */ FOER,
+    /** Error type. */ FOIX,
     /** Error type. */ FOJS,
     /** Error type. */ FONS,
     /** Error type. */ FORG,
@@ -1548,7 +1549,6 @@ public enum QueryError {
     /** Error type. */ FOUT,
     /** Error type. */ FTDY,
     /** Error type. */ FTST,
-    /** Error type. */ IXML,
     /** Error type. */ SENR,
     /** Error type. */ SEPM,
     /** Error type. */ SERE,

--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -344,8 +344,8 @@ public enum Function implements AFunction {
   INTERSPERSE(FnIntersperse::new, "intersperse(input,separator)",
       params(ITEM_ZM, ITEM_ZM), ITEM_ZM),
   /** XQuery function. */
-  INVISIBLE_XML(FnInvisibleXml::new, "invisible-xml(grammar)",
-      params(STRING_O), FuncType.get(DOCUMENT_NODE_O, STRING_O).seqType(), flag(HOF)),
+  INVISIBLE_XML(FnInvisibleXml::new, "invisible-xml(grammar[,options])",
+      params(STRING_ZO, MAP_O), FuncType.get(DOCUMENT_NODE_O, STRING_O).seqType(), flag(HOF)),
   /** XQuery function. */
   IRI_TO_URI(FnIriToUri::new, "iri-to-uri(value)",
       params(STRING_ZO), STRING_O),

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -985,10 +985,17 @@ public final class FnModuleTest extends SandboxTest {
         "<ixml xmlns:ixml=\"http://invisiblexml.org/NS\" ixml:state=\"failed\" "
         + "ixml:error-code=\"D06\">"
         + "[D06] The parse tree does not contain exactly one top-level element.</ixml>");
+    // empty $grammar
+    query(func.args(" ()") + "(\"s: 'x'.\")",
+        "<ixml><rule name=\"s\"><alt><literal string=\"x\"/></alt></rule></ixml>");
+
     // invalid grammar
     error(func.args("?%$"), IXML_GRM_X_X_X);
     // parser generation failure
     error(func.args("s: ~[#10ffff]."), IXML_GEN_X);
+    // invalid input with fail option
+    error("let $parser := " + func.args("s: ~[\"x\"]*.", " map {'fail-on-error': true()}") + "\n"
+        + "return $parser('x')", IXML_INP_X_X_X);
   }
 
   /** Test method. */

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
       <dependency>
         <groupId>de.bottlecaps</groupId>
         <artifactId>markup-blitz</artifactId>
-        <version>1.0</version>
+        <version>1.1</version>
         <scope>runtime</scope>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
The [draft specification](https://qt4cg.org/pr/791/xpath-functions-40/Overview.html#func-invisible-xml) for `fn:invisible-xml` needs these changes in the implementation:

- an empty sequence for `$grammar` must use the Invisible XML specification grammar,
- the optional `$options` argument must be supported,
- errors codes must be `FOIX0001` and `FOIX0002`.