### PR TITLE
Update Markup Blitz dependency to 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
       <dependency>
         <groupId>de.bottlecaps</groupId>
         <artifactId>markup-blitz</artifactId>
-        <version>1.2</version>
+        <version>1.3</version>
         <scope>runtime</scope>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
1.3 brings a significant performance improvement and thread-safe parsing functions.