### PR TITLE
Respect ICU collator properties while comparing collation elements

### DIFF
--- a/basex-core/src/main/java/org/basex/query/util/collation/UCACollation.java
+++ b/basex-core/src/main/java/org/basex/query/util/collation/UCACollation.java
@@ -54,11 +54,11 @@ final class UCACollation extends Collation {
   private static int mask(final int strength) {
     switch(strength) {
       case Collator.PRIMARY:
-        return 0xffff0000;
+        return 0xFFFF0000;
       case Collator.SECONDARY:
-        return 0xffffff00;
+        return 0xFFFFFF00;
       default:
-        return 0xffffffff;
+        return 0xFFFFFFFF;
     }
   }
 


### PR DESCRIPTION
The comparison of collation elements has been improved, now respecting the collator's properties.

This fixes most of the QT4 test cases that failed after adding ICU4J to the classpath, in particular those with name prefixes

- compare
- fn-contains
- fn-ends-with
- fn-starts-with
- fn-substring-after
- fn-substring-before
- defaultcolldecl
- fo-test-fn-contains
- fo-test-fn-starts-with
- fo-test-fn-ends-with
- fo-test-fn-substring-before
- fo-test-fn-substring-after

Some with the following prefixed are still failing, I am still working on those:

- format-time
- UCA