### PR TITLE
Add support for coercion of typed variable bindings

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -2547,7 +2547,8 @@ public class QueryParser extends InputParser {
     final InputInfo ii = info();
     final QNm name = varName();
     final SeqType st = type != null ? type : optAsType();
-    return new Var(name, st, qc, ii);
+    final boolean coerce = type == null && st != null;
+    return new Var(name, st, qc, ii, coerce);
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/var/Var.java
+++ b/basex-core/src/main/java/org/basex/query/var/Var.java
@@ -28,15 +28,13 @@ public final class Var extends ExprInfo {
 
   /** Declared type, {@code null} if not specified. */
   public SeqType declType;
-  /** Flag for function coercion. */
+  /** Flag for coercion. */
   public boolean coerce;
   /** Stack slot ({@code -1} if unused). */
   public int slot;
 
   /** Actual type (by type inference). */
   private final ExprType exprType;
-  /** Flag for function parameters. */
-  private final boolean param;
   /** Input expression, from which the data reference and DDO flag will be requested. */
   private Expr ex;
 
@@ -46,19 +44,18 @@ public final class Var extends ExprInfo {
    * @param declType declared type, {@code null} for no check
    * @param qc query context, used for generating a variable ID
    * @param info input info (can be {@code null})
-   * @param param function parameter flag
+   * @param coerce coercion flag
    * @param slot stack slot ({@code -1} if unused)
    * @param exprType expression type (can be {@code null})
    */
   public Var(final QNm name, final SeqType declType, final QueryContext qc, final InputInfo info,
-      final boolean param, final int slot, final ExprType exprType) {
+      final boolean coerce, final int slot, final ExprType exprType) {
     this.name = name;
-    this.param = param;
     this.info = info;
     this.slot = slot;
     this.declType = declType == null || declType.eq(SeqType.ITEM_ZM) ? null : declType;
     this.exprType = exprType != null ? exprType : new ExprType(SeqType.ITEM_ZM);
-    coerce = param;
+    this.coerce = coerce;
     id = qc.varIDs++;
   }
 
@@ -79,11 +76,11 @@ public final class Var extends ExprInfo {
    * @param declType declared sequence type, {@code null} for no check
    * @param qc query context, used for generating a variable ID
    * @param info input info (can be {@code null})
-   * @param param function parameter flag
+   * @param coerce coercion flag
    */
   public Var(final QNm name, final SeqType declType, final QueryContext qc, final InputInfo info,
-      final boolean param) {
-    this(name, declType, qc, info, param, -1, null);
+      final boolean coerce) {
+    this(name, declType, qc, info, coerce, -1, null);
   }
 
   /**
@@ -92,8 +89,7 @@ public final class Var extends ExprInfo {
    * @param qc query context
    */
   public Var(final Var var, final QueryContext qc) {
-    this(var.name, var.declType, qc, var.info, var.param, -1, new ExprType(var.exprType));
-    coerce = var.coerce;
+    this(var.name, var.declType, qc, var.info, var.coerce, -1, new ExprType(var.exprType));
   }
 
   /**

--- a/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
@@ -2120,9 +2120,13 @@ public final class RewritingsTest extends SandboxTest {
     check("for $a allowing empty in () group by $a return $a", "", root(GFLWOR.class));
     check("for $a in (1 to 6) group by $g := [ $a mod 1 ] return $g", 0, root(GFLWOR.class));
     check("for $a in (1 to 6) group by $g := [] return $g", "", root(GFLWOR.class));
+    check("for $a as xs:byte in (1 to 2)[. >= 0] group by $a return $a", "1\n2",
+        root(DISTINCT_VALUES), exists(GFLWOR.class));
+    check("for $a in (1 to 2)[. >= 0] group by $a as xs:byte := $a return $a", "1\n2",
+        root(GFLWOR.class));
 
-    error("for $a as xs:byte in (1 to 2)[. >= 0] group by $a return $a", INVTREAT_X_X_X);
-    error("for $a in (1 to 2)[. >= 0] group by $a as xs:byte := $a return $a", INVTREAT_X_X_X);
+    error("for $a as xs:byte in (127 to 128)[. >= 0] group by $a return $a", FUNCCAST_X_X_X);
+    error("for $a in (127 to 128)[. >= 0] group by $a as xs:byte := $a return $a", FUNCCAST_X_X_X);
   }
 
   /** Rewrite expression range to replicate. */

--- a/basex-core/src/test/java/org/basex/query/expr/GFLWORTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/GFLWORTest.java
@@ -408,7 +408,9 @@ public final class GFLWORTest extends SandboxTest {
   @Test public void inlineLetTest() {
     check("let $x := 1 let $b := $x + 2 return $b + 3", 6, empty(Let.class));
     check("let $x := <x>0</x> let $b := $x/text() return $b + 1", 1, empty(Let.class));
-    error("let $x := <x>false</x> let $b as xs:boolean := $x/text() return $b", INVTREAT_X_X_X);
+    check("let $x := <x>false</x> let $b as xs:boolean := $x/text() return $b", false,
+        empty(Let.class));
+    error("let $x := <x>42</x> let $b as xs:boolean := $x/text() return $b", FUNCCAST_X_X_X);
   }
 
   /** Tests flattening. */


### PR DESCRIPTION
These changes add coercion for variable bindings with an explicit type. The functionality was alread present in the `Var` class, it just needed to be activated in case there is a type definition. The `param` flag of `Var` was unused, so it has been removed.