### PR TITLE
Improve mixed-case English AM/PM and era indicators

### DIFF
--- a/basex-core/src/main/java/org/basex/query/util/format/FormatterEN.java
+++ b/basex-core/src/main/java/org/basex/query/util/format/FormatterEN.java
@@ -59,11 +59,11 @@ final class FormatterEN extends Formatter {
       "August", "September", "October", "November", "December");
 
   /** AM/PM Markers. */
-  private static final byte[][] AMPM = tokens("Am", "Pm");
+  private static final byte[][] AMPM = tokens("AM", "PM");
   /** Ordinal suffixes (st, nr, rd, th). */
   private static final byte[][] ORDSUFFIX = tokens("st", "nd", "rd", "th");
   /** Eras: BC, AD. */
-  private static final byte[][] ERAS = tokens("Bc", "Ad");
+  private static final byte[][] ERAS = tokens("BC", "AD");
 
   @Override
   public byte[] word(final long n, final NumeralType numType, final byte[] suffix) {


### PR DESCRIPTION
QT4 tests `format-time-021` and `format-time-022` currently fail when ICU4J is on the classpath, because AM/PM indicators in mixed case are expected to be `Am` and `Pm`, but come out as `AM` and `PM`.

I think that the expectation is dubious - would anyone in real life ever want `Am`/`Pm`? The mixed-case form of AM/PM and era indicators in English should rather be `AM`, `PM`, and `BC`, `AD`.

Changing it this way will make those tests fail without ICU4J, too. For getting that fixed, we should add alternate results to [format-time.xml](https://github.com/qt4cg/qt4tests/blob/7e29d5fd0dcb4c732d838a9f2e51d92436756b72/fn/format-time.xml#L392-L416). If you agree, I will gladly add a corresponding PR to [qt4tests](https://github.com/qt4cg/qt4tests).