### PR TITLE
Avoid reusing the EOF token (fixes BaseXdb/basex#2328)

### DIFF
--- a/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExLexer.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExLexer.java
@@ -14,9 +14,6 @@ import org.basex.util.list.*;
  * @author Leo Woerteler
  */
 public class RegExLexer implements TokenManager, RegExParserConstants {
-  /** End-of-file token. */
-  private static final Token EOF_TOKEN = new Token(EOF);
-
   /** The input string. */
   private final byte[] input;
   /** Input position. */
@@ -283,7 +280,7 @@ public class RegExLexer implements TokenManager, RegExParserConstants {
 
   @Override
   public Token getNextToken() {
-    if(pos >= input.length) return EOF_TOKEN;
+    if(pos >= input.length) return new Token(EOF);
     final int start = pos;
     payload = null;
     final int type = state > 0 ? inClass() : state < 0 ? inQuantifier() : normal();

--- a/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParser.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParser.java
@@ -520,7 +520,8 @@ for(final RegExp re : Escape.inGroup(token.image)) cg.add(re);
    * @throws ParseException parsing exception
    */
   final public   RegExp charRange(boolean isBegin) throws ParseException {int a = -1, b = -1;
-    if (getToken(2).kind == CHAR && "-".equals(getToken(2).image) && getToken(3).kind != BR_CLOSE) {
+    if (getToken(2).kind == CHAR && "-".equals(getToken(2).image)
+            && getToken(3).kind != BR_CLOSE && getToken(3).kind != EOF) {
       a = charOrEsc();
       jj_consume_token(CHAR);
       b = charOrEsc();
@@ -531,7 +532,7 @@ if(a > b) {if (true) throw new ParseException("Illegal range: " +
       case CHAR:
       case DIGIT:{
         a = XmlChar();
-if(a == '-' && ! (isBegin || getToken(1).kind == BR_CLOSE)) {if (true) throw new ParseException(
+if(a == '-' && !isBegin && getToken(1).kind != BR_CLOSE && getToken(1).kind != EOF) {if (true) throw new ParseException(
           "The - character is a valid character range only at the beginning or end of a positive character group.");}
         break;
         }
@@ -641,6 +642,12 @@ cp = Escape.getCp(token.image);
     return false;
   }
 
+  private boolean jj_3R_charRange_336_7_9()
+ {
+    if (jj_3R_XmlChar_366_5_11()) return true;
+    return false;
+  }
+
   private boolean jj_3_3()
  {
     if (jj_3R_charRange_330_5_6()) return true;
@@ -658,12 +665,6 @@ cp = Escape.getCp(token.image);
     return false;
   }
 
-  private boolean jj_3R_charRange_335_7_9()
- {
-    if (jj_3R_XmlChar_365_5_11()) return true;
-    return false;
-  }
-
   private boolean jj_3R_posCharGroup_313_5_5()
  {
     Token xsp;
@@ -675,23 +676,34 @@ cp = Escape.getCp(token.image);
     return false;
   }
 
-  private boolean jj_3R_charOrEsc_353_7_13()
+  private boolean jj_3R_charOrEsc_354_7_13()
  {
     if (jj_scan_token(SINGLE_ESC)) return true;
     return false;
   }
 
-  private boolean jj_3R_charRange_330_7_8()
+  private boolean jj_3R_charOrEsc_353_7_12()
  {
-    if (jj_3R_charOrEsc_352_5_10()) return true;
-    if (jj_scan_token(CHAR)) return true;
-    if (jj_3R_charOrEsc_352_5_10()) return true;
+    if (jj_3R_XmlChar_366_5_11()) return true;
     return false;
   }
 
-  private boolean jj_3R_charOrEsc_352_7_12()
+  private boolean jj_3R_charRange_330_7_8()
  {
-    if (jj_3R_XmlChar_365_5_11()) return true;
+    if (jj_3R_charOrEsc_353_5_10()) return true;
+    if (jj_scan_token(CHAR)) return true;
+    if (jj_3R_charOrEsc_353_5_10()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_charOrEsc_353_5_10()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_charOrEsc_353_7_12()) {
+    jj_scanpos = xsp;
+    if (jj_3R_charOrEsc_354_7_13()) return true;
+    }
     return false;
   }
 
@@ -700,22 +712,12 @@ cp = Escape.getCp(token.image);
     Token xsp;
     xsp = jj_scanpos;
     jj_lookingAhead = true;
-    jj_semLA = getToken(2).kind == CHAR && "-".equals(getToken(2).image) && getToken(3).kind != BR_CLOSE;
+    jj_semLA = getToken(2).kind == CHAR && "-".equals(getToken(2).image)
+        && getToken(3).kind != BR_CLOSE && getToken(3).kind != EOF;
     jj_lookingAhead = false;
     if (!jj_semLA || jj_3R_charRange_330_7_8()) {
     jj_scanpos = xsp;
-    if (jj_3R_charRange_335_7_9()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_charOrEsc_352_5_10()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_charOrEsc_352_7_12()) {
-    jj_scanpos = xsp;
-    if (jj_3R_charOrEsc_353_7_13()) return true;
+    if (jj_3R_charRange_336_7_9()) return true;
     }
     return false;
   }
@@ -732,7 +734,7 @@ cp = Escape.getCp(token.image);
     return false;
   }
 
-  private boolean jj_3R_XmlChar_365_5_11()
+  private boolean jj_3R_XmlChar_366_5_11()
  {
     Token xsp;
     xsp = jj_scanpos;

--- a/basex-core/src/main/javacc/regex.jj
+++ b/basex-core/src/main/javacc/regex.jj
@@ -327,13 +327,14 @@ PARSER_END(RegExParser)
   RegExp charRange(boolean isBegin) : {
     int a = -1, b = -1;
   } {
-    ( LOOKAHEAD({ getToken(2).kind == CHAR && "-".equals(getToken(2).image) && getToken(3).kind != BR_CLOSE })
+    ( LOOKAHEAD({ getToken(2).kind == CHAR && "-".equals(getToken(2).image)
+        && getToken(3).kind != BR_CLOSE && getToken(3).kind != EOF })
       (a = charOrEsc() <CHAR> b = charOrEsc()) {
         if(a > b) throw new ParseException("Illegal range: " +
             Literal.escape(a) + " > " + Literal.escape(b));
       }
     | a = XmlChar() {
-        if(a == '-' && ! (isBegin || getToken(1).kind == BR_CLOSE)) throw new ParseException(
+        if(a == '-' && !isBegin && getToken(1).kind != BR_CLOSE && getToken(1).kind != EOF) throw new ParseException(
           "The - character is a valid character range only at the beginning or end of a positive character group.");
       }
     ) {

--- a/basex-core/src/test/java/org/basex/query/func/fn/RegexTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/fn/RegexTest.java
@@ -6,6 +6,8 @@ import java.util.*;
 import java.util.regex.*;
 import java.util.stream.*;
 
+import org.basex.*;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.*;
 import org.junit.jupiter.params.provider.*;
 
@@ -15,7 +17,7 @@ import org.junit.jupiter.params.provider.*;
  * @author BaseX Team 2005-24, BSD License
  * @author Gunther Rademacher
  */
-public class RegexTest {
+public class RegexTest extends SandboxTest {
 
   /**
    * Test.
@@ -55,5 +57,10 @@ public class RegexTest {
             new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 14}),
         Arguments.of("^(?:\\-\\-((0[1-9])|(1(1|2)))\\-\\-)(?:$(?!\\s))", new int[] {0, 1, 1, 3})
     );
+  }
+
+  /** Test method. */
+  @Test public void gh2328() {
+    query("for $p in ('[^0', '[^0-') return try {matches('a', $p)} catch * {}", "");
   }
 }


### PR DESCRIPTION
`RegexLexer` was using a single static instance `EOF_TOKEN` whenever reaching the end of input. However the state of a `Token` comprises the `next` member, which `RegexParser` uses to set up a linked list of tokens. This could lead to `EOF_TOKEN` being linked to itself, creating an endless list, when `RegexLexer.getNextToken` was called again after the end had already been noticed.

Usually this does not happen, but the code in `RegexParser.charRange` does not consider `EOF`, which may lead to an extra token being acquired.

These changes remove `RegexLexer.EOF_TOKEN`, and add extra EOF-checking to `RegexParser.charRange`.