### PR TITLE
Support IANA time zone names

### DIFF
--- a/basex-core/src/main/java/org/basex/query/value/item/ADate.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/ADate.java
@@ -511,4 +511,33 @@ public abstract class ADate extends ADateDur {
   public final void toString(final QueryString qs) {
     qs.quoted(string(null));
   }
+
+  /**
+   * Create a duplicate of this ADate.
+   * @return the duplicate
+   */
+  public ADate duplicate() {
+    final ADate date;
+    switch((AtomType) type) {
+      case DATE:
+        date = new Dat(this);
+        break;
+      case TIME:
+        date = new Tim(this);
+        break;
+      case DATE_TIME:
+        date = new Dtm(this);
+        break;
+      case G_DAY:
+      case G_MONTH:
+      case G_MONTH_DAY:
+      case G_YEAR:
+      case G_YEAR_MONTH:
+        date = new GDt(this, type);
+        break;
+      default:
+        throw new IllegalStateException("Unsupported type: " + type);
+    }
+    return date;
+  }
 }

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -727,11 +727,35 @@ public final class FnModuleTest extends SandboxTest {
   }
 
   /** Test method. */
+  @Test public void formatDateTime() {
+    final Function func = FORMAT_DATETIME;
+
+    query(func.args(" xs:dateTime('2023-07-01T12:00:00Z')",
+        "[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01][Z]", " ()", " ()", "America/New_York"),
+        "2023-07-01T08:00:00-04:00");
+    query(func.args(" xs:dateTime('2023-07-01T12:00:00Z')",
+        "[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01][Z]", " ()", " ()", "Asia/Kolkata"),
+        "2023-07-01T17:30:00+05:30");
+  }
+
+  /** Test method. */
+  @Test public void formatTime() {
+    final Function func = FORMAT_TIME;
+
+    query(func.args(" xs:time('12:00:00Z')", "[H01]:[m01]:[s01][Z]", " ()", " ()",
+        "America/New_York"), "07:00:00-05:00");
+    query(func.args(" xs:time('12:00:00Z')", "[H01]:[m01]:[s01][Z]", " ()", " ()",
+        "Asia/Kolkata"), "17:30:00+05:30");
+  }
+
+  /** Test method. */
   @Test public void formatDate() {
     final Function func = FORMAT_DATE;
 
     query(func.args(" xs:date('2023-12-11')", "[Dwo] [MNn] ([FNn])", "zu"),
         "[Language: en]eleventh December (Monday)");
+    query(func.args(" xs:date('2024-01-12Z')", "[Y0001]-[M01]-[D01][Z]", " ()", " ()",
+        "America/New_York"), "2024-01-11-05:00");
 
     if(IcuFormatter.available()) {
       query(func.args(" xs:date('2023-12-11')", "[FNn], [MNn] [D], [Y]", "cy"),


### PR DESCRIPTION
These changes support IANA time zone names in the `$place` argument of `fn:format-date`, `fn:format-time`, and `fn:format-dateTime`, by adjusting the value to the given time zone before formatting. This is specified in the last paragraph of [9.8.4.8 The language, calendar, and place arguments](https://qt4cg.org/specifications/xpath-functions-40/Overview.html#lang-cal-place).