### PR TITLE
Fix instance tests for wildcard nametests, union nodetests, and choice item types

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -3282,7 +3282,7 @@ public class QueryParser extends InputParser {
   private SeqType castTarget() throws QueryException {
     Type type;
     if(wsConsume("(")) {
-      type = choiceItemType();
+      type = choiceItemType().type;
     } else {
       final QNm name = eQName(sc.elemNS, TYPEINVALID);
       if(!name.hasURI() && eq(name.local(), token(ENUM))) {
@@ -3341,7 +3341,7 @@ public class QueryParser extends InputParser {
    */
   private SeqType itemType() throws QueryException {
     // choice item type
-    if(wsConsume("(")) return SeqType.get(choiceItemType(), Occ.EXACTLY_ONE);
+    if(wsConsume("(")) return choiceItemType();
 
     // parse annotations and type name
     final AnnList anns = annotations(false).check(false, false);
@@ -3565,7 +3565,7 @@ public class QueryParser extends InputParser {
    * @return item type
    * @throws QueryException query exception
    */
-  private Type choiceItemType() throws QueryException {
+  private SeqType choiceItemType() throws QueryException {
     final ArrayList<SeqType> types = new ArrayList<>() {
       @Override
       public boolean add(final SeqType st) {
@@ -3589,7 +3589,7 @@ public class QueryParser extends InputParser {
       }
     } while(wsConsume("|"));
     check(')');
-    return types.size() == 1 ? types.get(0).type : new ChoiceItemType(types);
+    return types.size() == 1 ? types.get(0) : new ChoiceItemType(types).seqType();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/expr/path/NameTest.java
+++ b/basex-core/src/main/java/org/basex/query/expr/path/NameTest.java
@@ -128,11 +128,33 @@ public final class NameTest extends Test {
 
   @Override
   public boolean instanceOf(final Test test) {
-    if(test instanceof NameTest) {
-      final NameTest nt = (NameTest) test;
-      return type == nt.type && part == nt.part && qname.eq(nt.qname);
+    if(!(test instanceof NameTest)) return super.instanceOf(test);
+    final NameTest nt = (NameTest) test;
+    if(type != nt.type) return false;
+    switch(nt.part) {
+      case FULL:
+        switch(part) {
+          case FULL: return qname.eq(nt.qname);
+          case LOCAL:
+          case URI: return false;
+          default: throw Util.notExpected();
+        }
+      case LOCAL:
+        switch(part) {
+          case LOCAL:
+          case FULL: return Token.eq(qname.local(), nt.qname.local());
+          case URI: return false;
+          default: throw Util.notExpected();
+        }
+      case URI:
+        switch(part) {
+          case URI:
+          case FULL: return Token.eq(qname.uri(), nt.qname.uri());
+          case LOCAL: return false;
+          default: throw Util.notExpected();
+        }
+      default: throw Util.notExpected();
     }
-    return super.instanceOf(test);
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/expr/path/UnionTest.java
+++ b/basex-core/src/main/java/org/basex/query/expr/path/UnionTest.java
@@ -15,7 +15,7 @@ import org.basex.util.*;
  */
 public final class UnionTest extends Test {
   /** Tests. */
-  final Test[] tests;
+  public final Test[] tests;
 
   /**
    * Constructor.

--- a/basex-core/src/main/java/org/basex/query/func/Closure.java
+++ b/basex-core/src/main/java/org/basex/query/func/Closure.java
@@ -200,7 +200,14 @@ public final class Closure extends Single implements Scope, XQFunctionExpr {
     // only evaluate if:
     // - the closure is empty, so we don't lose variables
     // - the result size is not too large
-    return global.isEmpty() && !cc.largeResult(expr) ? cc.preEval(this) : this;
+    if(global.isEmpty() && !cc.largeResult(expr)) {
+      try {
+        return cc.preEval(this);
+      } catch(final QueryException qe) {
+        expr = cc.error(qe, expr);
+      }
+    }
+    return this;
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/value/item/QNm.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/QNm.java
@@ -188,7 +188,9 @@ public final class QNm extends Item {
    * @return result of check
    */
   public boolean eq(final QNm qnm) {
-    return qnm == this || Token.eq(uri(), qnm.uri()) && Token.eq(local(), qnm.local());
+    if(qnm == this) return true;
+    return uri == null && qnm.uri == null ? Token.eq(name,
+        qnm.name) : Token.eq(uri(), qnm.uri()) && Token.eq(local(), qnm.local());
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
@@ -663,9 +663,17 @@ public final class SeqType {
    * @return result of check
    */
   public boolean instanceOf(final SeqType st) {
+    if(this == st) return true;
     // empty sequence: only check cardinality
-    return this == st || (zero() ? !st.oneOrMore() :
-      type.instanceOf(st.type) && occ.instanceOf(st.occ) && kindInstanceOf(st));
+    if(zero()) return !st.oneOrMore();
+    if(!occ.instanceOf(st.occ)) return false;
+    if(type instanceof ChoiceItemType) {
+      return ((ChoiceItemType) type).instanceOf(st.with(EXACTLY_ONE));
+    }
+    if(st.type instanceof ChoiceItemType) {
+      return ((ChoiceItemType) st.type).hasInstance(this.with(EXACTLY_ONE));
+    }
+    return type.instanceOf(st.type) && kindInstanceOf(st);
   }
 
   /**

--- a/basex-core/src/test/java/org/basex/query/simple/TypeTest.java
+++ b/basex-core/src/test/java/org/basex/query/simple/TypeTest.java
@@ -50,6 +50,17 @@ public final class TypeTest extends QueryTest {
         { "TypeErr 1", "1 instance of xs:abcde" },
         { "TypeErr 2", "1 instance of xs:string()" },
         { "TypeErr 3", "1 instance of item" },
+
+        { "Subtyping 1", booleans(true), "declare namespace p1='p1'; declare namespace p2='p2'; "
+            + "declare variable $x external := ''; function() as element(p1:a)? {$x} "
+            + "instance of function() as element(p1:*)?" },
+        { "Subtyping 1", booleans(false), "declare namespace p1='p1'; declare namespace p2='p2'; "
+            + "declare variable $x external := ''; function() as element(p1:*|p2:*)? {$x} "
+            + "instance of function() as element(p1:*)?" },
+        { "Subtyping 1", booleans(true), "declare variable $x external := ''; function() as "
+            + "element(a|b)? {$x} instance of function() as element(*:a|*:b)?" },
+        { "Subtyping 1", booleans(false), "declare variable $x external := ''; function() as "
+            + "element(a|b|c)? {$x} instance of function() as (element(a)|element(b))?" },
     };
   }
 }


### PR DESCRIPTION
The QT4 `subtyping` tests have reported a number of failures that called for these fixes:

  - type errors were reported while pre-evaluating `Closure`s at compile time for a function body that is never executed by a query. Reporting them made all QT4 test cases with prefix `subtyping` fail with type errors, because they use a construct similar to this:
    ```xquery
    declare variable $var as item()* external := '';
    function() as xs:integer {$var} instance of function() as xs:decimal
    ```
 - `element(p1:a)` was incorrectly not considered an instance of `element(p1:*)`
 - `element(p1:*|p2:*)` was incorrectly considered an instance of  `element(p1:*)`
 - `element(a|b)` was incorrectly not considered an instance of  `element(*:a|*:b)`
 - `element(a|b|c)` was incorrectly considered an instance of  `(element(a)|element(b))`

These have been added as tests to `TypeTest`.

Note that for running the `subtyping` tests, `fn:load-xquery-module` is needed. These changes here however are independent of it.

