### PR TITLE
Update markup-blitz dependency to 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
       <dependency>
         <groupId>de.bottlecaps</groupId>
         <artifactId>markup-blitz</artifactId>
-        <version>1.4</version>
+        <version>1.5</version>
         <scope>runtime</scope>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
Markup Blitz 1.5 is a bugfix release.