### PR TITLE
Fix millisecs tests

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -627,6 +627,8 @@ public enum QueryError {
   /** Error code. */
   OPTAFTER_X(FODF, 1310, "Optional digit sign follows mandatory digit signs: '%'."),
   /** Error code. */
+  OPTBEFORE_X(FODF, 1310, "Mandatory digit sign follows optional digit signs: '%'."),
+  /** Error code. */
   INVGROUP_X(FODF, 1310, "Invalid position of grouping separator signs: '%'."),
   /** Error code. */
   DIFFMAND_X(FODF, 1310, "Mandatory digits is not of the same group: '%'."),

--- a/basex-core/src/main/java/org/basex/query/util/format/DateFormat.java
+++ b/basex-core/src/main/java/org/basex/query/util/format/DateFormat.java
@@ -22,10 +22,12 @@ final class DateFormat extends FormatParser {
    * Constructor.
    * @param picture variable marker (info picture)
    * @param def default presentation modifier
+   * @param frac fractional seconds flag
    * @param info input info (can be {@code null})
    * @throws QueryException query exception
    */
-  DateFormat(final byte[] picture, final byte[] def, final InputInfo info) throws QueryException {
+  DateFormat(final byte[] picture, final byte[] def, final boolean frac, final InputInfo info)
+      throws QueryException {
     super(info);
 
     // split variable marker
@@ -44,7 +46,7 @@ final class DateFormat extends FormatParser {
 
     // choose first character and case
     try {
-      finish(pres.length == 0 ? def : presentation(pres, def, true));
+      finish(pres.length == 0 ? def : presentation(pres, def, true, frac));
     } catch(final QueryException ex) {
       throw INVFDPATTERN_X.get(info, ex.getLocalizedMessage());
     }

--- a/basex-core/src/main/java/org/basex/query/util/format/FormatParser.java
+++ b/basex-core/src/main/java/org/basex/query/util/format/FormatParser.java
@@ -57,10 +57,11 @@ abstract class FormatParser extends FormatUtil {
    * @param pic picture
    * @param def default token
    * @param date date flag
+   * @param frac fractional seconds flag
    * @return presentation modifier
    * @throws QueryException query exception
    */
-  byte[] presentation(final byte[] pic, final byte[] def, final boolean date)
+  byte[] presentation(final byte[] pic, final byte[] def, final boolean date, final boolean frac)
       throws QueryException {
 
     // find primary format
@@ -93,17 +94,20 @@ abstract class FormatParser extends FormatUtil {
     tp.reset();
     boolean gss = true;
     boolean mds = false;
+    boolean ods = false;
     while(tp.more()) {
       ch = tp.next();
       final int d = zeroes(ch);
       if(d != -1) {
         // mandatory-digit-sign
+        if(ods && frac) throw OPTBEFORE_X.get(info, pic);
         if(first != d) throw DIFFMAND_X.get(info, pic);
         mds = true;
         gss = false;
       } else if(ch == '#') {
         // optional-digit-sign
-        if(mds) throw OPTAFTER_X.get(info, pic);
+        if(mds && !frac) throw OPTAFTER_X.get(info, pic);
+        ods = true;
         gss = false;
       } else if(!Character.isLetter(ch)) {
         // grouping-separator-sign

--- a/basex-core/src/main/java/org/basex/query/util/format/IntFormat.java
+++ b/basex-core/src/main/java/org/basex/query/util/format/IntFormat.java
@@ -48,7 +48,7 @@ public final class IntFormat extends FormatParser {
 
     final byte[] pres = substring(picture, rc + 1, sc == -1 ? picture.length : sc);
     if(pres.length == 0) throw PICEMPTY.get(info, picture);
-    finish(presentation(pres, ONE, false));
+    finish(presentation(pres, ONE, false, false));
     if(sc == -1) return;
 
     // parses the format modifier

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -806,6 +806,9 @@ public final class FnModuleTest extends SandboxTest {
         "America/New_York"), "07:00:00-05:00");
     query(func.args(" xs:time('12:00:00Z')", "[H01]:[m01]:[s01][Z]", " ()", " ()",
         "Asia/Kolkata"), "17:30:00+05:30");
+    query(func.args(" xs:time('12:01:01.123')", "[f99#]"), "123");
+    query(func.args(" xs:time('12:01:01.133')", "[f,2-4]"), "133");
+    query(func.args(" xs:time('12:01:01.135')", "[f00'0]"), "13'5");
   }
 
   /** Test method. */


### PR DESCRIPTION
These changes fix 10 QT4 test cases with name prefix `millisecs` that used to fail before.