### PR TITLE
Fix 10 qt4tests test cases for fn:format-integer

### DIFF
--- a/basex-core/src/main/java/org/basex/query/util/format/FormatParser.java
+++ b/basex-core/src/main/java/org/basex/query/util/format/FormatParser.java
@@ -74,7 +74,7 @@ abstract class FormatParser extends FormatUtil {
 
     // find digit of decimal-digit-pattern
     tp.reset();
-    while(first == -1 && tp.more()) first = zeroes(tp.next(), radix);
+    while(first == -1 && tp.more()) first = zeroes(tp.next());
     // no digit found: return default primary token
     if(first == -1) return def;
 
@@ -84,7 +84,7 @@ abstract class FormatParser extends FormatUtil {
     boolean mds = false;
     while(tp.more()) {
       ch = tp.next();
-      final int d = zeroes(ch, radix);
+      final int d = zeroes(ch);
       if(d != -1) {
         // mandatory-digit-sign
         if(first != d) throw DIFFMAND_X.get(info, pic);
@@ -108,13 +108,23 @@ abstract class FormatParser extends FormatUtil {
   }
 
   /**
+   * Checks if a character is a valid digit.
+   * @param ch character
+   * @param zero zero character
+   * @return result of check
+   */
+  public boolean digit(final int ch, final int zero) {
+    return ch >= zero && ch <= zero + 9;
+  }
+
+  /**
    * Finishes format parsing.
    * @param pres presentation string
    */
   void finish(final byte[] pres) {
     // skip correction of case if modifier has more than one codepoint (Ww)
     final int cp = ch(pres, 0);
-    cs = radix == 10 && (cl(pres, 0) < pres.length || digit(cp)) ? Case.STANDARD :
+    cs = radix == 10 && (cl(pres, 0) < pres.length || Token.digit(cp)) ? Case.STANDARD :
       (cp & ' ') == 0 ? Case.UPPER : Case.LOWER;
     primary = lc(pres);
     if(first == -1) first = ch(primary, 0);

--- a/basex-core/src/main/java/org/basex/query/util/format/FormatUtil.java
+++ b/basex-core/src/main/java/org/basex/query/util/format/FormatUtil.java
@@ -110,24 +110,9 @@ abstract class FormatUtil {
    * @param ch character
    * @return zero base
    */
-  static int zeroes(final int ch) {
+  int zeroes(final int ch) {
     for(final int zero : ZEROES) {
       if(ch >= zero && ch <= zero + 9) return zero;
-    }
-    return -1;
-  }
-
-  /**
-   * Returns the zero base for the specified code point, or {@code -1}.
-   * @param ch character
-   * @param radix radix (2-36)
-   * @return zero base
-   */
-  static int zeroes(final int ch, final int radix) {
-    if(radix == 10) return zeroes(ch);
-    for(int r = 0; r < radix; r++) {
-      final int c = DIGITS[r];
-      if(ch == c || ch > '9' && ch == uc(c)) return '0';
     }
     return -1;
   }

--- a/basex-core/src/main/java/org/basex/query/util/format/Formatter.java
+++ b/basex-core/src/main/java/org/basex/query/util/format/Formatter.java
@@ -601,7 +601,7 @@ public abstract class Formatter extends FormatUtil {
           // add remaining modifiers
           if(ch == '#') break;
           if(digit(ch, zero, fp.radix)) ch = zero;
-          if(regSep && modPos + 1 < digitPos) break;
+          if(modPos + 1 < digitPos) break;
         }
       } else if(inPos >= 0) {
         // add remaining numbers

--- a/basex-core/src/main/java/org/basex/query/util/format/Formatter.java
+++ b/basex-core/src/main/java/org/basex/query/util/format/Formatter.java
@@ -552,7 +552,7 @@ public abstract class Formatter extends FormatUtil {
    * @return number character sequence
    */
   private static byte[] number(final byte[] num, final FormatParser fp, final int first) {
-    final int zero = zeroes(first, fp.radix);
+    final int zero = fp.zeroes(first);
 
     // cache characters of presentation modifier
     final int[] mod = new TokenParser(fp.primary).toArray();
@@ -565,7 +565,7 @@ public abstract class Formatter extends FormatUtil {
     boolean regSep = false;
     for(int mp = modSize - 1; mp >= modStart; --mp) {
       final int ch = mod[mp];
-      if(digit(ch, zero, fp.radix)) {
+      if(fp.digit(ch, zero)) {
         digitPos = mp;
         continue;
       }
@@ -593,14 +593,14 @@ public abstract class Formatter extends FormatUtil {
         ch = mod[modPos--];
         if(inPos >= 0) {
           if(ch == '#' && sep) reverse.add(sepChar);
-          if(ch == '#' || digit(ch, zero, fp.radix)) {
+          if(ch == '#' || fp.digit(ch, zero)) {
             final int n = num[inPos--];
             ch = fp.radix == 10 ? zero + n - '0' : n;
           }
         } else {
           // add remaining modifiers
           if(ch == '#') break;
-          if(digit(ch, zero, fp.radix)) ch = zero;
+          if(fp.digit(ch, zero)) ch = zero;
           if(modPos + 1 < digitPos) break;
         }
       } else if(inPos >= 0) {
@@ -620,20 +620,6 @@ public abstract class Formatter extends FormatUtil {
     final TokenBuilder result = new TokenBuilder();
     for(int rs = reverse.size() - 1; rs >= 0; --rs) result.add(reverse.get(rs));
     return result.finish();
-  }
-
-  /**
-   * Checks if a character is a valid digit.
-   * @param ch character
-   * @param zero zero character
-   * @param radix radix
-   * @return result of check
-   */
-  static boolean digit(final int ch, final int zero, final int radix) {
-    if(radix == 10) return ch >= zero && ch <= zero + 9;
-    final int num = ch <= '9' ? ch : (ch & 0xDF) - 0x37;
-    return ch >= '0' && ch <= '9' || ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' &&
-        num < radix;
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/util/format/IntFormat.java
+++ b/basex-core/src/main/java/org/basex/query/util/format/IntFormat.java
@@ -22,11 +22,15 @@ public final class IntFormat extends FormatParser {
   public IntFormat(final byte[] picture, final InputInfo info) throws QueryException {
     super(info);
 
-    final int rc = indexOf(picture, '^');
-    radix = rc == -1 ? 10 : toInt(substring(picture, 0, rc));
-    if(radix < 2 || radix > 36) throw PICNUM_X.get(info, picture);
-
     final int sc = lastIndexOf(picture, ';');
+    int rc = indexOf(picture, '^');
+    int xc = indexOf(picture, 'X', rc + 1);
+    if(xc == -1 || sc != -1 && xc > sc) xc = indexOf(picture, 'x', rc + 1);
+    if(sc != -1 && xc > sc) xc = -1;
+    radix = rc == -1 ? 10 : toInt(substring(picture, 0, rc));
+    if(radix < 2 || radix > 36 || xc == -1) rc = -1;
+    if(rc == -1) radix = 10;
+
     final byte[] pres = substring(picture, rc + 1, sc == -1 ? picture.length : sc);
     if(pres.length == 0) throw PICEMPTY.get(info, picture);
     finish(presentation(pres, ONE, false));

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -732,12 +732,12 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args(11, "1"), "11");
     query(func.args(11, "001"), "011");
 
-    query(func.args(1234, "16^ffff"), "04d2");
-    query(func.args(1234, "16^F"), "4D2");
-    query(func.args(12345678, "16^ffff_ffff"), "00bc_614e");
-    query(func.args(12345678, "16^#_ffff"), "bc_614e");
-    query(func.args(255, "2^1111 1111"), "1111 1111");
-    query(func.args(1023, "32^AAAA"), "00VV");
+    query(func.args(1234, "16^xxxx"), "04d2");
+    query(func.args(1234, "16^X"), "4D2");
+    query(func.args(12345678, "16^xxxx_xxxx"), "00bc_614e");
+    query(func.args(12345678, "16^#_xxxx"), "bc_614e");
+    query(func.args(255, "2^xxxx xxxx"), "1111 1111");
+    query(func.args(1023, "32^XXXX"), "00VV");
   }
 
   /** Test method. */

--- a/basex-core/src/test/java/org/basex/query/func/fn/FnFormatIntegerTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/fn/FnFormatIntegerTest.java
@@ -67,7 +67,7 @@ public final class FnFormatIntegerTest extends QueryTest {
         "format-integer(1500000, '#,###,000')" },
       { "290", strings("1500\ud800\udd000,00"),
         "format-integer(1500000, '###\ud800\udd000,00')" },
-      { "300", strings("(602)347-826"),
+      { "300", strings("602)347-826"),
         "format-integer(602347826, '#(000)000-000')" },
       { "310", strings("SECOND"), "format-integer(2, 'W;o')" },
       { "330", strings("1st"), "format-integer(1, '1;o(-en)')" },


### PR DESCRIPTION
Here are some changes of fn:format-integer, which will

- consider an explicit radix only if an `X` or `x` mandatory-digit-sign is present in the primary format token
- prevent separators from appearing in the result before any digits
- handle format pictures containing `X` or `x` mandatory-digit-signs, when an explicit radix is present.

They will fix these tests from qt4tests:

- format-integer-030
- format-integer-40-001
- format-integer-40-002
- format-integer-40-008
- format-integer-40-009
- format-integer-40-010
- format-integer-40-013
- format-integer-40-016
- format-integer-40-014
- format-integer-40-015