### PR TITLE
Add support for UnionNodeTest

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/path/Test.java
+++ b/basex-core/src/main/java/org/basex/query/expr/path/Test.java
@@ -42,7 +42,7 @@ public abstract class Test extends ExprInfo {
   }
 
   /**
-   * Creates a single test with the same node type.
+   * Creates a single test.
    * @param tests tests to be merged (can contain {@code null} references)
    * @return single test, union test, or {@code null} if test cannot be created.
    */
@@ -51,17 +51,11 @@ public abstract class Test extends ExprInfo {
     if(tl == 0) return null;
     if(tl == 1) return tests[0];
 
-    // find common node type
-    NodeType type = null;
-    for(final Test test : tests) {
-      if(test == null || type != null && type != test.type) return null;
-      type = test.type;
-    }
+    for(final Test test : tests) if(test == null) return null;
 
     // merge name tests
     final List<Test> list = new ArrayList<>(tl);
     for(final Test test : tests) {
-      if(test instanceof KindTest) return test;
       if(test instanceof UnionTest) {
         for(final Test t : ((UnionTest) test).tests) {
           if(!list.contains(t)) list.add(t);
@@ -70,7 +64,7 @@ public abstract class Test extends ExprInfo {
         list.add(test);
       }
     }
-    return list.size() == 1 ? list.get(0) : new UnionTest(type, list.toArray(Test[]::new));
+    return list.size() == 1 ? list.get(0) : new UnionTest(list.toArray(Test[]::new));
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/expr/path/UnionTest.java
+++ b/basex-core/src/main/java/org/basex/query/expr/path/UnionTest.java
@@ -8,7 +8,7 @@ import org.basex.query.value.type.*;
 import org.basex.util.*;
 
 /**
- * Union test for nodes of common type.
+ * Union test for nodes.
  *
  * @author BaseX Team 2005-24, BSD License
  * @author Christian Gruen
@@ -19,12 +19,22 @@ public final class UnionTest extends Test {
 
   /**
    * Constructor.
-   * @param type common node type
-   * @param tests tests ({@link NameTest}, {@link DocTest} and {@link InvDocTest} instances)
+   * @param tests tests
    */
-  UnionTest(final NodeType type, final Test[] tests) {
-    super(type);
+  public UnionTest(final Test[] tests) {
+    super(unionType(tests));
     this.tests = tests;
+  }
+
+  /**
+   * Calculate union type of tests.
+   * @param tests tests
+   * @return union type
+   */
+  private static NodeType unionType(final Test[] tests) {
+    Type unionType = tests[0].type;
+    for (int i = 1; i < tests.length; ++i) unionType = unionType.union(tests[i].type);
+    return (NodeType) unionType;
   }
 
   @Override

--- a/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
@@ -1168,7 +1168,8 @@ public final class RewritingsTest extends SandboxTest {
 
   /** List to union. */
   @Test public void gh1818() {
-    check("<a/>[b, text()]", "", exists(Union.class), count(SingleIterPath.class, 2));
+    check("<a/>[b, text()]", "", count(SingleIterPath.class, 1),
+        type(IterStep.class, "element(b)|text()*"));
 
     // union expression will be further rewritten to single path
     check("<a/>[b, c]", "", empty(List.class), count(SingleIterPath.class, 1));
@@ -1967,9 +1968,9 @@ public final class RewritingsTest extends SandboxTest {
   @Test public void gh1914() {
     check("<a/>/(self::*|self::a)", "<a/>", root(CElem.class));
 
-    check("<a/>/(* | a)", "", type(IterStep.class, "element()*"));
-    check("<a/>/(a | *)", "", type(IterStep.class, "element()*"));
-    check("<a/>/(a | * | b)", "", type(IterStep.class, "element()*"));
+    check("<a/>/(* | a)", "", type(IterStep.class, "element()|element(a)*"));
+    check("<a/>/(a | *)", "", type(IterStep.class, "element(a)|element()*"));
+    check("<a/>/(a | * | b)", "", type(IterStep.class, "element(a)|element()|element(b)*"));
 
     check("(<a/> | <b/> | <a/>)/self::b", "<b/>", type(Union.class, "element(a)|element(b)+"));
     check("(<a/>, <b/>, <a/>)/self::b", "<b/>", type(Union.class, "element(a)|element(b)+"));
@@ -3234,18 +3235,22 @@ public final class RewritingsTest extends SandboxTest {
         count(IterStep.class, 1), "//@axis = 'descendant-or-self'");
 
     check("<A><B/></A>/descendant-or-self::node()/(* | text())", "<B/>",
-        count(IterStep.class, 2), "//@axis = 'descendant'");
+        count(IterStep.class, 1), "//@axis = 'descendant'");
+    check("<A><B/>X</A>/descendant-or-self::node()/(* | text())", "<B/>\nX",
+        count(IterStep.class, 1), "//@axis = 'descendant'");
     check("<A><B/></A>/descendant-or-self::node()/(descendant::* | text())", "<B/>",
-        count(IterStep.class, 2), "//@axis = 'descendant'");
+        count(IterStep.class, 1), "//@axis = 'descendant'");
     check("<A><B/></A>/descendant-or-self::node()/(* | descendant::text())", "<B/>",
-        count(IterStep.class, 2), "//@axis = 'descendant'");
+        count(IterStep.class, 1), "//@axis = 'descendant'");
 
     check("<A><B/></A>/descendant-or-self::node()/(* | text())[..]", "<B/>",
-        count(IterStep.class, 3), "//@axis = 'descendant'");
+        count(IterStep.class, 2), "//@axis = 'descendant'");
+    check("<A><B/>X</A>/descendant-or-self::node()/(* | text())[..]", "<B/>\nX",
+        count(IterStep.class, 2), "//@axis = 'descendant'");
     check("<A><B/></A>/descendant-or-self::node()/(descendant::* | text())[..]", "<B/>",
-        count(IterStep.class, 3), "//@axis = 'descendant'");
+        count(IterStep.class, 2), "//@axis = 'descendant'");
     check("<A><B/></A>/descendant-or-self::node()/(* | descendant::text())[..]", "<B/>",
-        count(IterStep.class, 3), "//@axis = 'descendant'");
+        count(IterStep.class, 2), "//@axis = 'descendant'");
   }
 
   /** Refine parameter types to arguments types of function call. */

--- a/basex-core/src/test/java/org/basex/query/expr/PathTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/PathTest.java
@@ -278,4 +278,16 @@ public final class PathTest extends SandboxTest {
     check("let $i := 0 return <a/>/*[position() = 1 to $i]",
         "", empty());
   }
+
+  /** Union node tests. */
+  @Test public void unionNodeTest() {
+    final String el = "<x a='a'><e>e</e>t<!--c--><?p p?></x>";
+    check(el + "/attribute::(document-node()|a|e|text())!string()", "a");
+    check(el + "/@(a|processing-instruction())!string()", "a");
+    check(el + "/attribute::(node()|processing-instruction())!string()", "a");
+    check(el + "/child::(a|e|text())!string()", "e\nt");
+    check(el + "/child::(a|e|processing-instruction())!string()", "e\np");
+    check(el + "/child::(a|e|text()|comment())!string()", "e\nt\nc");
+    check(el + "/descendant-or-self::(text()|*|comment())!string()", "et\ne\ne\nt\nc");
+  }
 }


### PR DESCRIPTION
These changes add support for the `UnionNodeTest` grammar rule and maps it to a `UnionTest` instance, by also lifting the restriction that a `UnionTest` combines only tests with the a common node type. Instead of that common type, the `UnionTest`'s type is now set to the union of the types of the combined tests.

This fixes all of the remaining QT4 test cases with name prefix `UnionNodeTest`.