### PR TITLE
Add coercion for explicit parameters of partially applied function

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/PartFunc.java
+++ b/basex-core/src/main/java/org/basex/query/func/PartFunc.java
@@ -85,14 +85,14 @@ public final class PartFunc extends Arr {
     final Var[] params = new Var[placeholders];
     for(int p = 0, e = 0; e < el; e++) {
       final Expr expr = exprs[e];
+      final SeqType at = ft.argTypes[e];
       if(placeholder(expr)) {
-        final SeqType at = ft.argTypes[e];
         final Var param = vs.addNew(func.paramName(e), at, qc, info);
         args[e] = new VarRef(info, param);
         params[placeholderPerm == null ? p : placeholderPerm[p]] = param;
         ++p;
       } else {
-        args[e] = expr.value(qc);
+        args[e] = at.coerce(expr.value(qc), null, qc, null, ii);
       }
     }
     final AnnList anns = func.annotations();


### PR DESCRIPTION
As discussed in qt4cg/qt4tests#148, coercion of explicit parameters is part of the process of constructing the function item, that results from partial function application.

This change thus adds coercion to `PartFunc.item`.

This causes some type errors to be detected earlier, fixing QT4 test cases
- `FunctionCall-422`
- `xqhof40`
- `xqhof41`