### PR TITLE
Add casting and relabeling to SeqType coercion

### DIFF
--- a/basex-core/src/main/java/org/basex/query/value/item/Uri.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/Uri.java
@@ -82,7 +82,12 @@ public final class Uri extends AStr {
   public Uri resolve(final Uri add, final InputInfo info) throws QueryException {
     if(add.value.length == 0) return this;
     try {
-      final URI base = new URI(Token.string(value)), res = new URI(Token.string(add.value));
+      final URI res = new URI(Token.string(add.value));
+      URI base = new URI(Token.string(value));
+      if("".equals(base.getPath()) && !"".equals(base.getHost())) {
+        // work around JDK-8272702, https://bugs.java.com/bugdatabase/view_bug?bug_id=8272702
+        base = new URI(Token.string(value) + "/");
+      }
       String uri = base.resolve(res).toString();
       if(uri.startsWith(IO.FILEPREF))
         uri = uri.replaceAll('^' + IO.FILEPREF + "([^/])", IO.FILEPREF + "//$1");

--- a/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
@@ -437,14 +437,15 @@ public final class SeqType {
           }
         } else if(type == DOUBLE && (tp == FLOAT || tp.instanceOf(DECIMAL))) {
           items.add(Dbl.get(item1.dbl(info)));
-        } else if(type == FLOAT && tp.instanceOf(DECIMAL)) {
+        } else if(type == FLOAT && (tp == DOUBLE || tp.instanceOf(DECIMAL))) {
           items.add(Flt.get(item1.flt(info)));
         } else if(type == STRING && item1 instanceof Uri) {
           items.add(Str.get(item1.string(info)));
         } else if(type.instanceOf(tp)
-            || type == ANY_URI && item1 instanceof Str
-            || type.instanceOf(HEX_BINARY) && item1 instanceof B64
-            || type.instanceOf(BASE64_BINARY) && item1 instanceof Hex) {
+            || type == DECIMAL && (tp == DOUBLE || tp == FLOAT)
+            || type == ANY_URI && tp.instanceOf(STRING)
+            || type == HEX_BINARY && tp == BASE64_BINARY
+            || type == BASE64_BINARY && tp == HEX_BINARY) {
           // casting and relabeling
           Item cast;
           try {

--- a/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
@@ -441,6 +441,21 @@ public final class SeqType {
           items.add(Flt.get(item1.flt(info)));
         } else if(type == STRING && item1 instanceof Uri) {
           items.add(Str.get(item1.string(info)));
+        } else if(type.instanceOf(tp)
+            || type == ANY_URI && item1 instanceof Str
+            || type.instanceOf(HEX_BINARY) && item1 instanceof B64
+            || type.instanceOf(BASE64_BINARY) && item1 instanceof Hex) {
+          // casting and relabeling
+          Item cast;
+          try {
+            cast = (Item) type.cast(item1, qc, info);
+          } catch(@SuppressWarnings("unused") final QueryException ex) {
+            cast = null;
+          }
+          if(cast == null || type.instanceOf(tp) && !cast.equal(item1, null, info)) {
+            throw typeError(item, with(EXACTLY_ONE), name, info, true);
+          }
+          items.add(cast);
         } else {
           throw typeError(item, with(EXACTLY_ONE), name, info, true);
         }

--- a/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
@@ -1006,9 +1006,11 @@ public final class RewritingsTest extends SandboxTest {
     check(wrap(1) + "coerce to xs:string", 1, root(TypeCheck.class));
     check("(1, 2) coerce to xs:double+", "1\n2",
         empty(TypeCheck.class), root(ItemSeq.class), count(Dbl.class, 2));
+    check("(-128, 127) coerce to xs:byte+", "-128\n127",
+        empty(TypeCheck.class), root(ItemSeq.class), count(Int.class, 2));
 
     error("<a/> coerce to empty-sequence()", INVCONVERT_X_X_X);
-    error("(1, 2) coerce to xs:byte+", INVCONVERT_X_X_X);
+    error("(1, 128) coerce to xs:byte+", INVCONVERT_X_X_X);
   }
 
   /** Treat and coerce, error messages. */


### PR DESCRIPTION
These changes extend `SeqType.coerce` by the new rules for coercing to `xs:anyURI`, `xs:base64Binary` and `xs:hexBinary`, as well as for relabeling.

This fixes these QT4 test cases:

- `DynamicFunctionCall-080`
- `DynamicFunctionCall-087`
- `DynamicFunctionCall-130`
- `DynamicFunctionCall-131`
- `DynamicFunctionCall-132`
- `DynamicFunctionCall-137`
- `FunctionCall-400`
- `FunctionCall-405`
- `function-call-promotion-401`
- `function-call-promotion-402`
- `function-call-promotion-404`
- `function-call-promotion-406`
- `function-call-promotion-407`
- `function-call-promotion-408`
- `function-call-promotion-409`
- `K2-FunctionProlog-5a`
- `K2-FunctionProlog-6a`

Test case `DynamicFunctionCall-130` also failed due to [JDK-8272702](https://bugs.java.com/bugdatabase/view_bug?bug_id=8272702), so a workaround for this was added to `Uri.resolve`.