### PR TITLE
Add calculation of parent groups in regexes

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/FnReplace.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnReplace.java
@@ -81,7 +81,7 @@ public final class FnReplace extends RegEx {
             s = ++i;
             if(i < sl && Character.isDigit(string.charAt(i))) i++;
             final int n = Integer.parseInt(string.substring(s, i));
-            if(n <= regExpr.groups) sb.append('$').append(n);
+            if(n <= matcher.groupCount()) sb.append('$').append(n);
             s = i;
           } else {
             sb.append(string, s, i + 1);

--- a/basex-core/src/main/java/org/basex/query/func/fn/RegEx.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/RegEx.java
@@ -4,6 +4,7 @@ import static java.util.regex.Pattern.*;
 import static org.basex.query.QueryError.*;
 import static org.basex.util.Token.*;
 
+import java.util.*;
 import java.util.regex.*;
 
 import org.basex.query.*;
@@ -31,9 +32,27 @@ abstract class RegEx extends StandardFunc {
    */
   static class RegExpr {
     /** Pattern. */
-    Pattern pattern;
-    /** Number of groups. */
-    int groups;
+    final Pattern pattern;
+    /** Parent group id's of capturing groups. */
+    private int[] parentGroups;
+
+    /**
+     * Constructor.
+     * @param pattern pattern
+     */
+    RegExpr(final Pattern pattern) {
+      this.pattern = pattern;
+      parentGroups = null;
+    }
+
+    /**
+     * Returns the parent group id's of capturing groups.
+     * @return parent group id's.
+     */
+    int[] getParentGroups() {
+      if(parentGroups == null) parentGroups = GroupScanner.parentGroups(pattern.pattern());
+      return parentGroups;
+    }
   }
 
   /**
@@ -108,7 +127,6 @@ abstract class RegEx extends StandardFunc {
     try {
       // Java syntax, literal query: no need to change anything
       final Pattern pattern;
-      int groups = 0;
       if(java || (flags & LITERAL) != 0) {
         pattern = Pattern.compile(string(regex), flags);
       } else {
@@ -124,17 +142,155 @@ abstract class RegEx extends StandardFunc {
             Pattern.compile(pattern.pattern());
           if(p.matcher("").matches()) throw REGEMPTY_X.get(info, string);
         }
-        groups = parser.groups();
       }
 
-      final RegExpr regExpr = new RegExpr();
-      regExpr.pattern = pattern;
-      regExpr.groups = groups;
-      return regExpr;
+      return new RegExpr(pattern);
 
     } catch(final PatternSyntaxException | ParseException | TokenMgrError ex) {
       Util.debug(ex);
       throw REGINVALID_X.get(info, regex);
     }
+  }
+
+  /**
+   * Analyze the nesting of capturing groups in a Java regular expression.
+   */
+  protected static final class GroupScanner {
+    /** The pattern. */
+    private final String pattern;
+    /** Pattern length. */
+    private final int len;
+    /** Current position. */
+    private int pos;
+    /** Length of most recent code point. */
+    private int chrCount;
+
+    /** Constructor.
+     * @param pattern a Java regular expression.
+     */
+    private GroupScanner(final String pattern) {
+      this.pattern = pattern;
+      len = pattern.length();
+      pos = 0;
+    }
+
+    /**
+     * Find the parent groups of capturing groups in a Java regular expression.
+     * @param pattern the regular expression.
+     * @return an array indicating the parent group id for each capturing group, where element i
+     * contains the parent group id of capturing group i+1.
+     */
+    public static int[] parentGroups(final String pattern) {
+      final GroupScanner gnd = new GroupScanner(pattern);
+      final Stack<Integer> open = new Stack<>();
+      open.push(0);
+      int[] parentGroups = new int[0];
+      boolean quoted = false;
+      int classLevel = 0;
+      for(;;) {
+        switch(gnd.nxtToken()) {
+          case EOP:
+            return parentGroups;
+          case LBRACKET:
+            if(!quoted) ++classLevel;
+            break;
+          case RBRACKET:
+            if(!quoted) --classLevel;
+            break;
+          case LQUOTE:
+            if(classLevel == 0) quoted = true;
+            break;
+          case RQUOTE:
+            if(classLevel == 0) quoted = false;
+            break;
+          case CAPT_LPAREN:
+            if(!quoted && classLevel == 0) {
+              parentGroups = Arrays.copyOf(parentGroups, parentGroups.length + 1);
+              parentGroups[parentGroups.length - 1] = open.peek();
+              open.push(parentGroups.length);
+            }
+            break;
+          case LPAREN:
+            if(!quoted && classLevel == 0) open.push(open.peek());
+            break;
+          case RPAREN:
+            if(!quoted && classLevel == 0) open.pop();
+            break;
+          default:
+        }
+      }
+    }
+
+    /**
+     * Return the next token.
+     * @return next token
+     */
+    private Token nxtToken() {
+      switch (nxtCp()) {
+        case -1: return Token.EOP;
+        case ']': return Token.RBRACKET;
+        case '[': return Token.LBRACKET;
+        case ')': return Token.RPAREN;
+        case '\\':
+          switch (nxtCp()) {
+            case -1: return Token.EOP;
+            case 'Q': return Token.LQUOTE;
+            case 'E': return Token.RQUOTE;
+            default: return Token.OTHER;
+          }
+        case '(':
+          switch(nxtCp()) {
+            case '?':
+              switch(nxtCp()) {
+                case '<': return Token.CAPT_LPAREN;
+                default:
+                  reset();
+                  return Token.LPAREN;
+              }
+            default:
+              reset();
+              return Token.CAPT_LPAREN;
+          }
+        default: return Token.OTHER;
+      }
+    }
+
+    /**
+     * Fetch the next code point.
+     * @return the next code point.
+     */
+    private int nxtCp() {
+      final int cp;
+      if(pos < len) {
+        cp = pattern.codePointAt(pos);
+        chrCount = Character.charCount(cp);
+        pos += chrCount;
+      }
+      else {
+        cp = -1;
+        chrCount = 0;
+      }
+      return cp;
+    }
+
+    /**
+     * Reset current position to before the most recent code point.
+     */
+    private void reset() {
+      pos -= chrCount;
+    }
+
+    /** Relevant token types. */
+    private enum Token {
+      /** End of pattern.                         */ EOP,
+      /** Capturing group's left parenthesis.     */ CAPT_LPAREN,
+      /** Non-capturing group's left parenthesis. */ LPAREN,
+      /** Right parenthesis.                      */ RPAREN,
+      /** Left square bracket.                    */ LBRACKET,
+      /** Right square bracket.                   */ RBRACKET,
+      /** Left quote.                             */ LQUOTE,
+      /** Right quote.                            */ RQUOTE,
+      /** Anything else.                          */ OTHER,
+    };
   }
 }

--- a/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParser.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParser.java
@@ -46,14 +46,6 @@ public class RegExParser implements RegExParserConstants {
     multiLine = multi;
   }
 
-  /**
-   * Returns the number of parsed groups.
-   * @return number of groups
-   */
-  final public int groups() {
-    return groups;
-  }
-
 /**
    * Root production.
    * @return expression
@@ -634,75 +626,7 @@ cp = Escape.getCp(token.image);
     finally { jj_save(3, xla); }
   }
 
-  private boolean jj_3R_charOrEsc_360_7_13()
- {
-    if (jj_scan_token(SINGLE_ESC)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_charRange_337_7_8()
- {
-    if (jj_3R_charOrEsc_359_5_10()) return true;
-    if (jj_scan_token(CHAR)) return true;
-    if (jj_3R_charOrEsc_359_5_10()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_charOrEsc_359_7_12()
- {
-    if (jj_3R_XmlChar_372_5_11()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_charRange_337_5_6()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    jj_lookingAhead = true;
-    jj_semLA = getToken(2).kind == CHAR && "-".equals(getToken(2).image) && getToken(3).kind != BR_CLOSE;
-    jj_lookingAhead = false;
-    if (!jj_semLA || jj_3R_charRange_337_7_8()) {
-    jj_scanpos = xsp;
-    if (jj_3R_charRange_342_7_9()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_charOrEsc_359_5_10()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_charOrEsc_359_7_12()) {
-    jj_scanpos = xsp;
-    if (jj_3R_charOrEsc_360_7_13()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3_2()
- {
-    if (jj_3R_posCharGroup_320_5_5()) return true;
-    return false;
-  }
-
-  private boolean jj_3_1()
- {
-    if (jj_scan_token(DIGIT)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_XmlChar_372_5_11()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(12)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(13)) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_posCharGroup_321_7_7()
+  private boolean jj_3R_posCharGroup_313_7_7()
  {
     Token xsp;
     xsp = jj_scanpos;
@@ -718,7 +642,7 @@ cp = Escape.getCp(token.image);
 
   private boolean jj_3_3()
  {
-    if (jj_3R_charRange_337_5_6()) return true;
+    if (jj_3R_charRange_329_5_6()) return true;
     return false;
   }
 
@@ -728,24 +652,92 @@ cp = Escape.getCp(token.image);
     xsp = jj_scanpos;
     if (jj_3_3()) {
     jj_scanpos = xsp;
-    if (jj_3R_posCharGroup_321_7_7()) return true;
+    if (jj_3R_posCharGroup_313_7_7()) return true;
     }
     return false;
   }
 
-  private boolean jj_3R_charRange_342_7_9()
+  private boolean jj_3R_charRange_334_7_9()
  {
-    if (jj_3R_XmlChar_372_5_11()) return true;
+    if (jj_3R_XmlChar_364_5_11()) return true;
     return false;
   }
 
-  private boolean jj_3R_posCharGroup_320_5_5()
+  private boolean jj_3R_posCharGroup_312_5_5()
  {
     Token xsp;
     if (jj_3_4()) return true;
     while (true) {
       xsp = jj_scanpos;
       if (jj_3_4()) { jj_scanpos = xsp; break; }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_charOrEsc_352_7_13()
+ {
+    if (jj_scan_token(SINGLE_ESC)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_charRange_329_7_8()
+ {
+    if (jj_3R_charOrEsc_351_5_10()) return true;
+    if (jj_scan_token(CHAR)) return true;
+    if (jj_3R_charOrEsc_351_5_10()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_charOrEsc_351_7_12()
+ {
+    if (jj_3R_XmlChar_364_5_11()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_charRange_329_5_6()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    jj_lookingAhead = true;
+    jj_semLA = getToken(2).kind == CHAR && "-".equals(getToken(2).image) && getToken(3).kind != BR_CLOSE;
+    jj_lookingAhead = false;
+    if (!jj_semLA || jj_3R_charRange_329_7_8()) {
+    jj_scanpos = xsp;
+    if (jj_3R_charRange_334_7_9()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_charOrEsc_351_5_10()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_charOrEsc_351_7_12()) {
+    jj_scanpos = xsp;
+    if (jj_3R_charOrEsc_352_7_13()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3_2()
+ {
+    if (jj_3R_posCharGroup_312_5_5()) return true;
+    return false;
+  }
+
+  private boolean jj_3_1()
+ {
+    if (jj_scan_token(DIGIT)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_XmlChar_364_5_11()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(12)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(13)) return true;
     }
     return false;
   }

--- a/basex-core/src/main/javacc/regex.jj
+++ b/basex-core/src/main/javacc/regex.jj
@@ -53,14 +53,6 @@ public class RegExParser {
     dotAll = all;
     multiLine = multi;
   }
-
-  /**
-   * Returns the number of parsed groups.
-   * @return number of groups
-   */
-  final public int groups() {
-    return groups;
-  }
 }
 
 PARSER_END(RegExParser)

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -4,8 +4,11 @@ import static org.basex.query.QueryError.*;
 import static org.basex.query.func.Function.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.*;
