### PR TITLE
Add support for RecordTest

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -1021,6 +1021,10 @@ public enum QueryError {
   /** Error code. */
   CASTTYPE_X(XPST, 3, "%"),
   /** Error code. */
+  NOSTRNCN_X(XPST, 3, "Expecting string or NCName, found '%'."),
+  /** Error code. */
+  DUPFIELD_X(XPST, 3, "Duplicate field name: '%'."),
+  /** Error code. */
   STATIC_X(XPST, 5, "No XML Schema support: %."),
   /** Error code. */
   VARUNDEF_X(XPST, 8, "Undeclared variable: %."),

--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -41,6 +41,7 @@ import org.basex.query.util.parse.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.seq.*;
 import org.basex.query.value.type.*;
+import org.basex.query.value.type.RecordType.*;
 import org.basex.query.var.*;
 import org.basex.util.*;
 import org.basex.util.ft.*;
@@ -3208,6 +3209,23 @@ public class QueryParser extends InputParser {
       return type;
     }
 
+    // record
+    if(type instanceof RecordType) {
+      final TokenObjMap<Field> fields = new TokenObjMap<>();
+      do {
+        if(wsConsume("*")) {
+          wsCheck(")");
+          return SeqType.RECORD;
+        }
+        final byte[] name = quote(current()) ? stringLiteral() : ncName(NOSTRNCN_X);
+        final boolean optional = wsConsume("?");
+        final SeqType seqType = wsConsume(AS) ? sequenceType() : null;
+        if(fields.contains(name)) throw error(DUPFIELD_X, name);
+        fields.put(name, new Field(optional, seqType));
+      } while(wsConsume(","));
+      check(')');
+      return new RecordType(false, fields);
+    }
     // map
     if(type instanceof MapType) {
       final Type key = itemType().type;

--- a/basex-core/src/main/java/org/basex/query/QueryText.java
+++ b/basex-core/src/main/java/org/basex/query/QueryText.java
@@ -130,6 +130,7 @@ public interface QueryText {
   /** Parser token. */ String PROCESSING_INSTRUCTION = "processing-instruction";
   /** Parser token. */ String PRESERVE = "preserve";
   /** Parser token. */ String PREVIOUS = "previous";
+  /** Parser token. */ String RECORD = "record";
   /** Parser token. */ String RELATIONSHIP = "relationship";
   /** Parser token. */ String RENAME = "rename";
   /** Parser token. */ String REPLACE = "replace";

--- a/basex-core/src/main/java/org/basex/query/value/map/XQMap.java
+++ b/basex-core/src/main/java/org/basex/query/value/map/XQMap.java
@@ -203,6 +203,7 @@ public final class XQMap extends XQData {
 
   @Override
   public boolean instanceOf(final Type tp) {
+    if(tp instanceof RecordType) return ((RecordType) tp).instance(this);
     if(type.instanceOf(tp)) return true;
 
     if(tp instanceof MapType) {

--- a/basex-core/src/main/java/org/basex/query/value/type/FuncType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/FuncType.java
@@ -183,6 +183,7 @@ public class FuncType extends FType {
         case QueryText.FUNCTION:
         case QueryText.FN:       return SeqType.FUNCTION;
         case QueryText.MAP:      return SeqType.MAP;
+        case QueryText.RECORD:   return SeqType.RECORD;
         case QueryText.ARRAY:    return SeqType.ARRAY;
       }
     }

--- a/basex-core/src/main/java/org/basex/query/value/type/MapType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/MapType.java
@@ -17,7 +17,7 @@ import org.basex.util.*;
  * @author BaseX Team 2005-24, BSD License
  * @author Leo Woerteler
  */
-public final class MapType extends FType {
+public class MapType extends FType {
   /** Key type of the map. */
   public final Type keyType;
   /** Value types (can be {@code null}, indicating that no type was specified). */
@@ -65,7 +65,7 @@ public final class MapType extends FType {
   @Override
   public boolean eq(final Type type) {
     if(this == type) return true;
-    if(!(type instanceof MapType)) return false;
+    if(type.getClass() != MapType.class) return false;
     final MapType mt = (MapType) type;
     return keyType.eq(mt.keyType) && valueType.eq(mt.valueType);
   }
@@ -73,7 +73,9 @@ public final class MapType extends FType {
   @Override
   public boolean instanceOf(final Type type) {
     if(this == type || type.oneOf(SeqType.MAP, SeqType.FUNCTION, AtomType.ITEM)) return true;
+    if(this == SeqType.MAP && type == SeqType.RECORD) return true;
     if(type instanceof ChoiceItemType) return ((ChoiceItemType) type).hasInstance(this);
+    if(type instanceof RecordType) return false;
     if(type instanceof MapType) {
       final MapType mt = (MapType) type;
       return valueType.instanceOf(mt.valueType) && keyType.instanceOf(mt.keyType);
@@ -89,6 +91,7 @@ public final class MapType extends FType {
   @Override
   public Type union(final Type type) {
     if(type instanceof ChoiceItemType) return type.union(this);
+    if(type == SeqType.RECORD) return SeqType.MAP;
     if(instanceOf(type)) return type;
     if(type.instanceOf(this)) return this;
 
@@ -103,6 +106,7 @@ public final class MapType extends FType {
   @Override
   public Type intersect(final Type type) {
     if(type instanceof ChoiceItemType) return type.intersect(this);
+    if(type == SeqType.RECORD) return SeqType.RECORD;
     if(instanceOf(type)) return this;
     if(type.instanceOf(this)) return type;
 

--- a/basex-core/src/main/java/org/basex/query/value/type/RecordType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/RecordType.java
@@ -1,0 +1,255 @@
+package org.basex.query.value.type;
+
+import static org.basex.query.QueryText.*;
+
+import org.basex.query.*;
+import org.basex.query.value.item.*;
+import org.basex.query.value.map.*;
+import org.basex.util.*;
+import org.basex.util.hash.*;
+
+/**
+ * Type for record tests.
+ *
+ * @author BaseX Team 2005-24, BSD License
+ * @author Gunther Rademacher
+ */
+public final class RecordType extends MapType {
+  /** Extensible flag. */
+  final boolean extensible;
+  /** Field declarations. */
+  final TokenObjMap<Field> fields;
+
+  /**
+   * Constructor.
+   * @param extensible extensible flag
+   * @param fields field declarations
+   */
+  public RecordType(final boolean extensible, final TokenObjMap<Field> fields) {
+    super(extensible ? AtomType.ANY_ATOMIC_TYPE : AtomType.STRING,
+        extensible ? SeqType.ITEM_ZM : unionType(fields));
+    this.extensible = extensible;
+    this.fields = fields;
+  }
+
+  /**
+   * Calculate union type of field sequence types.
+   * @param fields field declarations
+   * @return union type
+   */
+  private static SeqType unionType(final TokenObjMap<Field> fields) {
+    if(fields.isEmpty()) return SeqType.ITEM_ZM;
+    SeqType unionType = null;
+    for(final Field field : fields.values()) {
+      final SeqType st = field.seqType();
+      unionType = unionType == null ? st : unionType.union(st);
+    }
+    return unionType;
+  }
+
+  /**
+   * Checks if the specified map is an instance of this record type.
+   * @param map map to check
+   * @return result of check
+   */
+  public boolean instance(final XQMap map) {
+    try {
+      for(final byte[] name : fields) {
+        final Field field = fields.get(name);
+        final Item key = Str.get(name);
+        if(map.contains(key)) {
+          if(field.seqType != null && !field.seqType.instance(map.get(key))) return false;
+        } else if(!field.optional) {
+          return false;
+        }
+      }
+      if(!extensible) {
+        for(final Item item : map.keys()) {
+          if(!item.instanceOf(AtomType.STRING) || !fields.contains(item.string(null))) return false;
+        }
+      }
+      return true;
+    } catch(QueryException ex) {
+      throw Util.notExpected(ex);
+    }
+  }
+
+  @Override
+  public boolean eq(final Type type) {
+    if(this == type) return true;
+    if(!(type instanceof RecordType)) return false;
+    final RecordType rt = (RecordType) type;
+    if(extensible != rt.extensible || fields.size() != rt.fields.size()) return false;
+    for(final byte[] name : fields) {
+      if(!rt.fields.contains(name) || !fields.get(name).equals(rt.fields.get(name))) return false;
+    }
+    return true;
+  }
+
+  @Override
+  public boolean instanceOf(final Type type) {
+    if(this == type || type.oneOf(SeqType.RECORD, SeqType.MAP, SeqType.FUNCTION, AtomType.ITEM)) {
+      return true;
+    }
+    if(type instanceof ChoiceItemType) return ((ChoiceItemType) type).hasInstance(this);
+    if(type instanceof RecordType) {
+      final RecordType rt = (RecordType) type;
+      if(!rt.extensible) {
+        if(extensible) return false;
+        for(final byte[] name : fields) {
+          if(!rt.fields.contains(name)) return false;
+        }
+      }
+      for(final byte[] name : rt.fields) {
+        final Field rtf = rt.fields.get(name);
+        if(fields.contains(name)) {
+          final Field f = fields.get(name);
+          if(!rtf.optional && f.optional) return false;
+          if(!f.seqType().instanceOf(rtf.seqType())) return false;
+        } else if(!rtf.optional || extensible && rtf.seqType() != SeqType.ITEM_ZM) return false;
+      }
+      return true;
+    }
+    if(!extensible && type instanceof MapType) {
+      final MapType mt = (MapType) type;
+      if(!mt.keyType.oneOf(AtomType.STRING, AtomType.ANY_ATOMIC_TYPE)) return false;
+      for(final byte[] name : fields) {
+        if(!fields.get(name).seqType().instanceOf(mt.valueType)) return false;
+      }
+      return true;
+    }
+    if(type instanceof FuncType) {
+      final FuncType ft = type.funcType();
+      return funcType().declType.instanceOf(ft.declType) && ft.argTypes.length == 1 &&
+          ft.argTypes[0].instanceOf(SeqType.ANY_ATOMIC_TYPE_O);
+    }
+    return false;
+  }
+
+  @Override
+  public Type union(final Type type) {
+    if(type instanceof ChoiceItemType) return type.union(this);
+    if(type == SeqType.MAP) return SeqType.MAP;
+    if(instanceOf(type)) return type;
+    if(type.instanceOf(this)) return this;
+
+    if(type instanceof RecordType) {
+      final RecordType rt = (RecordType) type;
+      final TokenObjMap<Field> fld = new TokenObjMap<>();
+      for(final byte[] name : fields) {
+        final Field f = fields.get(name);
+        if(rt.fields.contains(name)) {
+          // common field
+          final Field rtf = rt.fields.get(name);
+          fld.put(name, new Field(f.optional || rtf.optional, f.seqType().union(rtf.seqType())));
+        } else {
+          // field missing in type
+          fld.put(name, new Field(true, f.seqType));
+        }
+      }
+      for(final byte[] name : rt.fields) {
+        if(!fields.contains(name)) {
+          // field missing in this RecordType
+          fld.put(name, new Field(true, rt.fields.get(name).seqType));
+        }
+      }
+      return new RecordType(extensible || rt.extensible, fld);
+    }
+    if(type instanceof MapType) {
+      final MapType mt = (MapType) type;
+      return get(keyType.union(mt.keyType), valueType.union(mt.valueType));
+    }
+    return type instanceof ArrayType ? SeqType.FUNCTION :
+           type instanceof FuncType ? type.union(this) : AtomType.ITEM;
+  }
+
+  @Override
+  public Type intersect(final Type type) {
+    if(type instanceof ChoiceItemType) return type.intersect(this);
+    if(instanceOf(type)) return this;
+    if(type.instanceOf(this)) return type;
+
+    if(!(type instanceof RecordType)) return null;
+    final RecordType rt = (RecordType) type;
+    final TokenObjMap<Field> fld = new TokenObjMap<>();
+    for(final byte[] name : fields) {
+      final Field f = fields.get(name);
+      if(rt.fields.contains(name)) {
+        // common field
+        final Field rtf = rt.fields.get(name);
+        final SeqType is = f.seqType().intersect(rtf.seqType());
+        if(is == null) return null;
+        fld.put(name, new Field(f.optional && rtf.optional, is));
+      } else {
+        // field missing in type
+        if(!rt.extensible) return null;
+        fld.put(name, new Field(false, f.seqType));
+      }
+    }
+    for(final byte[] name : rt.fields) {
+      if(!fields.contains(name)) {
+        // field missing in this RecordType
+        if(!extensible) return null;
+        fld.put(name, new Field(false, rt.fields.get(name).seqType));
+      }
+    }
+    return new RecordType(extensible && rt.extensible, fld);
+  }
+
+  @Override
+  public ID id() {
+    return ID.REC;
+  }
+
+  @Override
+  public String toString() {
+    final QueryString qs = new QueryString().token(RECORD).token("(");
+    if(this == SeqType.RECORD) return qs.token('*').token(')').toString();
+    int i = 0;
+    for(final byte[] name : fields) {
+      if(i++ != 0) qs.token(',').token(' ');
+      if(XMLToken.isNCName(name)) qs.token(name); else qs.quoted(name);
+      final Field field = fields.get(name);
+      if(field.optional) qs.token('?');
+      if(field.seqType != null) qs.token(AS).token(field.seqType);
+    }
+    if(extensible) qs.token(',').token(' ').token('*');
+    return qs.token(')').toString();
+  }
+
+  /**
+   * Field declaration.
+   */
+  public static class Field {
+    /** Optional flag. */
+    private final boolean optional;
+    /** Field type (can be {@code null}). */
+    private final SeqType seqType;
+
+    /**
+     * Constructor.
+     * @param optional optional flag
+     * @param seqType field type (can be {@code null})
+     */
+    public Field(final boolean optional, final SeqType seqType) {
+      this.optional = optional;
+      this.seqType = seqType;
+    }
+
+    /**
+     * Get effective sequence type of this field.
+     * @return sequence type
+     */
+    public SeqType seqType() {
+      return seqType == null ? SeqType.ITEM_ZM : seqType;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+      if(this == obj) return true;
+      if(!(obj instanceof Field)) return false;
+      final Field other = (Field) obj;
+      return optional == other.optional && seqType().equals(other.seqType());
+    }
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
@@ -18,6 +18,7 @@ import org.basex.query.value.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.seq.*;
 import org.basex.util.*;
+import org.basex.util.hash.*;
 
 /**
  * Stores a sequence type definition.
@@ -175,6 +176,8 @@ public final class SeqType {
   public static final FuncType FUNCTION = new FuncType(null, (SeqType[]) null);
   /** Java function type. */
   public static final FuncType JAVA = new FuncType(null);
+  /** The general record type. */
+  public static final RecordType RECORD = new RecordType(true, new TokenObjMap<>());
   /** The general map type. */
   public static final MapType MAP = ITEM_ZM.mapType(ANY_ATOMIC_TYPE);
   /** The general array type. */
@@ -194,6 +197,8 @@ public final class SeqType {
   public static final SeqType BIPREDICATE_O = FuncType.get(BOOLEAN_ZO, ITEM_O, ITEM_O).seqType();
   /** Action function. */
   public static final SeqType ACTION_O = FuncType.get(ITEM_ZM, ITEM_O, INTEGER_O).seqType();
+  /** Single record. */
+  public static final SeqType RECORD_O = RECORD.seqType();
   /** Single map. */
   public static final SeqType MAP_O = MAP.seqType();
   /** Zero or one map. */

--- a/basex-core/src/main/java/org/basex/query/value/type/Type.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/Type.java
@@ -22,6 +22,7 @@ public interface Type {
   enum ID {
     // function types
     /** function(*).              */ FUN(7),
+    /** record(*).                */ REC(29),
     /** map(*).                   */ MAP(30),
     /** array(*).                 */ ARRAY(31),
 

--- a/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
+++ b/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
@@ -9,6 +9,8 @@ import java.util.*;
 import java.util.function.*;
 
 import org.basex.query.value.type.*;
+import org.basex.query.value.type.RecordType.*;
+import org.basex.util.*;
 import org.basex.util.hash.*;
 import org.junit.jupiter.api.*;
 
@@ -248,6 +250,10 @@ public final class SeqTypeTest {
     assertTrue(FUNCTION_O.instanceOf(c6));
     assertFalse(c6.instanceOf(STRING_O));
     assertTrue(STRING_O.instanceOf(c6));
+
+    assertTrue(RECORD_O.instanceOf(FUNCTION_O));
+    assertTrue(MAP_O.instanceOf(RECORD_O));
+    assertTrue(RECORD_O.instanceOf(MAP_O));
   }
 
   /** Tests for {@link SeqType#union(SeqType)}. */
@@ -407,6 +413,52 @@ public final class SeqTypeTest {
     combine(c6, op);
     combine(c6, FUNCTION_O, ITEM_O, op);
     combine(c6, STRING_O, ITEM_O, op);
+
+    final TokenObjMap<Field> fld1 = new TokenObjMap<>(),
+        fld2 = new TokenObjMap<>(),
+        fld3 = new TokenObjMap<>(),
+        fld4 = new TokenObjMap<>(),
+        fld5 = new TokenObjMap<>(),
+        fld6 = new TokenObjMap<>(),
+        fld7 = new TokenObjMap<>();
+    fld1.put(Token.token("a"), new Field(false, INTEGER_O));
+    fld2.put(Token.token("a"), new Field(false, STRING_O));
+    fld3.put(Token.token("a"), new Field(false, ANY_ATOMIC_TYPE_O));
+    fld4.put(Token.token("a"), new Field(false, INTEGER_O));
+    fld5.put(Token.token("a"), new Field(true, INTEGER_O));
+    fld6.put(Token.token("b"), new Field(true, INTEGER_O));
+    fld7.put(Token.token("a"), new Field(true, INTEGER_O));
+    fld7.put(Token.token("b"), new Field(true, INTEGER_O));
+    final SeqType
+      // record(a as xs:integer)
+      r1 = SeqType.get(new RecordType(false, fld1), EXACTLY_ONE),
+      // record(a as xs:string)
+      r2 = SeqType.get(new RecordType(false, fld2), EXACTLY_ONE),
+      // record(a as xs:anyAtomicType)
+      r3 = SeqType.get(new RecordType(false, fld3), EXACTLY_ONE),
+      // record(a as xs:integer, *)
+      r4 = SeqType.get(new RecordType(true, fld4), EXACTLY_ONE),
+      // record(a as xs:integer?, *)
+      r5 = SeqType.get(new RecordType(true, fld5), EXACTLY_ONE),
+      // record(b as xs:integer?, *)
+      r6 = SeqType.get(new RecordType(true, fld6), EXACTLY_ONE),
+      // record(b as xs:integer?, *)
+      r7 = SeqType.get(new RecordType(true, fld7), EXACTLY_ONE);
+
+    combine(RECORD_O, FUNCTION_O, FUNCTION_O, op);
+    combine(RECORD_O, MAP_O, MAP_O, op);
+    combine(RECORD_O, r1, RECORD_O, op);
+    combine(FUNCTION_O, r1, FUNCTION_O, op);
+    combine(MAP_O, r1, MAP_O, op);
+    combine(r1, r2, r3, op);
+    combine(r1, r3, r3, op);
+    combine(r4, r1, r4, op);
+    combine(r5, r1, r5, op);
+    combine(r5, r4, r5, op);
+    combine(r1, r6, r6, op);
+    combine(r2, r6, r6, op);
+    combine(r4, r6, r7, op);
+    combine(r5, r6, r7, op);
   }
 
   /** Tests for {@link SeqType#intersect(SeqType)}. */
@@ -576,6 +628,52 @@ public final class SeqTypeTest {
     combine(c6, FUNCTION_O, FUNCTION_O, op);
     combine(c6, STRING_O, STRING_O, op);
     combine(c6, INTEGER_O, null, op);
+
+    final TokenObjMap<Field> fld1 = new TokenObjMap<>(),
+        fld2 = new TokenObjMap<>(),
+        fld3 = new TokenObjMap<>(),
+        fld4 = new TokenObjMap<>(),
+        fld5 = new TokenObjMap<>(),
+        fld6 = new TokenObjMap<>(),
+        fld7 = new TokenObjMap<>();
+    fld1.put(Token.token("a"), new Field(false, INTEGER_O));
+    fld2.put(Token.token("a"), new Field(false, STRING_O));
+    fld3.put(Token.token("a"), new Field(false, ANY_ATOMIC_TYPE_O));
+    fld4.put(Token.token("a"), new Field(false, INTEGER_O));
+    fld5.put(Token.token("a"), new Field(true, INTEGER_O));
+    fld6.put(Token.token("b"), new Field(true, INTEGER_O));
+    fld7.put(Token.token("a"), new Field(false, INTEGER_O));
+    fld7.put(Token.token("b"), new Field(false, INTEGER_O));
+    final SeqType
+      // record(a as xs:integer)
+      r1 = SeqType.get(new RecordType(false, fld1), EXACTLY_ONE),
+      // record(a as xs:string)
+      r2 = SeqType.get(new RecordType(false, fld2), EXACTLY_ONE),
+      // record(a as xs:anyAtomicType)
+      r3 = SeqType.get(new RecordType(false, fld3), EXACTLY_ONE),
+      // record(a as xs:integer, *)
+      r4 = SeqType.get(new RecordType(true, fld4), EXACTLY_ONE),
+      // record(a as xs:integer?, *)
+      r5 = SeqType.get(new RecordType(true, fld5), EXACTLY_ONE),
+      // record(b as xs:integer?, *)
+      r6 = SeqType.get(new RecordType(true, fld6), EXACTLY_ONE),
+      // record(b as xs:integer?, *)
+      r7 = SeqType.get(new RecordType(true, fld7), EXACTLY_ONE);
+
+    combine(RECORD_O, FUNCTION_O, RECORD_O, op);
+    combine(RECORD_O, MAP_O, RECORD_O, op);
+    combine(RECORD_O, r1, r1, op);
+    combine(FUNCTION_O, r1, r1, op);
+    combine(MAP_O, r1, r1, op);
+    combine(r1, r2, null, op);
+    combine(r1, r3, r1, op);
+    combine(r4, r1, r1, op);
+    combine(r5, r1, r1, op);
+    combine(r5, r4, r4, op);
+    combine(r1, r6, r1, op);
+    combine(r2, r6, r2, op);
+    combine(r4, r6, r7, op);
+    combine(r5, r6, r7, op);
   }
 
   /**

--- a/basex-core/src/test/java/org/basex/query/simple/TypeTest.java
+++ b/basex-core/src/test/java/org/basex/query/simple/TypeTest.java
@@ -42,6 +42,10 @@ public final class TypeTest extends QueryTest {
         { "Type 11", booleans(true), "fn($a as (enum('a')|enum('b'))) as item()* {$a} "
             + "instance of fn(enum('a', 'b')) as item()*"
         },
+        { "Type 12", booleans(true), "fn() as record(a as xs:integer) {map{'a': 42}} instance of "
+            + "fn() as record(a? as xs:integer)"},
+        { "Type 13", booleans(false), "fn() as record(a? as xs:integer) {map{}} instance of "
+            + "fn() as record(a as xs:integer)"},
 
         { "TypeErr 1", "1 instance of xs:abcde" },
         { "TypeErr 2", "1 instance of xs:string()" },


### PR DESCRIPTION
These changes provide the implementation of [RecordTest](https://qt4cg.org/specifications/xquery-40/xquery-40.html#id-record-test). This accomplished by adding a new class `RecordType extends MapType`.

This fixes 20 QT4 test cases with prefixes

- `array-members`
- `DynamicFunctionCall-R`
- `RecordTest`
- `Keywords-map-pair`
- `Keywords-array-members`

There are more test cases involving `RecordTest`s that are still failing. Those require coercion for records, which is not yet implemented.
