### PR TITLE
Coerce maps and arrays to FuncItem

### DIFF
--- a/basex-core/src/main/java/org/basex/query/value/item/FItem.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/FItem.java
@@ -76,8 +76,7 @@ public abstract class FItem extends Item implements XQFunction {
     if(nargs < arity) throw arityError(this, arity, nargs, false, info);
 
     // optimize: continue with coercion if current type is only an instance of new type
-    FuncType tp = funcType();
-    if(cc != null ? tp.eq(ft) : tp.instanceOf(ft)) return this;
+    if(type instanceof FuncType && (cc != null ? type.eq(ft) : type.instanceOf(ft))) return this;
 
     // create new compilation context and variable scope
     final VarScope vs = new VarScope();
@@ -100,6 +99,7 @@ public abstract class FItem extends Item implements XQFunction {
 
       // add type check if return types differ
       final SeqType dt = ft.declType;
+      FuncType tp = funcType();
       if(!tp.declType.instanceOf(dt)) {
         body = new TypeCheck(info, body, dt, true);
         if(cc != null) body = body.optimize(cc);

--- a/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
@@ -446,7 +446,8 @@ public final class SeqType {
 
     // check if function arguments must be coerced
     boolean coerce = false;
-    final SeqType[] argTypes = type instanceof FuncType ? ((FuncType) type).argTypes : null;
+    boolean toFunc = type instanceof FuncType;
+    final SeqType[] argTypes = toFunc ? ((FuncType) type).argTypes : null;
     if(argTypes != null) {
       for(final SeqType at : argTypes) {
         if(!at.eq(ITEM_ZM)) {
@@ -458,11 +459,11 @@ public final class SeqType {
 
     // check if value must be coerced
     if(!coerce) {
-      if(instance(value)) return value;
+      if(instance(value) && (!toFunc || value instanceof FuncItem)) return value;
 
       for(final Item item : value) {
         qc.checkStop();
-        if(!instance(item)) {
+        if(!instance(item) || toFunc && !(item instanceof FuncItem)) {
           coerce = true;
           break;
         }
@@ -542,7 +543,8 @@ public final class SeqType {
         items.add(it);
       }
     } else if(item instanceof FItem && type instanceof FuncType) {
-      items.add(((FItem) item).coerceTo((FuncType) type, qc, cc, info));
+      final FuncType ft = type == FUNCTION ? item.funcType() : (FuncType) type;
+      items.add(((FItem) item).coerceTo(ft, qc, cc, info));
     } else {
       throw error.get();
     }

--- a/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java
@@ -199,6 +199,11 @@ public final class FuncItemTest extends SandboxTest {
         "return $f(function() { 1, 2 })", INVCONVERT_X_X_X);
     error("let $x as fn (xs:byte) as item() := fn($x as item()) {$x} return $x(384)",
         FUNCCAST_X_X_X);
+    error("let $x as fn(xs:anyAtomicType) as xs:string? := { 1:'A', 'x':'B' } return $x?*",
+        LOOKUP_X);
+    error("let $x as fn(xs:integer) as xs:integer := [1, 2] return $x?*", LOOKUP_X);
+    error("let $x as fn(*) := { 1:'A', 'x':'B' } return $x?*", LOOKUP_X);
+    error("let $x as fn(*) := [1, 2] return $x?*", LOOKUP_X);
   }
 
   /** Checks if nested closures are inlined. */


### PR DESCRIPTION
Function coercion of a map or array item is currently skipped, when the `funcType` of the item passes an instance test for the required function type. This however preserves its array or map identity, keeping it a suitable argument for the lookup operator, which it should not be. See qt4cg/qt4tests#109.

This change makes sure that non-`FuncItem`s are processed by `FItem.coerceTo` to actually return a `FuncItem`, when the required type is a `FuncType`. When coercing to `function(*)`, the item's `funcType` is used instead, in order to avoid special handling that would be necessary, because there are no required `argTypes`.

The corresponding QT4 test case is `MapTest-058a`.