+
 import org.basex.*;
 import org.basex.query.expr.*;
+import org.basex.query.expr.List;
 import org.basex.query.expr.constr.*;
 import org.basex.query.expr.gflwor.*;
 import org.basex.query.expr.path.*;
@@ -147,6 +150,16 @@ public final class FnModuleTest extends SandboxTest {
   @Test public void analyzeString() {
     final Function func = ANALYZE_STRING;
     query(func.args("a", "", "j") + "//fn:non-match/text()", "a");
+
+    for(String opt : Arrays.asList(" ()", "j")) {
+      query(func.args("banana", "(b)(x?)", opt), "<analyze-string-result xmlns="
+          + "\"http://www.w3.org/2005/xpath-functions\"><match><group nr=\"1\">b</group>"
+          + "<group nr=\"2\"/></match><non-match>anana</non-match></analyze-string-result>");
+      query(func.args("banana", "(b(x?))", opt), "<analyze-string-result xmlns="
+          + "\"http://www.w3.org/2005/xpath-functions\"><match><group nr=\"1\">b<group nr=\"2\"/>"
+          + "</group></match><non-match>anana</non-match></analyze-string-result>");
+    }
+
     error(func.args("a", ""), REGEMPTY_X);
   }
 
@@ -1788,6 +1801,8 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args("bab", "a", " action := function($_, $__) { }"), "bb");
     query(func.args("bab", "(a)", " action := function($_, $__) { }"), "bb");
     query(func.args("bab", "(a)", " action := function($_, $__) { '' }"), "bb");
