### PR TITLE
Fix module import with respect to functions, variables, and types (fixes #2048)

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryContext.java
+++ b/basex-core/src/main/java/org/basex/query/QueryContext.java
@@ -107,6 +107,8 @@ public final class QueryContext extends Job implements Closeable {
 
   /** Parsed modules, containing the file path and module uri. */
   public final TokenMap modParsed = new TokenMap();
+  /** Parsed modules, containing the file path and library module. */
+  public final TokenObjMap<LibraryModule> libs = new TokenObjMap<>();
   /** Pre-declared modules, containing module uri and their file paths (required for test APIs). */
   final TokenMap modDeclared = new TokenMap();
   /** Stack of module files that are currently parsed. */

--- a/basex-core/src/main/java/org/basex/query/QueryContext.java
+++ b/basex-core/src/main/java/org/basex/query/QueryContext.java
@@ -251,7 +251,7 @@ public final class QueryContext extends Job implements Closeable {
           sf.anns = sf.anns.attach(new Ann(sf.info, Annotation._BASEX_INLINE, Int.ZERO));
         }
         // create and assign function call
-        final StaticFuncCall call = new StaticFuncCall(sf.name, args, null, sf.info);
+        final StaticFuncCall call = new StaticFuncCall(sf.name, args, null, sf.info, true);
         call.setFunc(sf);
         main = new MainModule(call, new VarScope(), sf.sc);
         updating = sf.updating();

--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -1036,6 +1036,8 @@ public enum QueryError {
   /** Error code. */
   VARUNDEF_X(XPST, 8, "Undeclared variable: %."),
   /** Error code. */
+  INVISIBLEVAR_X(XPST, 8, "Variable requires missing module import: %."),
+  /** Error code. */
   CIRCREF_X(XPST, 8, "Static variable references itself: %"),
   /** Error code. */
   VARPRIVATE_X(XPST, 8, "Variable % is private."),
@@ -1050,7 +1052,7 @@ public enum QueryError {
   /** Error code. */
   WHICHFUNC_X(XPST, 17, "Unknown function: %."),
   /** Error code. */
-  INVISIBLEFUNC_X(XPST, 17, "Function not imported: %."),
+  INVISIBLEFUNC_X(XPST, 17, "Function requires missing module import: %."),
   /** Error code. */
   KEYWORDTWICE_X(XPST, 17, "Keyword supplied twice: %."),
   /** Error code. */

--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -1049,6 +1049,8 @@ public enum QueryError {
   /** Error code. */
   WHICHFUNC_X(XPST, 17, "Unknown function: %."),
   /** Error code. */
+  INVISIBLEFUNC_X(XPST, 17, "Function not imported: %."),
+  /** Error code. */
   KEYWORDTWICE_X(XPST, 17, "Keyword supplied twice: %."),
   /** Error code. */
   ARGMISSING_X_X(XPST, 17, "%: No argument supplied: %."),

--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -799,42 +799,47 @@ public class QueryParser extends InputParser {
     final byte[] tUri = token(uri), pUri = qc.modParsed.get(tPath);
     if(pUri != null) {
       if(!eq(tUri, pUri)) throw error(WRONGMODULE_X_X_X, info, io.name(), uri, pUri);
-      return;
     }
-    qc.modParsed.put(tPath, tUri);
+    else {
+      qc.modParsed.put(tPath, tUri);
 
-    // read module
-    final String query;
-    try {
-      query = io.string();
-    } catch(final IOException expr) {
-      Util.debug(expr);
-      throw error(WHICHMODFILE_X, info, io);
-    }
-
-    qc.modStack.push(tPath);
-    final QueryParser qp = new QueryParser(query, io.path(), qc, null);
-
-    // check if import and declaration uri match
-    final LibraryModule lib = qp.parseLibrary(false);
-    final byte[] muri = lib.sc.module.uri();
-    if(!uri.equals(string(muri))) throw error(WRONGMODULE_X_X_X, info, io.name(), uri, muri);
-
-    // check if context value declaration types are compatible to each other
-    final StaticContext sctx = qp.sc;
-    if(sctx.contextType != null) {
-      if(sc.contextType == null) {
-        sc.contextType = sctx.contextType;
-      } else if(!sctx.contextType.eq(sc.contextType)) {
-        throw error(VALUETYPES_X_X, sctx.contextType, sc.contextType);
+      // read module
+      final String query;
+      try {
+        query = io.string();
+      } catch(final IOException expr) {
+        Util.debug(expr);
+        throw error(WHICHMODFILE_X, info, io);
       }
+
+      qc.modStack.push(tPath);
+      final QueryParser qp = new QueryParser(query, io.path(), qc, null);
+
+      // check if import and declaration uri match
+      final LibraryModule lib = qp.parseLibrary(false);
+      qc.libs.put(tPath, lib);
+      final byte[] muri = lib.sc.module.uri();
+      if(!uri.equals(string(muri))) throw error(WRONGMODULE_X_X_X, info, io.name(), uri, muri);
+
+      // check if context value declaration types are compatible to each other
+      final StaticContext sctx = qp.sc;
+      if(sctx.contextType != null) {
+        if(sc.contextType == null) {
+          sc.contextType = sctx.contextType;
+        } else if(!sctx.contextType.eq(sc.contextType)) {
+          throw error(VALUETYPES_X_X, sctx.contextType, sc.contextType);
+        }
+      }
+      qc.modStack.pop();
     }
-    qc.modStack.pop();
 
     // import the module's public types
-    for(final QNm qn : lib.types) {
-      if(declaredTypes.contains(qn)) throw error(DUPLTYPE_X, qn.string());
-      declaredTypes.put(qn, lib.types.get(qn));
+    LibraryModule lib = qc.libs.get(tPath);
+    if(lib != null) {
+      for(final QNm qn : lib.types) {
+        if(declaredTypes.contains(qn)) throw error(DUPLTYPE_X, qn.string());
+        declaredTypes.put(qn, lib.types.get(qn));
+      }
     }
   }
 

--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -1932,7 +1932,8 @@ public class QueryParser extends InputParser {
           arg = expr;
         }
         final FuncBuilder fb = argumentList(name != null, arg);
-        expr = name != null ? Functions.get(name, fb, qc) : Functions.dynamic(ex, fb);
+        expr = name != null ? Functions.get(name, fb, qc, moduleURIs.contains(name.uri()))
+                            : Functions.dynamic(ex, fb);
         if(mapping) {
           expr = new GFLWOR(ii, fr, expr);
           localVars.closeScope(s);
@@ -2555,7 +2556,7 @@ public class QueryParser extends InputParser {
       if(Function.ERROR.is(num)) return num;
       if(!(num instanceof Int)) throw error(ARITY_X, num);
       final int arity = (int) ((Int) num).itr();
-      return Functions.item(name, arity, false, info(), qc);
+      return Functions.item(name, arity, false, info(), qc, moduleURIs.contains(name.uri()));
     }
     pos = p;
     return null;
@@ -2773,7 +2774,9 @@ public class QueryParser extends InputParser {
     final QNm name = eQName(sc.funcNS, null);
     if(name != null && !reserved(name)) {
       skipWs();
-      if(current('(')) return Functions.get(name, argumentList(true, null), qc);
+      if(current('(')) {
+        return Functions.get(name, argumentList(true, null), qc, moduleURIs.contains(name.uri()));
+      }
     }
     pos = p;
     return null;

--- a/basex-core/src/main/java/org/basex/query/func/StaticFuncCall.java
+++ b/basex-core/src/main/java/org/basex/query/func/StaticFuncCall.java
@@ -32,6 +32,8 @@ public final class StaticFuncCall extends FuncCall {
   QNmMap<Expr> keywords;
   /** Placeholder for an external call (if not {@code null}, will be returned by the compiler). */
   ParseExpr external;
+  /** Indicates whether a module import for the function name's URI was present. */
+  final boolean hasImport;
 
   /**
    * Function call constructor.
@@ -39,10 +41,11 @@ public final class StaticFuncCall extends FuncCall {
    * @param args positional arguments
    * @param keywords keyword arguments (can be {@code null})
    * @param info input info (can be {@code null})
+   * @param hasImport indicates whether a module import for the function name's URI was present
    */
   public StaticFuncCall(final QNm name, final Expr[] args, final QNmMap<Expr> keywords,
-      final InputInfo info) {
-    this(name, args, (StaticFunc) null, info);
+      final InputInfo info, final boolean hasImport) {
+    this(name, args, (StaticFunc) null, info, hasImport);
     this.keywords = keywords;
   }
 
@@ -52,12 +55,14 @@ public final class StaticFuncCall extends FuncCall {
    * @param args arguments
    * @param func referenced function (can be {@code null})
    * @param info input info (can be {@code null})
+   * @param hasImport indicates whether a module import for the function name's URI was present
    */
   private StaticFuncCall(final QNm name, final Expr[] args, final StaticFunc func,
-      final InputInfo info) {
+      final InputInfo info, final boolean hasImport) {
     super(info, args);
     this.name = name;
     this.func = func;
+    this.hasImport = hasImport;
   }
 
   @Override
@@ -85,7 +90,7 @@ public final class StaticFuncCall extends FuncCall {
 
   @Override
   public StaticFuncCall copy(final CompileContext cc, final IntObjMap<Var> vm) {
-    return copyType(new StaticFuncCall(name, Arr.copyAll(cc, vm, exprs), func, info));
+    return copyType(new StaticFuncCall(name, Arr.copyAll(cc, vm, exprs), func, info, hasImport));
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/func/StaticFuncs.java
+++ b/basex-core/src/main/java/org/basex/query/func/StaticFuncs.java
@@ -255,10 +255,11 @@ public final class StaticFuncs extends ExprInfo {
           final StaticFunc func = call.func;
           if(func != null) {
             if(!call.hasImport) {
-              byte[] funcModule = func.sc.module == null ? Token.EMPTY : func.sc.module.uri();
-              byte[] callModule = call.info().sc().module == null ? Token.EMPTY
-                                                                  : call.info().sc().module.uri();
-              if(!Token.eq(funcModule, callModule)) {
+              final QNm funcMod = func.sc.module;
+              final QNm callMod = call.info().sc().module;
+              final byte[] funcModUri = funcMod == null ? Token.EMPTY : funcMod.uri();
+              final byte[] callModUri = callMod == null ? Token.EMPTY : callMod.uri();
+              if(!Token.eq(funcModUri, callModUri)) {
                 throw INVISIBLEFUNC_X.get(call.info(), call.name);
               }
             }

--- a/basex-core/src/main/java/org/basex/query/func/StaticFuncs.java
+++ b/basex-core/src/main/java/org/basex/query/func/StaticFuncs.java
@@ -254,6 +254,14 @@ public final class StaticFuncs extends ExprInfo {
           // check if all implementations exist for all functions, set updating flag
           final StaticFunc func = call.func;
           if(func != null) {
+            if(!call.hasImport) {
+              byte[] funcModule = func.sc.module == null ? Token.EMPTY : func.sc.module.uri();
+              byte[] callModule = call.info().sc().module == null ? Token.EMPTY
+                                                                  : call.info().sc().module.uri();
+              if(!Token.eq(funcModule, callModule)) {
+                throw INVISIBLEFUNC_X.get(call.info(), call.name);
+              }
+            }
             if(func.expr == null) throw FUNCNOIMPL_X.get(func.info, func.name.prefixString());
             if(func.updating) qc.updating();
           } else if(((JavaCall) call.external).updating) qc.updating();

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnFunctionLookup.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnFunctionLookup.java
@@ -50,7 +50,7 @@ public final class FnFunctionLookup extends StandardFunc {
     final long arity = toLong(arg(1), qc);
     if(arity >= 0 && arity <= Integer.MAX_VALUE) {
       try {
-        return Functions.item(name, (int) arity, true, info, qc);
+        return Functions.item(name, (int) arity, true, info, qc, true);
       } catch(final QueryException ex) {
         Util.debug(ex);
       }

--- a/basex-core/src/main/java/org/basex/query/func/inspect/InspectFunctions.java
+++ b/basex-core/src/main/java/org/basex/query/func/inspect/InspectFunctions.java
@@ -24,7 +24,7 @@ public final class InspectFunctions extends StandardFunc {
     if(!defined(0)) {
       final ValueBuilder vb = new ValueBuilder(qc);
       for(final StaticFunc sf : qc.functions.funcs()) {
-        vb.add(Functions.item(sf, sf.info, qc));
+        vb.add(Functions.item(sf, sf.info, qc, true));
       }
       return vb.value(this);
     }
@@ -48,7 +48,7 @@ public final class InspectFunctions extends StandardFunc {
     // collect new functions
     final ValueBuilder vb = new ValueBuilder(qc);
     for(final StaticFunc sf : qc.functions.funcs()) {
-      if(!old.contains(sf)) vb.add(Functions.item(sf, sf.info, qc));
+      if(!old.contains(sf)) vb.add(Functions.item(sf, sf.info, qc, true));
     }
     funcs = vb.value(this);
     qc.resources.addFunctions(source.path(), funcs);

--- a/basex-core/src/main/java/org/basex/query/util/parse/LocalVars.java
+++ b/basex-core/src/main/java/org/basex/query/util/parse/LocalVars.java
@@ -102,8 +102,9 @@ public final class LocalVars {
     // - if a variable uses the module or an imported URI, or
     // - if it is specified in the main module
     final QNm module = parser.sc.module;
-    if(module == null || eq(module.uri(), uri) || parser.moduleURIs.contains(uri))
-      return parser.qc.vars.newRef(name, info);
+    final boolean hasImport = parser.moduleURIs.contains(uri);
+    if(module == null || eq(module.uri(), uri) || hasImport)
+      return parser.qc.vars.newRef(name, info, hasImport);
 
     throw parser.error(VARUNDEF_X, info, '$' + string(name.string()));
   }

--- a/basex-core/src/main/java/org/basex/query/var/StaticVarRef.java
+++ b/basex-core/src/main/java/org/basex/query/var/StaticVarRef.java
@@ -23,15 +23,18 @@ final class StaticVarRef extends ParseExpr {
   private final QNm name;
   /** Referenced variable. */
   private StaticVar var;
-
+  /** Indicates whether a module import for the variable name's URI was present. */
+  final boolean hasImport;
   /**
    * Constructor.
    * @param info input info (can be {@code null})
    * @param name variable name
+   * @param hasImport indicates whether a module import for the variable name's URI was present
    */
-  StaticVarRef(final InputInfo info, final QNm name) {
+  StaticVarRef(final InputInfo info, final QNm name, final boolean hasImport) {
     super(info, SeqType.ITEM_ZM);
     this.name = name;
+    this.hasImport = hasImport;
   }
 
   @Override
@@ -72,7 +75,7 @@ final class StaticVarRef extends ParseExpr {
 
   @Override
   public Expr copy(final CompileContext cc, final IntObjMap<Var> vm) {
-    final StaticVarRef ref = new StaticVarRef(info, name);
+    final StaticVarRef ref = new StaticVarRef(info, name, hasImport);
     ref.var = var;
     return copyType(ref);
   }

--- a/basex-core/src/test/java/org/basex/query/ModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/ModuleTest.java
@@ -100,7 +100,7 @@ public final class ModuleTest extends SandboxTest {
     }
   }
 
-  /** Tests rejection of functions, that are not explicitly imported. */
+  /** Tests rejection of functions and variables, when their modules are not explicitly imported. */
   @Test public void gh2048() {
     final IOFile sandbox = sandbox();
     final IOFile b = new IOFile(sandbox, "b.xqm");
@@ -108,8 +108,9 @@ public final class ModuleTest extends SandboxTest {
         + "import module namespace c = 'c' at 'c.xqm';");
     write(new IOFile(sandbox, "c.xqm"), "module namespace c  = 'c';\n"
         + "declare function c:hello(){\n"
-        + "  \"can you see me now\"\n"
-        + "};");
+        + "  $c:hello\n"
+        + "};\n"
+        + "declare variable $c:hello := 'can you see me now';");
 
     // function is still visible to fn:function-lookup
     query("import module namespace b  = 'b'   at '" + b.path() + "';\n"
@@ -126,5 +127,8 @@ public final class ModuleTest extends SandboxTest {
     error("import module namespace b  = 'b'   at '" + b.path() + "';\n"
         + "declare namespace c = 'c';\n"
         + "c:hello#0()", QueryError.INVISIBLEFUNC_X);
+    error("import module namespace b  = 'b'   at '" + b.path() + "';\n"
+        + "declare namespace c = 'c';\n"
+        + "$c:hello", QueryError.INVISIBLEFUNC_X);
   }
 }

--- a/basex-core/src/test/java/org/basex/query/ModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/ModuleTest.java
@@ -129,6 +129,6 @@ public final class ModuleTest extends SandboxTest {
         + "c:hello#0()", QueryError.INVISIBLEFUNC_X);
     error("import module namespace b  = 'b'   at '" + b.path() + "';\n"
         + "declare namespace c = 'c';\n"
-        + "$c:hello", QueryError.INVISIBLEFUNC_X);
+        + "$c:hello", QueryError.INVISIBLEVAR_X);
   }
 }

--- a/basex-core/src/test/java/org/basex/query/ModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/ModuleTest.java
@@ -100,34 +100,56 @@ public final class ModuleTest extends SandboxTest {
     }
   }
 
+  /** Tests type import. */
+  @Test public void importedTypes() {
+    final IOFile sandbox = sandbox();
+    final IOFile a = new IOFile(sandbox, "a.xqm");
+    write(a, "module namespace a = 'a';\n"
+        + "import module namespace b = 'b' at 'b.xqm';\n"
+        + "declare variable $a:v as b:t := 42;");
+    final IOFile b = new IOFile(sandbox, "b.xqm");
+    write(b, "module namespace b = 'b';\n"
+        + "declare type b:t as xs:integer;"
+        + "declare %private type b:p as xs:string;");
+
+    // type is visible from second import of module b
+    query("import module namespace a = 'a' at '" + a.path() + "';\n"
+        + "import module namespace b = 'b' at '" + b.path() + "';\n"
+        + "let $v as b:t := $a:v return $v");
+
+    // private type remains invisible
+    error("import module namespace b = 'b' at '" + b.path() + "';\n"
+        + "let $v as b:p := 'b:p should not be visible' return $v", QueryError.TYPEUNKNOWN_X);
+  }
+
   /** Tests rejection of functions and variables, when their modules are not explicitly imported. */
   @Test public void gh2048() {
     final IOFile sandbox = sandbox();
     final IOFile b = new IOFile(sandbox, "b.xqm");
     write(b, "module namespace b = 'b';\n"
         + "import module namespace c = 'c' at 'c.xqm';");
-    write(new IOFile(sandbox, "c.xqm"), "module namespace c  = 'c';\n"
+    write(new IOFile(sandbox, "c.xqm"), "module namespace c = 'c';\n"
         + "declare function c:hello(){\n"
         + "  $c:hello\n"
         + "};\n"
         + "declare variable $c:hello := 'can you see me now';");
 
     // function is still visible to fn:function-lookup
-    query("import module namespace b  = 'b'   at '" + b.path() + "';\n"
+    query("import module namespace b = 'b'  at '" + b.path() + "';\n"
         + "declare namespace c = 'c';\n"
         + "fn:function-lookup(xs:QName('c:hello'), 0)()", "can you see me now");
     // function is still visible to inspect:functions
-    query("import module namespace b  = 'b'   at '" + b.path() + "';\n"
+    query("import module namespace b  = 'b'  at '" + b.path() + "';\n"
         + "declare namespace c = 'c';\n"
         + "inspect:functions()", "Q{c}hello#0");
 
-    error("import module namespace b  = 'b'   at '" + b.path() + "';\n"
+    error("import module namespace b = 'b'  at '" + b.path() + "';\n"
         + "declare namespace c = 'c';\n"
         + "c:hello()", QueryError.INVISIBLEFUNC_X);
-    error("import module namespace b  = 'b'   at '" + b.path() + "';\n"
+    error("import module namespace b = 'b'  at '" + b.path() + "';\n"
         + "declare namespace c = 'c';\n"
         + "c:hello#0()", QueryError.INVISIBLEFUNC_X);
-    error("import module namespace b  = 'b'   at '" + b.path() + "';\n"
+    error("import module namespace b = 'b'  at '" + b.path() + "';\n"
         + "declare namespace c = 'c';\n"
         + "$c:hello", QueryError.INVISIBLEVAR_X);
   }


### PR DESCRIPTION
This change fixes 3 problems:

 - functions from a different module that is not directly imported are no longer visible (this fixes #2048),
 - variables from a different module that is not directly imported are no longer visible,
 - public types from a directly imported module are now visible, even if the module was imported somewhere else before (this fixes a bug in the original implementation of type imports).
 
For functions and variables, a `hasImport` flag is introduced, that serves for detecting the absence of a required module import.

For getting the type import right, `QueryContext` now has a new member `libs`, that provides the `LibraryModule` holding the declared public types.