### PR TITLE
Extend support for keyword args and placeholders

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -2168,7 +2168,7 @@ public class QueryParser extends InputParser {
           } while(wsConsume("["));
           expr = new CachedFilter(info(), expr, el.finish());
         } else if(current('(')) {
-          expr = Functions.dynamic(expr, argumentList(true, null));
+          expr = Functions.dynamic(expr, argumentList(false, null));
         } else {
           final int p = pos;
           if(consume("?") && !consume(':')) {

--- a/basex-core/src/main/java/org/basex/query/func/Closure.java
+++ b/basex-core/src/main/java/org/basex/query/func/Closure.java
@@ -466,4 +466,14 @@ public final class Closure extends Single implements Scope, XQFunctionExpr {
     qs.token(AS).token(declType != null ? declType : SeqType.ITEM_ZM).brace(expr);
     if(inlined) qs.token(')');
   }
+
+  /**
+   * Parameter names.
+   * @return parameter names
+   */
+  public QNm[] paramNames() {
+    final QNm[] names = new QNm[params.length];
+    for(int p = 0; p < names.length; ++p) names[p] = paramName(p);
+    return names;
+  }
 }

--- a/basex-core/src/main/java/org/basex/query/func/Functions.java
+++ b/basex-core/src/main/java/org/basex/query/func/Functions.java
@@ -108,13 +108,27 @@ public final class Functions {
    * @param expr function expression
    * @param fb function arguments
    * @return function call
+   * @throws QueryException query exception
    */
-  public static Expr dynamic(final Expr expr, final FuncBuilder fb) {
-    final Expr[] args = fb.args();
+  public static Expr dynamic(final Expr expr, final FuncBuilder fb) throws QueryException {
+    final Expr[] args;
+    final int[] paramPerm;
     final int ph = fb.placeholders;
-    return ph > 0 ? ph == args.length ? expr :
-      new PartFunc(fb.info, ExprList.concat(args, expr), ph) :
-      new DynFuncCall(fb.info, expr, args);
+
+    if(fb.keywords == null) {
+      args = fb.args();
+      if(ph == 0) return new DynFuncCall(fb.info, expr, args);
+      if(ph == args.length) return expr;
+      paramPerm = null;
+    } else {
+      if(!(expr instanceof Closure)) throw Util.notExpected();
+      final QNm[] names = ((Closure) expr).paramNames();
+      args = prepareArgs(fb, names, expr);
+      if(ph == 0) return new DynFuncCall(fb.info, expr, args);
+      paramPerm = preparePlaceholders(fb, names, args);
+    }
+
+    return new PartFunc(fb.info, ExprList.concat(args, expr), ph, paramPerm);
   }
 
   /**
@@ -434,5 +448,42 @@ public final class Functions {
     }
     checkArity(arity, min, max, false, fb.info, function);
     return args;
+  }
+
+  /**
+   * Calculates the permutation of argument placeholder ordinals, that will map from the order of
+   * placeholders in the target function's argument list to the parameter positions in the parameter
+   * list of a partially evaluated function.
+   * @param fb function arguments
+   * @param names parameter names
+   * @param exprs expressions (arguments with optional placeholders, followed by body)
+   * @return an integer array, where the value at index i indicates the index in the parameter list
+   *         of the partially evaluated function of the i-th placeholder in the (positional) target
+   *         function argument list.
+   */
+  private static int[] preparePlaceholders(final FuncBuilder fb, final QNm[] names,
+      final Expr[] exprs) {
+    final int[] placeholderPerm = new int[fb.placeholders];
+    final int posArgs = fb.arity - fb.keywords.size();
+    int p = 0;
+    for(int a = 0; a < posArgs; ++a) {
+      if(PartFunc.placeholder(exprs[a])) {
+        placeholderPerm[p] = p;
+        ++p;
+      }
+    }
+    final int nonKwPh = p;
+    for(int a = posArgs; a < fb.arity; ++a) {
+      if(PartFunc.placeholder(exprs[a])) {
+        QNm name = names[a];
+        int i = nonKwPh;
+        for(final QNm qnm : fb.keywords) {
+          if(qnm.eq(name)) break;
+          if(PartFunc.placeholder(fb.keywords.get(qnm))) ++i;
+        }
+        placeholderPerm[p++] = i;
+      }
+    }
+    return placeholderPerm;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/Functions.java
+++ b/basex-core/src/main/java/org/basex/query/func/Functions.java
@@ -475,7 +475,7 @@ public final class Functions {
     final int nonKwPh = p;
     for(int a = posArgs; a < fb.arity; ++a) {
       if(PartFunc.placeholder(exprs[a])) {
-        QNm name = names[a];
+        final QNm name = names[a];
         int i = nonKwPh;
         for(final QNm qnm : fb.keywords) {
           if(qnm.eq(name)) break;

--- a/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java
@@ -322,4 +322,12 @@ public final class FuncItemTest extends SandboxTest {
     query("array:fold-right(" + array + ", 1, fn($a, $b) { if($b > 10000000) then $b else $a+$b })",
         10094951);
   }
+
+  /** Checks order of keyword placeholder parameters of partially evaluated function. */
+  @Test public void placeholderOrder() {
+    query("declare function local:f($s as xs:string, $i as xs:integer) {$s, $i}; "
+        + "let $result := local:f(i := ?, s := ?)(4.0, xs:anyURI('XQuery'))"
+        + "return ($result[1] instance of xs:string, $result[2] instance of xs:integer)",
+        "true\ntrue");
+  }
 }


### PR DESCRIPTION
The support for calling user-defined functions needs to be extended by
- handling keyword arguments,
- establishing the correct order of parameters of partially evaluated functions. This may deviate from the order in the target function when placeholders are used for keyword arguments.

This change 

- adds a call to `prepareArgs` to `Functions.dynamic`, in order to integrate keyword arguments into the positional argument list.
- calculates a permutation of placeholder ordinals, mapping the i-th placeholder in the integrated positional argument list (for the target function) to its position in the parameter list of the partially applied function,
- propagates the type to the parameter variable, in order to enable item coercion,
- disallows keyword arguments in dynamic function calls during parsing.

The corresponding QT4 test cases are
- `FunctionCall-414`
- `FunctionCall-415`
- `FunctionCall-416`
- `FunctionCall-417`