### PR TITLE
Allow unknown UCA option names and values when fallback is not "no"

### DIFF
--- a/basex-core/src/main/java/org/basex/query/util/collation/BaseXCollationOptions.java
+++ b/basex-core/src/main/java/org/basex/query/util/collation/BaseXCollationOptions.java
@@ -4,7 +4,6 @@ import static org.basex.util.Strings.*;
 
 import java.text.*;
 import java.util.*;
-import java.util.Map.Entry;
 
 import org.basex.core.*;
 import org.basex.util.options.*;
@@ -71,15 +70,12 @@ public final class BaseXCollationOptions extends CollationOptions {
     }
   }
 
-  /** Fallback parsing. */
-  private final boolean fallback;
-
   /**
    * Constructor.
    * @param fallback fallback option
    */
   public BaseXCollationOptions(final boolean fallback) {
-    this.fallback = fallback;
+    super(fallback);
   }
 
   @Override
@@ -95,15 +91,17 @@ public final class BaseXCollationOptions extends CollationOptions {
    */
   private Collator collator(final HashMap<String, String> args) throws BaseXException {
     if(fallback) {
-      for(final Entry<String, String> entry : args.entrySet()) {
-        final String name = entry.getKey();
-        String value = entry.getValue();
-        if(name.equals(STRENGTH.name())) {
-          if(eq(value, "1")) value = Strength.PRIMARY.toString();
-          else if(eq(value, "2")) value = Strength.SECONDARY.toString();
-          else if(eq(value, "3")) value = Strength.TERTIARY.toString();
-          else if(eq(value, "quaternary", "4", "5")) value = Strength.IDENTICAL.toString();
+      final String name = STRENGTH.name();
+      if(args.containsKey(name)) {
+        String value = args.get(name);
+        if(eq(value, "1")) value = Strength.PRIMARY.toString();
+        else if(eq(value, "2")) value = Strength.SECONDARY.toString();
+        else if(eq(value, "3")) value = Strength.TERTIARY.toString();
+        else if(eq(value, "quaternary", "4", "5")) value = Strength.IDENTICAL.toString();
+        try {
           assign(name, value);
+        } catch (@SuppressWarnings("unused") BaseXException ex) {
+          // fallback == true -> ignore invalid values
         }
       }
     } else {

--- a/basex-core/src/main/java/org/basex/query/util/collation/Collation.java
+++ b/basex-core/src/main/java/org/basex/query/util/collation/Collation.java
@@ -96,9 +96,10 @@ public abstract class Collation {
     if(eq(URL, base)) {
       opts = new BaseXCollationOptions(false);
     } else if(eq(UCA, base)) {
+      final boolean fallback = !YesNo.NO.toString().equals(args.get(UCAOptions.FALLBACK.name()));
       if(UCAOptions.ACTIVE) {
-        opts = new UCAOptions();
-      } else if(!YesNo.NO.toString().equals(args.get(UCAOptions.FALLBACK.name()))) {
+        opts = new UCAOptions(fallback);
+      } else if(fallback) {
         opts = new BaseXCollationOptions(true);
       }
     }

--- a/basex-core/src/main/java/org/basex/query/util/collation/CollationOptions.java
+++ b/basex-core/src/main/java/org/basex/query/util/collation/CollationOptions.java
@@ -13,6 +13,17 @@ import org.basex.util.options.*;
  * @author Christian Gruen
  */
 abstract class CollationOptions extends Options {
+  /** Fallback parsing. */
+  protected final boolean fallback;
+
+  /**
+   * Constructor.
+   * @param fallback fallback option
+   */
+  CollationOptions(final boolean fallback) {
+    this.fallback = fallback;
+  }
+
   /**
    * Parses the specified options and returns the faulty key.
    * @param args arguments
@@ -28,7 +39,11 @@ abstract class CollationOptions extends Options {
    */
   void assign(final HashMap<String, String> args) throws BaseXException {
     for(final Entry<String, String> entry : args.entrySet()) {
-      assign(entry.getKey(), entry.getValue());
+      try {
+        assign(entry.getKey(), entry.getValue());
+      } catch (BaseXException ex) {
+        if(!fallback) throw ex;
+      }
     }
   }
 

--- a/basex-core/src/main/java/org/basex/query/util/collation/UCACollation.java
+++ b/basex-core/src/main/java/org/basex/query/util/collation/UCACollation.java
@@ -4,8 +4,6 @@ import static com.ibm.icu.text.CollationElementIterator.*;
 import static com.ibm.icu.text.Collator.*;
 import static org.basex.util.Token.*;
 
-import java.util.*;
-
 import org.basex.util.*;
 
 import com.ibm.icu.text.*;
@@ -35,8 +33,8 @@ final class UCACollation extends Collation {
    * Private Constructor.
    * @param collator collation options
    */
-  UCACollation(final Comparator<Object> collator) {
-    this.collator = (RuleBasedCollator) collator;
+  UCACollation(final RuleBasedCollator collator) {
+    this.collator = collator;
     strength = this.collator.getStrength();
     strengthMask = mask(strength);
     isShifted = this.collator.isAlternateHandlingShifted();

--- a/basex-core/src/main/java/org/basex/query/util/collation/UCAOptions.java
+++ b/basex-core/src/main/java/org/basex/query/util/collation/UCAOptions.java
@@ -3,13 +3,16 @@ package org.basex.query.util.collation;
 import static org.basex.util.Reflect.*;
 import static org.basex.util.Strings.*;
 
-import java.lang.reflect.*;
 import java.util.*;
 
 import org.basex.core.*;
 import org.basex.util.Util;
 import org.basex.util.list.*;
 import org.basex.util.options.*;
+
+import com.ibm.icu.lang.*;
+import com.ibm.icu.text.*;
+import com.ibm.icu.util.*;
 
 /**
  * UCA collation options.
@@ -42,127 +45,140 @@ public final class UCAOptions extends CollationOptions {
   public static final StringOption REORDER = new StringOption("reorder");
 
   /** Name of the Collator class. */
-  static final Class<?> COLLATOR = find("com.ibm.icu.text.Collator");
-  /** Stemmer class corresponding to the required properties. */
+  private static final Class<?> COLLATOR = find("com.ibm.icu.text.Collator");
+  /** Whether the Collator class is on the class path. */
   static final boolean ACTIVE = COLLATOR != null;
-  /** Name of the Collator class. */
-  static final Class<?> RBC = find("com.ibm.icu.text.RuleBasedCollator");
+
+  /**
+   * Constructor.
+   * @param fallback fallback option
+   */
+  public UCAOptions(final boolean fallback) {
+    super(fallback);
+  }
 
   @Override
-  @SuppressWarnings("unchecked")
   Collation get(final HashMap<String, String> args) throws BaseXException {
     assign(args);
 
     Locale locale = Locale.US;
     if(contains(LANG)) {
-      locale = Locales.MAP.get(get(LANG));
-      if(locale == null) throw error(LANG);
+      final Locale l = Locales.MAP.get(get(LANG));
+      if(l != null) locale = l;
+      else if(!fallback) throw error(LANG);
     }
 
-    final Method m = method(COLLATOR, "getInstance", Locale.class);
-    final Object coll = invoke(m, null, locale);
-
-    if(!coll.getClass().equals(RBC)) throw new BaseXException(
+    final Collator coll = Collator.getInstance(locale);
+    if(!coll.getClass().equals(RuleBasedCollator.class)) throw new BaseXException(
         "Invalid collator: %.", coll.getClass().getName());
+    final RuleBasedCollator rbc = (RuleBasedCollator) coll;
 
     if(contains(VERSION)) {
       final String v = get(VERSION);
       try {
-        final Class<?> vc = find("com.ibm.icu.util.VersionInfo");
-        final Object vi = invoke(method(vc, "getInstance", String.class), null, v);
-        final Object vic = invoke(method(RBC, "getUCAVersion"), coll);
-        if(vi == null || vic == null || ((Comparable<Object>) vi).compareTo(vic) > 0)
+        final VersionInfo vi = VersionInfo.getInstance(v);
+        final VersionInfo vic = rbc.getUCAVersion();
+        if((vi == null || vic == null || vi.compareTo(vic) > 0) && !fallback)
           throw error(VERSION);
       } catch(final IllegalArgumentException ex) {
         Util.debug(ex);
-        throw new BaseXException("Version not supported: %.", v);
+        if(!fallback) throw new BaseXException("Version not supported: %.", v);
       }
     }
 
     if(contains(STRENGTH)) {
       final String v = get(STRENGTH);
-      final int s;
-      if(eq(v, "primary", "1")) s = 0;         // Collator.PRIMARY
-      else if(eq(v, "secondary", "2")) s = 1;  // Collator.SECONDARY
-      else if(eq(v, "tertiary", "3")) s = 2;   // Collator.TERTIARY
-      else if(eq(v, "quaternary", "4")) s = 3; // Collator.QUATERNARY
-      else if(eq(v, "identical", "5")) s = 15; // Collator.IDENTICAL
-      else throw error(STRENGTH);
-      invoke(method(RBC, "setStrength", int.class), coll, s);
+      final Integer s;
+      if(eq(v, "primary", "1")) s = Collator.PRIMARY;
+      else if(eq(v, "secondary", "2")) s = Collator.SECONDARY;
+      else if(eq(v, "tertiary", "3")) s = Collator.TERTIARY;
+      else if(eq(v, "quaternary", "4")) s = Collator.QUATERNARY;
+      else if(eq(v, "identical", "5")) s = Collator.IDENTICAL;
+      else s = null;
+      if(s != null) rbc.setStrength(s);
+      else if(!fallback) throw error(STRENGTH);
     }
 
     if(contains(ALTERNATE)) {
       final String v = get(ALTERNATE);
-      final boolean b;
-      if(eq(v, "non-ignorable")) b = false;
-      else if(eq(v, "shifted", "blanked")) b = true;
-      else throw error(ALTERNATE);
-      invoke(method(RBC, "setAlternateHandlingShifted", boolean.class), coll, b);
-      if(eq(v, "blanked") && eq(get(STRENGTH), "quaternary")) {
-        invoke(method(RBC, "setStrength", int.class), coll, 2); // Collator.TERTIARY
-      }
+      final Boolean b;
+      if(eq(v, "non-ignorable")) b = Boolean.FALSE;
+      else if(eq(v, "shifted", "blanked")) b = Boolean.TRUE;
+      else b = null;
+      if(b != null) {
+        rbc.setAlternateHandlingShifted(b);
+        if(eq(v, "blanked") && rbc.getStrength() == Collator.QUATERNARY) {
+          rbc.setStrength(Collator.TERTIARY);
+        }
+      } else if(!fallback) throw error(ALTERNATE);
     }
 
     if(contains(BACKWARDS)) {
-      invoke(method(RBC, "setFrenchCollation", boolean.class), coll, yesNo(BACKWARDS));
+      Boolean b = yesNo(BACKWARDS);
+      if(b != null) rbc.setFrenchCollation(b);
     }
 
     if(contains(NORMALIZATION)) {
-      invoke(method(RBC, "setDecomposition", int.class), coll, yesNo(NORMALIZATION) ? 17 : 16);
+      Boolean n = yesNo(NORMALIZATION);
+      if(n != null) {
+        rbc.setDecomposition(n ? Collator.CANONICAL_DECOMPOSITION : Collator.NO_DECOMPOSITION);
+      }
     }
 
     if(contains(CASELEVEL)) {
-      invoke(method(RBC, "setCaseLevel", boolean.class), coll, yesNo(CASELEVEL));
+      Boolean c = yesNo(CASELEVEL);
+      if(c != null) rbc.setCaseLevel(c);
     }
 
     if(contains(CASEFIRST)) {
-      final String v = get(CASEFIRST), f;
+      final String v = get(CASEFIRST);
       switch(v) {
-        case "upper": f = "setUpperCaseFirst"; break;
-        case "lower": f = "setLowerCaseFirst"; break;
-        default: throw error(CASEFIRST);
+        case "upper": rbc.setUpperCaseFirst(true); break;
+        case "lower": rbc.setLowerCaseFirst(true); break;
+        default: if(!fallback) throw error(CASEFIRST);
       }
-      invoke(method(RBC, f, boolean.class), coll, true);
     }
 
     if(contains(NUMERIC)) {
-      invoke(method(RBC, "setNumericCollation", boolean.class), coll, yesNo(NUMERIC));
+      Boolean n = yesNo(NUMERIC);
+      if(n != null) rbc.setNumericCollation(n);
     }
 
     if(contains(REORDER)) {
       final String v = get(REORDER);
       final IntList list = new IntList();
-      final Method uscript = method(find("com.ibm.icu.lang.UScript"), "getCode", String.class);
       for(final String code : split(v, ',')) {
         switch(code) {
-          case "space":    list.add(0x1000); break;
-          case "punct":    list.add(0x1001); break;
-          case "symbol":   list.add(0x1002); break;
-          case "currency": list.add(0x1003); break;
-          case "digit":    list.add(0x1004); break;
+          case "space":    list.add(Collator.ReorderCodes.SPACE);       break;
+          case "punct":    list.add(Collator.ReorderCodes.PUNCTUATION); break;
+          case "symbol":   list.add(Collator.ReorderCodes.SYMBOL);      break;
+          case "currency": list.add(Collator.ReorderCodes.CURRENCY);    break;
+          case "digit":    list.add(Collator.ReorderCodes.DIGIT);       break;
           default:
-            final int[] c = code.length() == 4 ? (int[]) invoke(uscript, null, code) : null;
+            final int[] c = code.length() == 4 ? UScript.getCode(code) : null;
             if(c != null) list.add(c[0]);
-            else throw error(REORDER);
+            else if(!fallback) throw error(REORDER);
             break;
         }
       }
-      if(!list.isEmpty()) invoke(method(RBC, "setReorderCodes", int[].class), coll, list.finish());
+      if(!list.isEmpty()) rbc.setReorderCodes(list.finish());
     }
 
-    return new UCACollation((Comparator<Object>) coll);
+    return new UCACollation(rbc);
   }
 
   /**
-   * Returns the boolean value of a yes/no option.
+   * Returns the boolean value of a yes/no option, or {@code null}, if not recognized and fallback
+   * is allowed.
    * @param option option
    * @return result
    * @throws BaseXException database exception
    */
-  private boolean yesNo(final StringOption option) throws BaseXException {
+  private Boolean yesNo(final StringOption option) throws BaseXException {
     final String v = get(option);
-    if(v.equals(Text.YES)) return true;
-    if(v.equals(Text.NO)) return false;
-    throw error(option);
+    if(v.equals(Text.YES)) return Boolean.TRUE;
+    if(v.equals(Text.NO)) return Boolean.FALSE;
+    if(!fallback) throw error(option);
+    return null;
   }
 }

--- a/basex-core/src/test/java/org/basex/util/options/OptionsTest.java
+++ b/basex-core/src/test/java/org/basex/util/options/OptionsTest.java
@@ -26,7 +26,7 @@ public final class OptionsTest extends SandboxTest {
   /** Initializes various options. */
   @AfterAll public static void init() {
     // instantiate options at least once
-    new UCAOptions();
+    new UCAOptions(false);
     new CsvOptions();
     new CsvParserOptions();
     new CsvSerialOptions();


### PR DESCRIPTION
These changes fix the test failures that came up after adding ICU4J to the classpath, in tests with name prefix `UCA`.

The failure count for those tests reduces to 1 without and to 3 with ICU4J. The remaining failures are

- `UCA-params-034`: Unknown function: `fn:collation-key`. This occurs in either variant.
- `UCA-reorder-codes-009`, `UCA-reorder-codes-010`: these occur **with** ICU4J, and IMO they trigger a bug in ICU4J when using `RuleBasedCollator.setReorderCodes`. I made some experiments by setting the codes in a more explicit fashion, but did not manage to get it working consistently. This might be the same bug that Saxon is referring to [in its documentation of `reorder`](https://www.saxonica.com/documentation12/index.html#!localization/unicode-collation-algorithm).