### PR TITLE
Make sure FItem argument coercion is not skipped

### DIFF
--- a/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
@@ -446,14 +446,24 @@ public final class SeqType {
   public Value coerce(final Value value, final QNm name, final QueryContext qc,
       final CompileContext cc, final InputInfo info) throws QueryException {
 
-    if(instance(value)) return value;
+    boolean coerceArgs = false;
+    final SeqType[] argTypes = type instanceof FuncType ? ((FuncType) type).argTypes : null;
+    if(argTypes != null) {
+      for(final SeqType at : argTypes) {
+        if(!at.eq(ITEM_ZM)) {
+          coerceArgs = true;
+          break;
+        }
+      }
+    }
+    if(instance(value) && !coerceArgs) return value;
 
     final long size = value.size();
     ItemList items = null;
     for(long i = 0; i < size; i++) {
       qc.checkStop();
       final Item item = value.itemAt(i);
-      if(instance(item)) {
+      if(instance(item) && !coerceArgs) {
         if(items != null) items.add(item);
       } else {
         if(items == null) {

--- a/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java
@@ -197,6 +197,8 @@ public final class FuncItemTest extends SandboxTest {
   @Test public void funcItemCoercion() {
     error("let $f := function($g as function() as item()) { $g() }" +
         "return $f(function() { 1, 2 })", INVCONVERT_X_X_X);
+    error("let $x as fn (xs:byte) as item() := fn($x as item()) {$x} return $x(384)",
+        FUNCCAST_X_X_X);
   }
 
   /** Checks if nested closures are inlined. */


### PR DESCRIPTION
In `SeqType.coerce` coercion is skipped, if an instance test succeeds. But in case of a function item, this also skips coercion of the arguments, which may still be necessary.

This change calculates whether there is any non-`item()*` argument, and enforces coercion in case there is.

The corresponding QT4 test cases are `enum-024` and `FunctionCall-058`, these now produce the expected result.