### PR TITLE
Add support for item type declarations

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -927,6 +927,8 @@ public enum QueryError {
   /** Error code. */
   FUNCNAME(XPST, 3, "Expecting function name."),
   /** Error code. */
+  TYPENAME(XPST, 3, "Expecting type name."),
+  /** Error code. */
   RESERVED_X(XPST, 3, "'%' is a reserved keyword."),
   /** Error code. */
   NOVARNAME(XPST, 3, "Variable name expected, '%' found."),
@@ -1012,6 +1014,8 @@ public enum QueryError {
   ANNVALUE_X(XPST, 3, "Literal expected, '%' found."),
   /** Error code. */
   UPDATINGVAR(XPST, 3, "Variable cannot be updating."),
+  /** Error code. */
+  UPDATINGTYPE(XPST, 3, "Type cannot be updating."),
   /** Error code. */
   SIMPLETYPE_X(XPST, 3, "Simple type expected, function found: %(."),
   /** Error code. */
@@ -1234,6 +1238,8 @@ public enum QueryError {
   /** Error code. */
   ANNWHICH_X_X(XQST, 45, "Annotation %% is in reserved namespace."),
   /** Error code. */
+  TYPERESERVED_X(XQST, 45, "Type % is in reserved namespace."),
+  /** Error code. */
   INVURI_X(XQST, 46, "Invalid URI: %."),
   /** Error code. */
   DUPLMODULE_X(XQST, 47, "Module namespace is declared twice: %."),
@@ -1339,6 +1345,8 @@ public enum QueryError {
   NOVISALLOWED(XQST, 125, "No visibility annotation allowed in inline function."),
   /** Error code. */
   NSAXIS(XQST, 134, "Namespace axis is not supported."),
+  /** Error code. */
+  DUPLTYPE_X(XQST, 146, "Duplicate declaration of type %."),
   /** Error code. */
   PARAMOPTIONAL_X(XQST, 148, "Parameter must be declared as optional: $%."),
 

--- a/basex-core/src/main/java/org/basex/query/QueryText.java
+++ b/basex-core/src/main/java/org/basex/query/QueryText.java
@@ -91,6 +91,7 @@ public interface QueryText {
   /** Parser token. */ String INTO = "into";
   /** Parser token. */ String INVOKE = "invoke";
   /** Parser token. */ String ITEM = "item";
+  /** Parser token. */ String ITEM_TYPE = "item-type";
   /** Parser token. */ String KEY = "key";
   /** Parser token. */ String LANGUAGE = "language";
   /** Parser token. */ String LAST = "last";

--- a/basex-core/src/main/java/org/basex/query/scope/AModule.java
+++ b/basex-core/src/main/java/org/basex/query/scope/AModule.java
@@ -4,6 +4,8 @@ import java.util.*;
 
 import org.basex.query.*;
 import org.basex.query.func.*;
+import org.basex.query.util.hash.*;
+import org.basex.query.value.type.*;
 import org.basex.query.var.*;
 import org.basex.util.hash.*;
 
@@ -18,6 +20,8 @@ public abstract class AModule extends StaticScope {
   public ArrayList<StaticFunc> funcs;
   /** Static variables. */
   public ArrayList<StaticVar> vars;
+  /** Public types. */
+  public QNmMap<SeqType> types;
   /** URIs of modules. */
   public TokenSet modules;
   /** Namespaces. */
@@ -35,14 +39,16 @@ public abstract class AModule extends StaticScope {
    * Assigns module properties.
    * @param fn user-defined functions
    * @param vr static variables
+   * @param tp public types
    * @param md URIs of modules
    * @param ns namespaces
    * @param d documentation string
    */
-  public void set(final ArrayList<StaticFunc> fn, final ArrayList<StaticVar> vr, final TokenSet md,
-      final TokenMap ns, final String d) {
+  public void set(final ArrayList<StaticFunc> fn, final ArrayList<StaticVar> vr,
+      final QNmMap<SeqType> tp, final TokenSet md, final TokenMap ns, final String d) {
     funcs = fn;
     vars = vr;
+    types = tp;
     modules = md;
     namespaces = ns;
     doc(d);

--- a/basex-core/src/test/java/org/basex/query/expr/MixedTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/MixedTest.java
@@ -58,6 +58,18 @@ public final class MixedTest extends SandboxTest {
     contains("import module namespace a='world' at '" + XQMFILE + "'; a:inlined()", "hello:foo");
   }
 
+  /** Checks imported module's types. */
+  @Test public void typesInModules() {
+    query("import module namespace a='world' at '" + XQMFILE + "'; '42' cast as a:int", 42);
+    query("import module namespace a='world' at '" + XQMFILE + "';" +
+      "declare item-type a:private-int as a:int; '42' cast as a:private-int", 42);
+
+    error("import module namespace a='world' at '" + XQMFILE + "';" +
+      "declare item-type Q{world}int as xs:double; '42' cast as a:int", DUPLTYPE_X);
+    error("import module namespace a='world' at '" + XQMFILE + "'; '42' cast as a:private-int",
+      WHICHCAST_X);
+  }
+
   /**
    * Overwrites an empty attribute value.
    */

--- a/basex-core/src/test/resources/hello.xqm
+++ b/basex-core/src/test/resources/hello.xqm
@@ -42,3 +42,9 @@ declare %private %Q{ns}ignored function hello:internal() as xs:string {
 declare function hello:closure() {
   count#1(1)
 };
+
+(:~ Private type. :)
+declare %private item-type hello:private-int as xs:integer;
+
+(:~ Public type. :)
+declare item-type hello:int as hello:private-int;


### PR DESCRIPTION
This change adds support for [Item Type Declarations](https://qt4cg.org/specifications/xquery-40/xquery-40.html#id-item-type-declaration), implementing them as aliases for the defined item type, and substituting each type reference with the definition during parser execution.

This does not yet take care of the spec changes in qt4cg/qtspecs#1355, nor does it include support yet for recursive record types.