### PR TITLE
Fixes for failing tests with respect to function coercion

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/Expr.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Expr.java
@@ -310,8 +310,7 @@ public abstract class Expr extends ExprInfo {
    * @return function type, or {@code null} if expression yields no functions
    */
   public FuncType funcType() {
-    final Type type = seqType().type;
-    return type instanceof FuncType ? (FuncType) type : null;
+    return seqType().type.funcType();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/expr/Lookup.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Lookup.java
@@ -45,8 +45,9 @@ public final class Lookup extends Arr {
     if(is == 0) return cc.replaceWith(this, inputs);
 
     // skip optimizations if input may yield other items than maps or arrays
-    final FuncType ft = inputs.funcType();
-    final boolean map = ft instanceof MapType, array = ft instanceof ArrayType;
+    final SeqType st = inputs.seqType();
+    final Type tp = st.type;
+    final boolean map = tp instanceof MapType, array = tp instanceof ArrayType;
     if(!(map || array)) return this;
 
     final Expr expr = opt(cc);
@@ -54,7 +55,7 @@ public final class Lookup extends Arr {
 
     // derive type from input expression
     final Expr keys = exprs[1];
-    final SeqType st = ft.declType, kt = keys.seqType();
+    final SeqType kt = keys.seqType();
     Occ occ = st.occ;
     if(inputs.size() != 1 || keys == WILDCARD || !kt.one() || kt.mayBeArray()) {
       // key is wildcard, or expressions yield no single item
@@ -63,7 +64,7 @@ public final class Lookup extends Arr {
       // map lookup may result in empty sequence
       occ = occ.union(Occ.ZERO);
     }
-    exprType.assign(st.type, occ);
+    exprType.assign(tp, occ);
 
     return this;
   }
@@ -81,7 +82,7 @@ public final class Lookup extends Arr {
 
     final long is = input.size();
     final QueryBiFunction<Expr, Expr, Expr> rewrite = (in, arg) ->
-      keys == WILDCARD ? cc.function(input.funcType() instanceof MapType ?
+      keys == WILDCARD ? cc.function(input.seqType().type instanceof MapType ?
       Function._MAP_VALUES : Function._ARRAY_VALUES, info, in) :
       new DynFuncCall(info, in, arg).optimize(cc);
 

--- a/basex-core/src/main/java/org/basex/query/expr/Lookup.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Lookup.java
@@ -45,8 +45,7 @@ public final class Lookup extends Arr {
     if(is == 0) return cc.replaceWith(this, inputs);
 
     // skip optimizations if input may yield other items than maps or arrays
-    final SeqType st = inputs.seqType();
-    final Type tp = st.type;
+    final Type tp = inputs.seqType().type;
     final boolean map = tp instanceof MapType, array = tp instanceof ArrayType;
     if(!(map || array)) return this;
 
@@ -56,6 +55,7 @@ public final class Lookup extends Arr {
     // derive type from input expression
     final Expr keys = exprs[1];
     final SeqType kt = keys.seqType();
+    final SeqType st = map ? ((MapType) tp).valueType : ((ArrayType) tp).memberType;
     Occ occ = st.occ;
     if(inputs.size() != 1 || keys == WILDCARD || !kt.one() || kt.mayBeArray()) {
       // key is wildcard, or expressions yield no single item
@@ -64,7 +64,7 @@ public final class Lookup extends Arr {
       // map lookup may result in empty sequence
       occ = occ.union(Occ.ZERO);
     }
-    exprType.assign(tp, occ);
+    exprType.assign(st.type, occ);
 
     return this;
   }

--- a/basex-core/src/main/java/org/basex/query/func/DynFuncCall.java
+++ b/basex-core/src/main/java/org/basex/query/func/DynFuncCall.java
@@ -79,8 +79,7 @@ public final class DynFuncCall extends FuncCall {
       if(!sc().mixUpdates && !updating && ft.anns.contains(Annotation.UPDATING)) {
         throw FUNCUP_X.get(info, func);
       }
-      final SeqType dt = ft.declType;
-      exprType.assign(ft instanceof MapType ? dt.union(Occ.ZERO) : dt);
+      exprType.assign(ft.declType);
     }
 
     if(func instanceof XQData) {

--- a/basex-core/src/main/java/org/basex/query/func/StandardFunc.java
+++ b/basex-core/src/main/java/org/basex/query/func/StandardFunc.java
@@ -77,7 +77,7 @@ public abstract class StandardFunc extends Arr {
 
     // pre-evaluate if arguments are values and not too large
     final SeqType st = definition.seqType;
-    return allAreValues(st.occ.max > 1 || st.type instanceof FuncType) && isSimple()
+    return allAreValues(st.occ.max > 1 || st.type instanceof FType) && isSimple()
         ? cc.preEval(this) : this;
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayAppend.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayAppend.java
@@ -29,7 +29,7 @@ public final class ArrayAppend extends ArrayFn {
 
     final Type type = array.seqType().type;
     if(type instanceof ArrayType) {
-      final SeqType dt = ((ArrayType) type).declType.union(add.seqType());
+      final SeqType dt = ((ArrayType) type).memberType.union(add.seqType());
       exprType.assign(ArrayType.get(dt));
     }
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayFilter.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayFilter.java
@@ -35,7 +35,7 @@ public final class ArrayFilter extends ArrayFn {
 
     final Type type = array.seqType().type;
     if(type instanceof ArrayType) {
-      arg(1, arg -> refineFunc(arg, cc, SeqType.BOOLEAN_O, ((ArrayType) type).declType,
+      arg(1, arg -> refineFunc(arg, cc, SeqType.BOOLEAN_O, ((ArrayType) type).memberType,
           SeqType.INTEGER_O));
       exprType.assign(type);
     }

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayFlatten.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayFlatten.java
@@ -82,7 +82,7 @@ public final class ArrayFlatten extends ArrayFn {
    * @return result type
    */
   private static Type type(final Type type) {
-    return type instanceof ArrayType ? type(((ArrayType) type).declType.type) : type;
+    return type instanceof ArrayType ? type(((ArrayType) type).memberType.type) : type;
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayFoot.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayFoot.java
@@ -23,7 +23,7 @@ public final class ArrayFoot extends ArrayFn {
   @Override
   protected Expr opt(final CompileContext cc) {
     final Type type = arg(0).seqType().type;
-    if(type instanceof ArrayType) exprType.assign(((ArrayType) type).declType);
+    if(type instanceof ArrayType) exprType.assign(((ArrayType) type).memberType);
     return this;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayForEach.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayForEach.java
@@ -35,7 +35,7 @@ public final class ArrayForEach extends ArrayFn {
 
     final Type type = array.seqType().type;
     if(type instanceof ArrayType) {
-      arg(1, arg -> refineFunc(arg, cc, SeqType.ITEM_ZM, ((ArrayType) type).declType,
+      arg(1, arg -> refineFunc(arg, cc, SeqType.ITEM_ZM, ((ArrayType) type).memberType,
           SeqType.INTEGER_O));
     }
 

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayForEachPair.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayForEachPair.java
@@ -40,7 +40,7 @@ public final class ArrayForEachPair extends ArrayFn {
     final Type type1 = array1.seqType().type, type2 = array2.seqType().type;
     if(type1 instanceof ArrayType && type2 instanceof ArrayType) {
       arg(2, arg -> refineFunc(arg, cc, SeqType.ITEM_ZM,
-          ((ArrayType) type1).declType, ((ArrayType) type2).declType, SeqType.INTEGER_O));
+          ((ArrayType) type1).memberType, ((ArrayType) type2).memberType, SeqType.INTEGER_O));
     }
 
     // assign type after coercion (expression might have changed)

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayGet.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayGet.java
@@ -32,7 +32,7 @@ public final class ArrayGet extends StandardFunc {
     // combine result type with return type of fallback function
     final Type type = array.seqType().type;
     if(type instanceof ArrayType) {
-      SeqType st = ((ArrayType) type).declType;
+      SeqType st = ((ArrayType) type).memberType;
       if(defined(2)) {
         final FuncType ft = arg(2).funcType();
         if(ft != null) st = st.union(ft.declType);

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayHead.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayHead.java
@@ -23,7 +23,7 @@ public final class ArrayHead extends ArrayFn {
   @Override
   protected Expr opt(final CompileContext cc) {
     final Type type = arg(0).seqType().type;
-    if(type instanceof ArrayType) exprType.assign(((ArrayType) type).declType);
+    if(type instanceof ArrayType) exprType.assign(((ArrayType) type).memberType);
     return this;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayIndexWhere.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayIndexWhere.java
@@ -36,7 +36,7 @@ public final class ArrayIndexWhere extends ArrayFn {
 
     final Type type = array.seqType().type;
     if(type instanceof ArrayType) {
-      arg(1, arg -> refineFunc(arg, cc, SeqType.BOOLEAN_O, ((ArrayType) type).declType,
+      arg(1, arg -> refineFunc(arg, cc, SeqType.BOOLEAN_O, ((ArrayType) type).memberType,
           SeqType.INTEGER_O));
     }
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayInsertBefore.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayInsertBefore.java
@@ -25,7 +25,7 @@ public final class ArrayInsertBefore extends ArrayFn {
   protected ArrayInsertBefore opt(final CompileContext cc) {
     final Type type = arg(0).seqType().type;
     if(type instanceof ArrayType) {
-      final SeqType dt = ((ArrayType) type).declType.union(arg(2).seqType());
+      final SeqType dt = ((ArrayType) type).memberType.union(arg(2).seqType());
       exprType.assign(ArrayType.get(dt));
     }
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayJoin.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayJoin.java
@@ -47,7 +47,7 @@ public final class ArrayJoin extends ArrayFn {
   @Override
   protected Expr opt(final CompileContext cc) throws QueryException {
     final Expr arrays = arg(0);
-    if(arrays.funcType() instanceof ArrayType) {
+    if(arrays.seqType().type instanceof ArrayType) {
       // remove empty entries
       final Expr[] args = arrays.args();
       if(arrays instanceof List && ((Checks<Expr>) arg -> arg == XQArray.empty()).any(args)) {

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayMembers.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayMembers.java
@@ -52,8 +52,10 @@ public final class ArrayMembers extends StandardFunc {
 
   @Override
   protected Expr opt(final CompileContext cc) {
-    final FuncType ft = arg(0).funcType();
-    if(ft instanceof ArrayType) exprType.assign(MapType.get(AtomType.STRING, ft.declType));
+    final Type tp = arg(0).seqType().type;
+    if(tp instanceof ArrayType) {
+      exprType.assign(MapType.get(AtomType.STRING, ((ArrayType) tp).memberType));
+    }
     return this;
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayOfMembers.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayOfMembers.java
@@ -28,8 +28,8 @@ public final class ArrayOfMembers extends ArrayFn {
 
   @Override
   protected Expr opt(final CompileContext cc) {
-    final FuncType ft = arg(0).funcType();
-    if(ft instanceof MapType) exprType.assign(ArrayType.get(ft.declType));
+    final Type tp = arg(0).seqType().type;
+    if(tp instanceof MapType) exprType.assign(ArrayType.get(((MapType) tp).valueType));
     return this;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayPut.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayPut.java
@@ -26,7 +26,7 @@ public final class ArrayPut extends ArrayFn {
   protected Expr opt(final CompileContext cc) {
     final Type type = arg(0).seqType().type;
     if(type instanceof ArrayType) {
-      final SeqType dt = ((ArrayType) type).declType.union(arg(2).seqType());
+      final SeqType dt = ((ArrayType) type).memberType.union(arg(2).seqType());
       exprType.assign(ArrayType.get(dt));
     }
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/array/ArraySort.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArraySort.java
@@ -47,7 +47,8 @@ public final class ArraySort extends FnSort {
     final Type type = st.type;
     if(type instanceof ArrayType) {
       if(defined(2) && arg(2).size() == 1) {
-        arg(2, arg -> refineFunc(arg, cc, SeqType.ANY_ATOMIC_TYPE_ZM, ((ArrayType) type).declType));
+        arg(2,
+            arg -> refineFunc(arg, cc, SeqType.ANY_ATOMIC_TYPE_ZM, ((ArrayType) type).memberType));
       }
       exprType.assign(type);
     }

--- a/basex-core/src/main/java/org/basex/query/func/array/ArraySplit.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArraySplit.java
@@ -54,7 +54,7 @@ public class ArraySplit extends ArrayFn {
     final Expr array = arg(0);
     if(array == XQArray.empty()) return Empty.VALUE;
 
-    final FuncType ft = array.funcType();
+    final Type ft = array.seqType().type;
     if(ft instanceof ArrayType) exprType.assign(ft.seqType(Occ.ZERO_OR_MORE));
     return this;
   }

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayValues.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayValues.java
@@ -60,8 +60,8 @@ public class ArrayValues extends StandardFunc {
 
   @Override
   protected final Expr opt(final CompileContext cc) {
-    final FuncType ft = arg(0).funcType();
-    if(ft instanceof ArrayType) exprType.assign(ft.declType.with(Occ.ZERO_OR_MORE));
+    final Type tp = arg(0).seqType().type;
+    if(tp instanceof ArrayType) exprType.assign(((ArrayType) tp).memberType.with(Occ.ZERO_OR_MORE));
     return this;
   }
 
@@ -69,7 +69,7 @@ public class ArrayValues extends StandardFunc {
   public Expr simplifyFor(final Simplify mode, final CompileContext cc) throws QueryException {
     final Expr array = arg(0);
     final Expr expr = mode.oneOf(Simplify.STRING, Simplify.NUMBER, Simplify.DATA) &&
-        array.funcType() instanceof ArrayType ? array : this;
+        array.seqType().type instanceof ArrayType ? array : this;
     return cc.simplify(this, expr, mode);
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/client/ClientQuery.java
+++ b/basex-core/src/main/java/org/basex/query/func/client/ClientQuery.java
@@ -41,7 +41,7 @@ public final class ClientQuery extends ClientFn {
       while(cq.more()) {
         final String value = cq.next();
         final Type type = cq.type();
-        if(type instanceof FuncType) throw CLIENT_FITEM_X.get(info, value);
+        if(type instanceof FType) throw CLIENT_FITEM_X.get(info, value);
         vb.add(type.cast(value, qc, info));
       }
       return vb.value();

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnApply.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnApply.java
@@ -35,10 +35,10 @@ public class FnApply extends StandardFunc {
   protected Expr opt(final CompileContext cc) throws QueryException {
     final Expr func = arg(0), args = arg(1);
     FuncType ft = func.funcType();
-    final FuncType ftArgs = args.funcType();
+    final Type tpArgs = args.seqType().type;
 
     // try to pass on types of array argument to function item
-    if(ftArgs instanceof ArrayType) {
+    if(tpArgs instanceof ArrayType) {
       if(args instanceof XQArray) {
         // argument is a value: final types are known
         final XQArray array = (XQArray) args;
@@ -51,7 +51,7 @@ public class FnApply extends StandardFunc {
         final SeqType[] at = ft.argTypes;
         if(at != null) {
           final SeqType[] ast = new SeqType[at.length];
-          Arrays.fill(ast, ftArgs.declType);
+          Arrays.fill(ast, ((ArrayType) tpArgs).memberType);
           arg(0, arg -> refineFunc(arg, cc, SeqType.ITEM_ZM, ast));
         }
       }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnFoldLeft.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnFoldLeft.java
@@ -103,7 +103,7 @@ public class FnFoldLeft extends StandardFunc {
 
       // function argument is a single function item
       final SeqType zst = zero.seqType(), curr = array && ist.type instanceof ArrayType ?
-        ((ArrayType) ist.type).declType : ist.with(Occ.EXACTLY_ONE);
+        ((ArrayType) ist.type).memberType : ist.with(Occ.EXACTLY_ONE);
 
       // assign item type of iterated value, optimize function
       final SeqType[] types = { left ? SeqType.ITEM_ZM : curr, left ? curr : SeqType.ITEM_ZM,

--- a/basex-core/src/main/java/org/basex/query/func/map/MapEntries.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapEntries.java
@@ -50,8 +50,8 @@ public class MapEntries extends StandardFunc {
 
   @Override
   protected Expr opt(final CompileContext cc) {
-    final FuncType ft = arg(0).funcType();
-    if(ft instanceof MapType) exprType.assign(ft);
+    final Type tp = arg(0).seqType().type;
+    if(tp instanceof MapType) exprType.assign(tp);
     return this;
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/map/MapFilter.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapFilter.java
@@ -35,8 +35,8 @@ public final class MapFilter extends StandardFunc {
     final Type type = map.seqType().type;
     if(type instanceof MapType) {
       final MapType mtype = (MapType) type;
-      final SeqType declType = mtype.argTypes[0].with(Occ.EXACTLY_ONE);
-      arg(1, arg -> refineFunc(arg, cc, SeqType.BOOLEAN_O, declType, mtype.declType));
+      final SeqType declType = SeqType.get(mtype.keyType, Occ.EXACTLY_ONE);
+      arg(1, arg -> refineFunc(arg, cc, SeqType.BOOLEAN_O, declType, mtype.valueType));
       exprType.assign(type);
     }
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/map/MapForEach.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapForEach.java
@@ -58,8 +58,8 @@ public class MapForEach extends StandardFunc {
     final Type type = map.seqType().type;
     if(type instanceof MapType) {
       final MapType mtype = (MapType) type;
-      final SeqType declType = mtype.argTypes[0].with(Occ.EXACTLY_ONE);
-      arg(1, arg -> refineFunc(arg, cc, SeqType.ITEM_ZM, declType, mtype.declType));
+      final SeqType declType = SeqType.get(mtype.keyType, Occ.EXACTLY_ONE);
+      arg(1, arg -> refineFunc(arg, cc, SeqType.ITEM_ZM, declType, mtype.valueType));
     }
 
     final FuncType ft = arg(1).funcType();

--- a/basex-core/src/main/java/org/basex/query/func/map/MapGet.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapGet.java
@@ -40,7 +40,7 @@ public final class MapGet extends StandardFunc {
     // combine result type with return type of fallback function, or with empty sequence
     final Type type = map.seqType().type;
     if(type instanceof MapType) {
-      SeqType st = ((MapType) type).declType;
+      SeqType st = ((MapType) type).valueType;
       if(fallback) {
         final FuncType ft = arg(2).funcType();
         if(ft != null) st = st.union(ft.declType);

--- a/basex-core/src/main/java/org/basex/query/func/map/MapKeys.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapKeys.java
@@ -24,7 +24,7 @@ public final class MapKeys extends StandardFunc {
   @Override
   protected Expr opt(final CompileContext cc) throws QueryException {
     final Type type = arg(0).seqType().type;
-    if(type instanceof MapType) exprType.assign(((MapType) type).keyType());
+    if(type instanceof MapType) exprType.assign(((MapType) type).keyType);
     return this;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapKeysWhere.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapKeysWhere.java
@@ -29,12 +29,12 @@ public final class MapKeysWhere extends StandardFunc {
 
   @Override
   protected Expr opt(final CompileContext cc) throws QueryException {
-    final FuncType ft = arg(0).funcType();
-    if(ft instanceof MapType) {
-      final MapType mt = (MapType) ft;
-      final AtomType kt = mt.keyType();
+    final Type tp = arg(0).seqType().type;
+    if(tp instanceof MapType) {
+      final MapType mt = (MapType) tp;
+      final AtomType kt = mt.keyType;
       arg(1, arg -> refineFunc(arg, cc, SeqType.BOOLEAN_O, kt.seqType()));
-      exprType.assign(((MapType) ft).keyType());
+      exprType.assign(kt);
     }
     return this;
   }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapMerge.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapMerge.java
@@ -67,13 +67,13 @@ public final class MapMerge extends StandardFunc {
 
       // check if duplicates will be combined (if yes, adjust occurrence of return type)
       MapType mt = (MapType) st.type;
-      final SeqType dt = mt.declType;
+      final SeqType dt = mt.valueType;
       // broaden type if values may be combined
       //   map:merge((1 to 2) ! map { 1: 1 }, map { 'duplicates': 'combine' })
       if(!dt.zero() && defined(1)) {
         if(!(arg(1) instanceof Value) || toOptions(arg(1), new MergeOptions(), false, cc.qc).
             get(MergeOptions.DUPLICATES) == MergeDuplicates.COMBINE) {
-          mt = MapType.get(mt.keyType(), dt.union(Occ.ONE_OR_MORE));
+          mt = MapType.get(mt.keyType, dt.union(Occ.ONE_OR_MORE));
         }
       }
       exprType.assign(mt);

--- a/basex-core/src/main/java/org/basex/query/func/map/MapOfPairs.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapOfPairs.java
@@ -40,9 +40,9 @@ public final class MapOfPairs extends StandardFunc {
 
   @Override
   protected Expr opt(final CompileContext cc) {
-    final FuncType ft = arg(0).funcType();
-    if(ft instanceof MapType) {
-      final SeqType st = ft.declType;
+    final Type tp = arg(0).seqType().type;
+    if(tp instanceof MapType) {
+      final SeqType st = ((MapType) tp).valueType;
       final AtomType kt = st.type.atomic();
       exprType.assign(MapType.get(kt != null ? kt : AtomType.ANY_ATOMIC_TYPE, st));
     }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapPairs.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapPairs.java
@@ -21,10 +21,10 @@ public class MapPairs extends MapEntries {
 
   @Override
   protected Expr opt(final CompileContext cc) {
-    final FuncType ft = arg(0).funcType();
-    if(ft instanceof MapType) {
-      final MapType mt = (MapType) ft;
-      exprType.assign(MapType.get(AtomType.STRING, mt.declType.union(mt.keyType().seqType())));
+    final Type tp = arg(0).seqType().type;
+    if(tp instanceof MapType) {
+      final MapType mt = (MapType) tp;
+      exprType.assign(MapType.get(AtomType.STRING, mt.valueType.union(mt.keyType.seqType())));
     }
     return this;
   }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapPut.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapPut.java
@@ -41,8 +41,8 @@ public final class MapPut extends StandardFunc {
         // merge types if input is expected to have at least one entry
         if(map != XQMap.empty()) {
           final MapType mt = (MapType) type;
-          typeKey = mt.keyType().union(typeKey);
-          st = mt.declType.union(value.seqType());
+          typeKey = mt.keyType.union(typeKey);
+          st = mt.valueType.union(value.seqType());
         }
         exprType.assign(MapType.get(typeKey, st));
       }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapValues.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapValues.java
@@ -49,8 +49,8 @@ public class MapValues extends StandardFunc {
 
   @Override
   protected final Expr opt(final CompileContext cc) {
-    final FuncType ft = arg(0).funcType();
-    if(ft instanceof MapType) exprType.assign(ft.declType.with(Occ.ZERO_OR_MORE));
+    final Type tp = arg(0).seqType().type;
+    if(tp instanceof MapType) exprType.assign(((MapType) tp).valueType.with(Occ.ZERO_OR_MORE));
     return this;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/value/item/FItem.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/FItem.java
@@ -42,14 +42,8 @@ public abstract class FItem extends Item implements XQFunction {
   }
 
   @Override
-  public void refineType(final Expr expr) {
-    final FuncType t = funcType().intersect(expr.seqType().type);
-    if(t != null) type = t;
-  }
-
-  @Override
   public FuncType funcType() {
-    return (FuncType) type;
+    return type.funcType();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/value/item/FItem.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/FItem.java
@@ -48,7 +48,7 @@ public abstract class FItem extends Item implements XQFunction {
   }
 
   @Override
-  public final FuncType funcType() {
+  public FuncType funcType() {
     return (FuncType) type;
   }
 

--- a/basex-core/src/main/java/org/basex/query/value/item/FItem.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/FItem.java
@@ -87,11 +87,14 @@ public abstract class FItem extends Item implements XQFunction {
 
     // create new compilation context and variable scope
     final VarScope vs = new VarScope();
-    final Var[] vars = new Var[arity];
+    final Var[] vars = new Var[nargs];
     final Expr[] args = new Expr[arity];
     for(int a = 0; a < arity; a++) {
       vars[a] = vs.addNew(paramName(a), argTypes[a], true, qc, info);
       args[a] = new VarRef(info, vars[a]).optimize(cc);
+    }
+    for(int a = arity; a < nargs; a++) {
+      vars[a] = vs.addNew(QNm.EMPTY, argTypes[a], true, qc, info);
     }
 
     try {

--- a/basex-core/src/main/java/org/basex/query/value/item/FuncItem.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/FuncItem.java
@@ -106,6 +106,12 @@ public final class FuncItem extends FItem implements Scope {
   }
 
   @Override
+  public void refineType(final Expr exp) {
+    final Type t = funcType().intersect(exp.seqType().type);
+    if(t != null) type = t;
+  }
+
+  @Override
   public Value invokeInternal(final QueryContext qc, final InputInfo ii, final Value[] args)
       throws QueryException {
 

--- a/basex-core/src/main/java/org/basex/query/value/map/XQMap.java
+++ b/basex-core/src/main/java/org/basex/query/value/map/XQMap.java
@@ -57,8 +57,7 @@ public final class XQMap extends XQData {
 
   @Override
   public FuncType funcType() {
-    final SeqType dt = ((MapType) type).declType.union(Occ.ZERO);
-    return FuncType.get(dt, SeqType.ANY_ATOMIC_TYPE_O);
+    return ((MapType) type).funcType();
   }
 
   /**
@@ -220,6 +219,8 @@ public final class XQMap extends XQData {
     if(ft instanceof MapType) {
       kt = ((MapType) ft).keyType();
       if(kt == AtomType.ANY_ATOMIC_TYPE) kt = null;
+    } else if (ft.declType.occ.min != 0) {
+      return false;
     }
 
     SeqType dt = ft.declType;

--- a/basex-core/src/main/java/org/basex/query/value/map/XQMap.java
+++ b/basex-core/src/main/java/org/basex/query/value/map/XQMap.java
@@ -55,6 +55,12 @@ public final class XQMap extends XQData {
     return EMPTY;
   }
 
+  @Override
+  public FuncType funcType() {
+    final SeqType dt = ((MapType) type).declType.union(Occ.ZERO);
+    return FuncType.get(dt, SeqType.ANY_ATOMIC_TYPE_O);
+  }
+
   /**
    * Creates a map with a single entry.
    * @param key key
@@ -82,7 +88,10 @@ public final class XQMap extends XQData {
 
   @Override
   public void refineType(final Expr expr) {
-    if(root.size != 0) super.refineType(expr);
+    if(root.size != 0) {
+      final Type t = type.intersect(expr.seqType().type);
+      if(t != null) type = t;
+    }
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/value/type/FType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/FType.java
@@ -1,0 +1,67 @@
+package org.basex.query.value.type;
+
+import static org.basex.query.QueryError.*;
+
+import java.util.*;
+
+import org.basex.query.*;
+import org.basex.query.value.item.*;
+import org.basex.util.*;
+
+/**
+ * Abstract super class for function types.
+ * This class is inherited by {@link MapType}, {@link ArrayType}, and {@link FuncType}.
+ *
+ * @author BaseX Team 2005-24, BSD License
+ * @author Gunther Rademacher
+ */
+public abstract class FType implements Type {
+  /** Any function placeholder string. */
+  static final String[] WILDCARD = { "*" };
+
+  /** Sequence types (lazy instantiation). */
+  private EnumMap<Occ, SeqType> seqTypes;
+
+  @Override
+  public final boolean isNumber() {
+    return false;
+  }
+
+  @Override
+  public final boolean isUntyped() {
+    return false;
+  }
+
+  @Override
+  public final boolean isNumberOrUntyped() {
+    return false;
+  }
+
+  @Override
+  public final boolean isStringOrUntyped() {
+    return false;
+  }
+
+  @Override
+  public final boolean isSortable() {
+    return false;
+  }
+
+  @Override
+  public final SeqType seqType(final Occ occ) {
+    // cannot statically be instantiated due to circular dependencies
+    if(seqTypes == null) seqTypes = new EnumMap<>(Occ.class);
+    return seqTypes.computeIfAbsent(occ, o -> new SeqType(this, o));
+  }
+
+  @Override
+  public final Item cast(final Object value, final QueryContext qc, final InputInfo info)
+      throws QueryException {
+    throw FUNCCAST_X_X.get(info, this, value);
+  }
+
+  @Override
+  public final boolean nsSensitive() {
+    return false;
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/value/type/MapType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/MapType.java
@@ -73,7 +73,8 @@ public final class MapType extends FuncType {
     if(!(type instanceof FuncType) || type instanceof ArrayType) return false;
 
     final FuncType ft = (FuncType) type;
-    return declType.instanceOf(ft.declType) && (
+    final SeqType dt = type instanceof MapType ? declType : funcType().declType;
+    return dt.instanceOf(ft.declType) && (
       type instanceof MapType ? keyType().instanceOf(((MapType) type).keyType()) :
       ft.argTypes.length == 1 && ft.argTypes[0].instanceOf(SeqType.ANY_ATOMIC_TYPE_O)
     );
@@ -128,5 +129,14 @@ public final class MapType extends FuncType {
   public String toString() {
     final Object[] param = this == SeqType.MAP ? WILDCARD : new Object[] { keyType(), declType };
     return new QueryString().token(MAP).params(param).toString();
+  }
+
+  /**
+   * Returns the function type of this map type.
+   * @return function type
+   */
+  public FuncType funcType() {
+    final SeqType dt = declType.union(Occ.ZERO);
+    return FuncType.get(dt, SeqType.ANY_ATOMIC_TYPE_O);
   }
 }

--- a/basex-core/src/main/java/org/basex/query/value/type/MapType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/MapType.java
@@ -17,27 +17,32 @@ import org.basex.util.*;
  * @author BaseX Team 2005-24, BSD License
  * @author Leo Woerteler
  */
-public final class MapType extends FuncType {
+public final class MapType extends FType {
   /** Name. */
   public static final byte[] MAP = Token.token(QueryText.MAP);
+  /** Key type of the map. */
+  public final AtomType keyType;
+  /** Value types (can be {@code null}, indicating that no type was specified). */
+  public final SeqType valueType;
 
   /**
    * Constructor.
    * @param keyType key type
-   * @param declType declared return type
+   * @param valueType value type
    */
-  MapType(final AtomType keyType, final SeqType declType) {
-    super(declType, keyType.seqType());
+  MapType(final AtomType keyType, final SeqType valueType) {
+    this.keyType = keyType;
+    this.valueType = valueType;
   }
 
   /**
    * Creates a new map type.
    * @param keyType key type
-   * @param declType declared return type
+   * @param valueType value type
    * @return map type
    */
-  public static MapType get(final AtomType keyType, final SeqType declType) {
-    return declType.mapType(keyType);
+  public static MapType get(final AtomType keyType, final SeqType valueType) {
+    return valueType.mapType(keyType);
   }
 
   @Override
@@ -64,20 +69,22 @@ public final class MapType extends FuncType {
     if(this == type) return true;
     if(!(type instanceof MapType)) return false;
     final MapType mt = (MapType) type;
-    return keyType().eq(mt.keyType()) && declType.eq(mt.declType);
+    return keyType.eq(mt.keyType) && valueType.eq(mt.valueType);
   }
 
   @Override
   public boolean instanceOf(final Type type) {
     if(this == type || type.oneOf(SeqType.MAP, SeqType.FUNCTION, AtomType.ITEM)) return true;
-    if(!(type instanceof FuncType) || type instanceof ArrayType) return false;
-
-    final FuncType ft = (FuncType) type;
-    final SeqType dt = type instanceof MapType ? declType : funcType().declType;
-    return dt.instanceOf(ft.declType) && (
-      type instanceof MapType ? keyType().instanceOf(((MapType) type).keyType()) :
-      ft.argTypes.length == 1 && ft.argTypes[0].instanceOf(SeqType.ANY_ATOMIC_TYPE_O)
-    );
+    if(type instanceof MapType) {
+      final MapType mt = (MapType) type;
+      return valueType.instanceOf(mt.valueType) && keyType.instanceOf(mt.keyType);
+    }
+    if (type instanceof FuncType) {
+      final FuncType ft = type.funcType();
+      return funcType().declType.instanceOf(ft.declType) && ft.argTypes.length == 1
+          && ft.argTypes[0].instanceOf(SeqType.ANY_ATOMIC_TYPE_O);
+    }
+    return false;
   }
 
   @Override
@@ -87,37 +94,28 @@ public final class MapType extends FuncType {
 
     if(type instanceof MapType) {
       final MapType mt = (MapType) type;
-      return get(keyType().union(mt.keyType()), declType.union(mt.declType));
+      return get(keyType.union(mt.keyType), valueType.union(mt.valueType));
     }
-    return type instanceof ArrayType ? SeqType.FUNCTION :
-           type instanceof FuncType  ? type.union(this) : AtomType.ITEM;
+    return type instanceof ArrayType ? SeqType.FUNCTION
+                                     : type instanceof FuncType ? type.union(this)
+                                                                : AtomType.ITEM;
   }
 
   @Override
-  public MapType intersect(final Type type) {
+  public Type intersect(final Type type) {
     if(instanceOf(type)) return this;
-    if(type.instanceOf(this)) return (MapType) type;
+    if(type.instanceOf(this)) return type;
 
-    if(!(type instanceof FuncType) || type instanceof ArrayType) return null;
+    if(!(type instanceof MapType)) return null;
+    final MapType mt = (MapType) type;
 
-    final FuncType ft = (FuncType) type;
-    final SeqType dt = declType.intersect(ft.declType);
-    if(dt == null) return null;
+    final SeqType vt = valueType.intersect(mt.valueType);
+    if(vt == null) return null;
 
-    if(type instanceof MapType) {
-      final Type kt = keyType().intersect(((MapType) type).keyType());
-      if(kt instanceof AtomType) return get((AtomType) kt, dt);
-    }
+    final Type kt = keyType.intersect(mt.keyType);
+    if(!(kt instanceof AtomType)) return null;
 
-    return null;
-  }
-
-  /**
-   * Returns the key type.
-   * @return key type
-   */
-  public AtomType keyType() {
-    return (AtomType) argTypes[0].type;
+    return get((AtomType) kt, vt);
   }
 
   @Override
@@ -127,16 +125,18 @@ public final class MapType extends FuncType {
 
   @Override
   public String toString() {
-    final Object[] param = this == SeqType.MAP ? WILDCARD : new Object[] { keyType(), declType };
+    final Object[] param = this == SeqType.MAP ? WILDCARD : new Object[] { keyType, valueType};
     return new QueryString().token(MAP).params(param).toString();
   }
 
-  /**
-   * Returns the function type of this map type.
-   * @return function type
-   */
+  @Override
   public FuncType funcType() {
-    final SeqType dt = declType.union(Occ.ZERO);
+    final SeqType dt = valueType.union(Occ.ZERO);
     return FuncType.get(dt, SeqType.ANY_ATOMIC_TYPE_O);
+  }
+
+  @Override
+  public AtomType atomic() {
+    return null;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
@@ -467,7 +467,7 @@ public final class SeqType {
              tp == FLOAT && type.intersect(DECIMAL) != null ||
              tp == STRING && type.intersect(ANY_URI) != null;
     }
-    return st.type instanceof FuncType && type instanceof FuncType;
+    return st.type instanceof FType && type instanceof FType;
   }
 
   /**
@@ -570,7 +570,7 @@ public final class SeqType {
    * @return result of check
    */
   public boolean mayBeFunction() {
-    return !zero() && (type instanceof FuncType || ANY_ATOMIC_TYPE.instanceOf(type));
+    return !zero() && (type instanceof FType || ANY_ATOMIC_TYPE.instanceOf(type));
   }
 
   /**
@@ -628,7 +628,7 @@ public final class SeqType {
   @Override
   public String toString() {
     final TokenBuilder tb = new TokenBuilder();
-    if(!one() && type instanceof FuncType) {
+    if(!one() && type instanceof FType) {
       tb.add('(').add(typeString()).add(')');
     } else {
       tb.add(typeString());

--- a/basex-core/src/main/java/org/basex/query/value/type/Type.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/Type.java
@@ -193,6 +193,14 @@ public interface Type {
     return false;
   }
 
+  /**
+   * Returns the function type of this type, if any.
+   * @return function type, or {@code null} if type cannot represent a function
+   */
+  default FuncType funcType() {
+    return null;
+  }
+
   // PUBLIC AND STATIC METHODS ====================================================================
 
   /**

--- a/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
+++ b/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
@@ -196,7 +196,9 @@ public final class SeqTypeTest {
       // function(xs:integer) as xs:nonNegativeInteger
       f4 = FuncType.get(NON_NEGATIVE_INTEGER.seqType(), INTEGER_O).seqType(),
       // function(xs:boolean) as xs:integer
-      f5 = FuncType.get(INTEGER_O, BOOLEAN_O).seqType();
+      f5 = FuncType.get(INTEGER_O, BOOLEAN_O).seqType(),
+      // function(xs:boolean) as xs:integer?
+      f6 = FuncType.get(INTEGER_ZO, BOOLEAN_O).seqType();
 
     combine(f1, op);
     combine(f2, op);
@@ -235,7 +237,7 @@ public final class SeqTypeTest {
     combine(MAP_O, m1, MAP_O, op);
     combine(m1, INTEGER_O, ITEM_O, op);
     combine(m1, f1, f1, op);
-    combine(m1, f2, f5, op);
+    combine(m1, f2, f6, op);
     combine(m1, m2, m1, op);
     combine(m1, m3, m1, op);
     combine(m2, m4, m1, op);

--- a/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
+++ b/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
@@ -300,7 +300,9 @@ public final class SeqTypeTest {
       // function(xs:boolean) as xs:integer
       f5 = FuncType.get(INTEGER_O, BOOLEAN_O).seqType(),
       // function(xs:boolean) as xs:boolean
-      f6 = FuncType.get(BOOLEAN_O, BOOLEAN_O).seqType();
+      f6 = FuncType.get(BOOLEAN_O, BOOLEAN_O).seqType(),
+      // function(xs:boolean) as xs:integer?
+      f7 = FuncType.get(INTEGER_ZO, BOOLEAN_O).seqType();
 
     combine(f1, op);
     combine(f2, op);
@@ -345,7 +347,7 @@ public final class SeqTypeTest {
     combine(m1, m3,
         MapType.get(BOOLEAN, NON_NEGATIVE_INTEGER.seqType()).seqType(), op);
     combine(m2, m4, null, op);
-    combine(m4, f5, m4, op);
+    combine(m4, f7, m4, op);
 
     final SeqType
       // array(xs:integer)

--- a/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
@@ -2078,7 +2078,7 @@ public final class RewritingsTest extends SandboxTest {
     check("()?*", "", empty());
     check("map { 1: 2 }?*", 2, root(Int.class));
     check("[ 1 ]?*", 1, root(Int.class));
-    check("((map { 1: 'A', 'x': 'B' }) treat as function(xs:anyAtomicType) as xs:string)?1",
+    check("((map { 1: 'A', 'x': 'B' }) treat as function(xs:anyAtomicType) as xs:string?)?1",
         "A", root(Str.class));
 
     // do not pre-evaluate lookups with multiple input items

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -614,10 +614,12 @@ public final class FnModuleTest extends SandboxTest {
     check(func.args(9, " map{9:true()}"), 9);
     check(func.args(9, " map{9:false()}"), null);
     error(func.args(9, " map{9:()}"), INVCONVERT_X_X_X);
+    error(func.args(8, " map{9:true()}"), INVCONVERT_X_X_X);
 
     check(func.args(1, " [true()]"), 1);
     check(func.args(1, " [false()]"), null);
     error(func.args(1, " [()]"), INVCONVERT_X_X_X);
+    error(func.args(2, " [true()]"), ARRAYBOUNDS_X_X);
 
     inline(true);
     check(func.args(" (<a/>, <b/>)", " boolean#1"), "<a/>\n<b/>", root(List.class));


### PR DESCRIPTION
This comprises 3 commits:
- b74c63b6b2282f3475c8c9c028c9268ca3b2d473: in `XQMap.funcType`, create a separate `FuncType` for maps, that reflects a min occurrence of 0 (this fixes `xqhof21`)
- ba82cbdb846c0e14fe3188d9a96ff065a64d045a: moves the map function type creation to `MapType`, in order to use it in instance tests (this fixes `MapTest-061`, `MapTest-062`, `MapTest-066`)
- cb35628e27921c9d0ab74bc96fe655dd8d8f6b1f: make sure that a coerced function comes with all parameters, for passing subsequent arity checks (this fixes `function-literal-428`, `function-literal-430`, `function-literal-432`)