+    query(func.args("abcde", "b(.)d", "$1"), "ace");
+    query(func.args("abcde", "b(.)d", "$1", "j"), "ace");
 
     error(func.args("W", ".*", " ()", " ()", " function($k, $g) { }"), REGEMPTY_X);
   }

--- a/basex-core/src/test/java/org/basex/query/func/fn/RegexTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/fn/RegexTest.java
@@ -1,0 +1,59 @@
+package org.basex.query.func.fn;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+import java.util.regex.*;
+import java.util.stream.*;
+
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+/**
+ * This class tests {@link RegEx}.
+ *
+ * @author BaseX Team 2005-24, BSD License
+ * @author Gunther Rademacher
+ */
+public class RegexTest {
+
+  /**
+   * Test.
+   * @param regex regular expression
+   * @param parentGroups expected parent group id's
+   */
+  @ParameterizedTest
+  @MethodSource
+  public void testParentGroups(final String regex, final int[] parentGroups) {
+    final int[] actualGroups = RegEx.GroupScanner.parentGroups(regex);
+    assertArrayEquals(parentGroups, actualGroups,
+        () -> "Unexpected result: " + Arrays.toString(actualGroups));
+    assertEquals(Pattern.compile(regex).matcher("").groupCount(), parentGroups.length);
+  }
+
+  /**
+   * Test arguments.
+   * @return test arguments
+   */
+  private static Stream<Arguments> testParentGroups() {
+    return Stream.of(
+        Arguments.of("(b)(x?)", new int[] {0, 0}),
+        Arguments.of("(b(x?))", new int[] {0, 1}),
+        Arguments.of("(?:((())(?:())))", new int[] {0, 1, 2, 1}),
+        Arguments.of("(([()&&[()]]))()", new int[] {0, 1, 0}),
+        Arguments.of("((\\Q()\\E))()", new int[] {0, 1, 0}),
+        Arguments.of("(?<x>())", new int[] {0, 1}),
+        Arguments.of("(?:<x>)", new int[] {}),
+        Arguments.of("^(.*?)d(.*)(?:$(?!\\s))", new int[] {0, 0}),
+        Arguments.of("^((?:aa)*)(?:X+((?:\\p{Nd}+|\\-)(?:X+(.+))?))?(?:$(?!\\s))",
+            new int[] {0, 0, 2}),
+        Arguments.of("^(?:((ab)(ac){0,2})?)(?:$(?!\\s))", new int[] {0, 1, 1}),
+        Arguments.of("^(?:[abcd&&[^d]]+)(?:$(?!\\s))", new int[] {}),
+        Arguments.of("(?:(((((boy)|(girl))[0-1][x-z]{2})?)|(man|woman)[0-1]?[y\\|n])*)(?:$(?!\\s))",
+            new int[] {0, 1, 2, 3, 4, 4, 1}),
+        Arguments.of("(((((((((((((((a)(b)))))))))))))))",
+            new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14}),
+        Arguments.of("^(?:\\-\\-((0[1-9])|(1(1|2)))\\-\\-)(?:$(?!\\s))", new int[] {0, 1, 1, 3})
+    );
+  }
+}


### PR DESCRIPTION
These changes fix QT4 test case `analyzeString-017`. This requires calculation of the parent group of a regex group, for being able to decide where to put an empty match for some group within the result of `fn:analyze-string`.

The parent group could have been calculated while parsing the regex, however when using option `j`, this does not take place. So it was implemented by a separate scan of the Java regex. This however is only done when a group matches the empty string while processing the result of `fn:analyze-string`.

Member `groups` of `RegExp.RegExpr` has been dropped, because the same information is available from `Matcher.groupCount`. This change also enables proper handling of group references in `fn:replace` when using the `j` option (`groups` was not set in this case).