### PR TITLE
Add coercion for array lookup key

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayGet.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayGet.java
@@ -21,7 +21,7 @@ public final class ArrayGet extends StandardFunc {
     final Item position = toAtomItem(arg(1), qc);
     final FItem fallback = toFunctionOrNull(arg(2), 1, qc);
 
-    final Value value = array.getInternal(position, info, fallback == null);
+    final Value value = array.getInternal(position, qc, info, fallback == null);
     return value != null ? value : fallback.invoke(qc, info, position);
   }
 

--- a/basex-core/src/main/java/org/basex/query/value/array/XQArray.java
+++ b/basex-core/src/main/java/org/basex/query/value/array/XQArray.java
@@ -270,24 +270,23 @@ public abstract class XQArray extends XQData {
   @Override
   public final Value invokeInternal(final QueryContext qc, final InputInfo ii, final Value[] args)
       throws QueryException {
-    return getInternal(key(args[0], qc, ii), ii, true);
+    return getInternal(key(args[0], qc, ii), qc, ii, true);
   }
 
   /**
    * Gets the internal map value.
    * @param key key to look for
+   * @param qc query context
    * @param ii input info (can be {@code null})
    * @param error if {@code true}, raise error if index is out of bounds
    * @return value or {@code null}
    * @throws QueryException query exception
    */
-  public Value getInternal(final Item key, final InputInfo ii, final boolean error)
-      throws QueryException {
-    final Type tp = key.type;
-    if(!tp.instanceOf(AtomType.INTEGER) && !tp.isUntyped())
-      throw typeError(key, AtomType.INTEGER, ii);
+  public Value getInternal(final Item key, final QueryContext qc, final InputInfo ii,
+      final boolean error) throws QueryException {
+    final Item ki = (Item) SeqType.INTEGER_O.coerce(key, null, qc, null, ii);
 
-    final long pos = key.itr(ii), size = arraySize();
+    final long pos = ki.itr(ii), size = arraySize();
     if(pos > 0 && pos <= size) return get(pos - 1);
 
     if(error) throw (size == 0 ? ARRAYEMPTY : ARRAYBOUNDS_X_X).get(ii, pos, size);

--- a/basex-core/src/test/java/org/basex/query/expr/ArrayTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/ArrayTest.java
@@ -242,6 +242,13 @@ public final class ArrayTest extends SandboxTest {
     query("[ 'x' ]([ 1 ])", "x");
   }
 
+  /** Coerce key. */
+  @Test public void coerceKey() {
+    query("[ 'x' ]( 1.0 )", "x");
+    query("[ 'x' ]?( 1.0 )", "x");
+    query("array:get([ 'x' ], 1.0)", "x");
+  }
+
   /** Tests if {@link XQArray#members()} uses the array's offset correctly. */
   @Test public void gh1047() {
     query("array:head(array:for-each(array:subarray([ 1, 2, 3 ], 2), function($x) { $x }))",


### PR DESCRIPTION
Per XQuery 4, the different forms of accessing an array element, by

- using the array as a function item,
- `array:get`, and
- the lookup operator `?`,

are all subject to the coercion rules with respect to the array index.

This change invokes `SeqType.coerce` on the key from within `XQArray.getInternal`.

The corresponding QT4 test cases are `Lookup-019a`, `Lookup-119a`, and `UnaryLookup-019a`.