### PR TITLE
Suppress quaternary level for UCA collation with alternate=blanked

### DIFF
--- a/basex-core/src/main/java/org/basex/query/util/collation/UCAOptions.java
+++ b/basex-core/src/main/java/org/basex/query/util/collation/UCAOptions.java
@@ -98,6 +98,9 @@ public final class UCAOptions extends CollationOptions {
       else if(eq(v, "shifted", "blanked")) b = true;
       else throw error(ALTERNATE);
       invoke(method(RBC, "setAlternateHandlingShifted", boolean.class), coll, b);
+      if(eq(v, "blanked") && eq(get(STRENGTH), "quaternary")) {
+        invoke(method(RBC, "setStrength", int.class), coll, 2); // Collator.TERTIARY
+      }
     }
 
     if(contains(BACKWARDS)) {


### PR DESCRIPTION
`alternate=blanked` is similar to `alternate=shifted`, however the differences must show up at `identical` level rather than at `quaternary` level, effectively making the set of `quaternary` differences empty. Combining it with `strength=quaternary` should do the same as `strength=tertiary`.

The ICU collator only has `strength` and `isShifted`. `blanked` must be represented by suppressing the `quaternary` level.

This fixes QT4 test case `compare-041`.