### PR TITLE
Support BCP 47 language tags in fn:format-integer, fn:format-date, fn:format-number

### DIFF
--- a/basex-core/src/main/java/org/basex/query/util/format/DecFormatter.java
+++ b/basex-core/src/main/java/org/basex/query/util/format/DecFormatter.java
@@ -132,12 +132,12 @@ public final class DecFormatter extends FormatUtil {
 
   /**
    * Returns a decimal formatter for the given language.
-   * @param language language
+   * @param languageTag language tag
    * @return a decimal formatter, or {@code null} if the language is not supported
    * @throws QueryException query exception
    */
-  public static DecFormatter forLanguage(final byte[] language) throws QueryException {
-    final String l = string(language);
+  public static DecFormatter forLanguage(final byte[] languageTag) throws QueryException {
+    final String l = string(languageTag);
     final DecFormatOptions dfo = IcuFormatter.available() ? IcuFormatter.decFormat(l) :
       decFormatSymbols(l);
     return dfo != null ? new DecFormatter(dfo, null) : null;
@@ -145,12 +145,12 @@ public final class DecFormatter extends FormatUtil {
 
   /**
    * Returns a decimal format symbols for the given language.
-   * @param language language
+   * @param languageTag language tag
    * @return format symbols, or {@code null} if the language is not supported
    */
-  private static DecFormatOptions decFormatSymbols(final String language) {
+  private static DecFormatOptions decFormatSymbols(final String languageTag) {
     for(final Locale locale : DecimalFormatSymbols.getAvailableLocales()) {
-      if(locale.toString().equals(language)) {
+      if(locale.toLanguageTag().equals(languageTag)) {
         final DecimalFormatSymbols dfs = DecimalFormatSymbols.getInstance(locale);
         final DecFormatOptions dfo = new DecFormatOptions();
         dfo.put(DecFormatOptions.DECIMAL_SEPARATOR, String.valueOf(dfs.getDecimalSeparator()));

--- a/basex-core/src/main/java/org/basex/query/util/format/Formatter.java
+++ b/basex-core/src/main/java/org/basex/query/util/format/Formatter.java
@@ -44,32 +44,33 @@ public abstract class Formatter extends FormatUtil {
 
   /**
    * Returns a formatter for the specified language.
-   * @param language language
+   * @param languageTag language tag
    * @return formatter instance
    */
-  public static Formatter get(final byte[] language) {
-    if(IcuFormatter.available()) return IcuFormatter.get(language);
-    final Formatter form = getInternal(language);
+  public static Formatter get(final byte[] languageTag) {
+    if(IcuFormatter.available()) return IcuFormatter.get(languageTag);
+    final Formatter form = getInternal(languageTag);
     return form != null ? form : getInternal(EN);
   }
 
   /**
    * Returns an internal formatter for the specified language.
-   * @param language language
+   * @param languageTag language tag
    * @return formatter instance, or {@code null} if not implemented
    */
-   protected static Formatter getInternal(final byte[] language) {
-    return MAP.get(language);
+  protected static Formatter getInternal(final byte[] languageTag) {
+    final int i = indexOf(languageTag, '-');
+    return i < 0 ? MAP.get(languageTag) : MAP.get(substring(languageTag, 0, i));
   }
 
   /**
    * Checks whether a formatter is available for the specified language.
-   * @param language language
+   * @param languageTag language tag
    * @return true if the language is supported
    */
-  public static boolean available(final byte[] language) {
-    if(IcuFormatter.available()) return IcuFormatter.available(language);
-    return getInternal(language) != null;
+  public static boolean available(final byte[] languageTag) {
+    if(IcuFormatter.available()) return IcuFormatter.available(languageTag);
+    return getInternal(languageTag) != null;
   }
 
   /**
@@ -130,7 +131,7 @@ public abstract class Formatter extends FormatUtil {
   /**
    * Formats the specified date.
    * @param date date to be formatted
-   * @param language language
+   * @param languageTag language tag
    * @param picture picture
    * @param calendar calendar (can be {@code null})
    * @param place place
@@ -139,12 +140,12 @@ public abstract class Formatter extends FormatUtil {
    * @return formatted string
    * @throws QueryException query exception
    */
-  public final byte[] formatDate(final ADate date, final byte[] language, final byte[] picture,
+  public final byte[] formatDate(final ADate date, final byte[] languageTag, final byte[] picture,
       final byte[] calendar, final byte[] place, final StaticContext sc, final InputInfo info)
       throws QueryException {
 
     final TokenBuilder tb = new TokenBuilder();
-    if(language.length != 0 && !available(language)) tb.add("[Language: en]");
+    if(languageTag.length != 0 && !available(languageTag)) tb.add("[Language: en]");
     if(calendar != null) {
       final QNm qnm;
       try {

--- a/basex-core/src/main/java/org/basex/query/util/format/IcuFormatter.java
+++ b/basex-core/src/main/java/org/basex/query/util/format/IcuFormatter.java
@@ -89,51 +89,52 @@ public final class IcuFormatter extends Formatter {
 
   /**
    * Returns a cached formatter instance for the specified language.
-   * @param language language
+   * @param languageTag language tag
    * @return formatter instance
    */
-  public static IcuFormatter get(final byte[] language) {
+  public static IcuFormatter get(final byte[] languageTag) {
     final TokenObjMap<IcuFormatter> map = MAP.get();
     final IcuFormatter form;
-    if(map.contains(language)) {
-      form = map.get(language);
+    if(map.contains(languageTag)) {
+      form = map.get(languageTag);
     } else {
-      form = forLanguage(language);
+      form = forLanguage(languageTag);
       // put null values as well, in order to avoid recalculation
-      map.put(language, form);
+      map.put(languageTag, form);
     }
     return form != null ? form : get(EN);
   }
 
   /**
    * Constructs a formatter for the specified language, if available.
-   * @param language language
+   * @param languageTag language tag
    * @return formatter instance, or {@code null} if not available
    */
-  private static IcuFormatter forLanguage(final byte[] language) {
-    final String lang = string(language);
-    if(lang.isBlank()) return null;
-    final Locale l = Locale.forLanguageTag(lang);
+  private static IcuFormatter forLanguage(final byte[] languageTag) {
+    final String tag = string(languageTag);
+    if(tag.isBlank()) return null;
+    final ULocale l = ULocale.forLanguageTag(tag);
     final RuleBasedNumberFormat s = new RuleBasedNumberFormat(l, RuleBasedNumberFormat.SPELLOUT);
     final RuleBasedNumberFormat o = new RuleBasedNumberFormat(l, RuleBasedNumberFormat.ORDINAL);
     final DateFormatSymbols d = new DateFormatSymbols(l);
+    final String lang = l.getLanguage();
     return s.getLocale(ULocale.ACTUAL_LOCALE).getLanguage().equals(lang) &&
            o.getLocale(ULocale.ACTUAL_LOCALE).getLanguage().equals(lang) &&
            d.getLocale(ULocale.ACTUAL_LOCALE).getLanguage().equals(lang)
-        ? new IcuFormatter(s, o, d, getInternal(language))
+        ? new IcuFormatter(s, o, d, getInternal(languageTag))
         : null;
   }
 
   /**
    * Checks whether a formatter is available for the specified language.
-   * @param language language
+   * @param languageTag language tag
    * @return true if the language is supported
    */
-  public static boolean available(final byte[] language) {
+  public static boolean available(final byte[] languageTag) {
     // instantiate a formatter, if available
-    get(language);
+    get(languageTag);
     // check map using get rather than contains, as map contains null values
-    return MAP.get().get(language) != null;
+    return MAP.get().get(languageTag) != null;
   }
 
   /**
@@ -291,27 +292,26 @@ public final class IcuFormatter extends Formatter {
 
   /**
    * Returns decimal-format properties for the given language.
-   * @param language language
+   * @param languageTag language tag
    * @return properties, or {@code null} if the language is not supported
    */
-  static DecFormatOptions decFormat(final String language) {
-    for(final ULocale locale : DecimalFormatSymbols.getAvailableULocales()) {
-      if(locale.toString().equals(language)) {
-        final DecimalFormatSymbols dfs = DecimalFormatSymbols.getInstance(locale);
-        final DecFormatOptions dfo = new DecFormatOptions();
-        dfo.put(DecFormatOptions.DECIMAL_SEPARATOR, dfs.getDecimalSeparatorString());
-        dfo.put(DecFormatOptions.DIGIT, String.valueOf(dfs.getDigit()));
-        dfo.put(DecFormatOptions.GROUPING_SEPARATOR, dfs.getGroupingSeparatorString());
-        dfo.put(DecFormatOptions.EXPONENT_SEPARATOR, dfs.getExponentSeparator());
-        dfo.put(DecFormatOptions.INFINITY, dfs.getInfinity());
-        dfo.put(DecFormatOptions.MINUS_SIGN, dfs.getMinusSignString());
-        dfo.put(DecFormatOptions.NAN, dfs.getNaN());
-        dfo.put(DecFormatOptions.PATTERN_SEPARATOR, String.valueOf(dfs.getPatternSeparator()));
-        dfo.put(DecFormatOptions.PERCENT, dfs.getPercentString());
-        dfo.put(DecFormatOptions.PER_MILLE, dfs.getPerMillString());
-        dfo.put(DecFormatOptions.ZERO_DIGIT, String.valueOf(dfs.getZeroDigit()));
-        return dfo;
-      }
+  static DecFormatOptions decFormat(final String languageTag) {
+    final ULocale locale = ULocale.forLanguageTag(languageTag);
+    final DecimalFormatSymbols dfs = DecimalFormatSymbols.getInstance(locale);
+    if(dfs.getLocale(ULocale.ACTUAL_LOCALE).toLanguageTag().equals(languageTag)) {
+      final DecFormatOptions dfo = new DecFormatOptions();
+      dfo.put(DecFormatOptions.DECIMAL_SEPARATOR, dfs.getDecimalSeparatorString());
+      dfo.put(DecFormatOptions.DIGIT, String.valueOf(dfs.getDigit()));
+      dfo.put(DecFormatOptions.GROUPING_SEPARATOR, dfs.getGroupingSeparatorString());
+      dfo.put(DecFormatOptions.EXPONENT_SEPARATOR, dfs.getExponentSeparator());
+      dfo.put(DecFormatOptions.INFINITY, dfs.getInfinity());
+      dfo.put(DecFormatOptions.MINUS_SIGN, dfs.getMinusSignString());
+      dfo.put(DecFormatOptions.NAN, dfs.getNaN());
+      dfo.put(DecFormatOptions.PATTERN_SEPARATOR, String.valueOf(dfs.getPatternSeparator()));
+      dfo.put(DecFormatOptions.PERCENT, dfs.getPercentString());
+      dfo.put(DecFormatOptions.PER_MILLE, dfs.getPerMillString());
+      dfo.put(DecFormatOptions.ZERO_DIGIT, String.valueOf(dfs.getZeroDigit()));
+      return dfo;
     }
     return null;
   }

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -736,6 +736,13 @@ public final class FnModuleTest extends SandboxTest {
     if(IcuFormatter.available()) {
       query(func.args(" xs:date('2023-12-11')", "[FNn], [MNn] [D], [Y]", "cy"),
           "Dydd Llun, Rhagfyr 11, 2023");
+      query(func.args(" xs:date('2023-09-01')", "[MNn]", "es"), "septiembre");
+      // different wording for country
+      query(func.args(" xs:date('2023-09-01')", "[MNn]", "es-PE"), "setiembre");
+      // fallback to base language
+      query(func.args(" xs:date('2023-09-01')", "[MNn]", "es-CZ"), "septiembre");
+      // fallback to default language
+      query(func.args(" xs:date('2023-09-01')", "[MNn]", "zu-DE"), "[Language: en]September");
     }
   }
 
@@ -759,6 +766,13 @@ public final class FnModuleTest extends SandboxTest {
       query(func.args(1, "Ww;c", "de"), "Ein");
       query(func.args(1, "Ww;o(%spellout-cardinal-feminine-financial)", "bs"), "Jedinica");
       query(func.args(1, "Ww;c(%spellout-ordinal-neuter)", "es"), "Primera");
+      query(func.args(99, "w", "fr"), "quatre-vingt-dix-neuf");
+      // different wording for country
+      query(func.args(99, "w", "fr-CH"), "nonante-neuf");
+      // fallback to language code
+      query(func.args(99, "w", "fr-PL"), "quatre-vingt-dix-neuf");
+      // fallback to default language
+      query(func.args(99, "w", "zu-DE"), "ninety-nine");
     }
   }
 
@@ -769,10 +783,11 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args(" 12345.67", "#.##0,00", "de"), "12.345,67");
     query(func.args(" 12345.67", "#.##0,00", " ()", " map { 'decimal-separator': ',', "
         + "'grouping-separator': '.' }"), "12.345,67");
-    query(func.args(" 12345.67", "#\u2019##0.00", "de_CH"), "12\u2019345.67");
+    query(func.args(" 12345.67", "#\u2019##0.00", "de-CH"), "12\u2019345.67");
 
     error(func.args(" 12345.67", "#.##0,00", "de", " map { 'decimal-separator': ',', "
         + "'grouping-separator': '.' }"), FORMDUP_X);
+    error(func.args(" 12345.67", "#.##0,00", "de-XX"), FORMNUM_X);
   }
 
   /** Test method. */


### PR DESCRIPTION
This is a follow-up change to the recent changes to `fn:format-[integer|date|number]`, which unifies language support such that all changed functions now support BCP 47 language tags.