### PR TITLE
Fix coercion to RecordType

### DIFF
--- a/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
@@ -514,11 +514,11 @@ public final class SeqType {
       }
     } else if(item instanceof XQArray && type instanceof ArrayType) {
       vb.add(((XQArray) item).coerceTo((ArrayType) type, qc, cc, info));
-    } else if(item instanceof XQMap && type instanceof MapType) {
-      vb.add(((XQMap) item).coerceTo((MapType) type, qc, cc, info));
     } else if(item instanceof XQMap && type instanceof RecordType) {
       final RecordType rt = (RecordType) type;
       vb.add(((XQMap) item).coerceTo(rt, qc, cc, info));
+    } else if(item instanceof XQMap && type instanceof MapType) {
+      vb.add(((XQMap) item).coerceTo((MapType) type, qc, cc, info));
     } else if(item instanceof FItem && type instanceof FuncType) {
       final FuncType ft = type == FUNCTION ? item.funcType() : (FuncType) type;
       vb.add(((FItem) item).coerceTo(ft, qc, cc, info));


### PR DESCRIPTION
The recent commit ba616c118c965d4df5600a44e06c2ab1ed335243 has introduced coercion to `MapType`. However this currently hides coercion to `RecordType`, because it is checked before the latter and succeeds for `RecordType`, that being a subclass of `MapType`.

This fixes `RecordTest.recRec`.