### PR TITLE
Support loading of repository modules via `fn:load-xquery-module`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/FnLoadXQueryModule.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnLoadXQueryModule.java
@@ -156,7 +156,7 @@ public final class FnLoadXQueryModule extends Parse {
           throw ex;
         } catch (Exception ex) {
           Util.debug(ex);
-          throw VAREMPTY_X.get(info, var.name);
+          throw VAREMPTY_X.get(info, var.name());
         }
       }
     }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnLoadXQueryModule.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnLoadXQueryModule.java
@@ -8,6 +8,7 @@ import java.io.*;
 import java.util.*;
 import java.util.List;
 
+import org.basex.core.*;
 import org.basex.io.*;
 import org.basex.query.*;
 import org.basex.query.ann.*;
@@ -50,7 +51,12 @@ public final class FnLoadXQueryModule extends Parse {
         locs = opt.get(LOCATION_HINTS);
       } else {
         final byte[] loc = qc.modDeclared.get(modUri);
-        locs = loc == null ? new String[0] : new String[] {Token.string(loc)};
+        if(loc != null) {
+          locs = new String[] { Token.string(loc) };
+        } else {
+          final String path = repoFilePath(modUri, qc.context);
+          locs = path == null ? new String[0] : new String[] { path };
+        }
       }
       if(locs.length == 0) throw MODULE_NOT_FOUND_X.get(info, modUri);
       for(final String loc : locs) srcs.add(ii.sc().resolve(loc, ii.path()));
@@ -144,7 +150,14 @@ public final class FnLoadXQueryModule extends Parse {
     final MapBuilder variables = new MapBuilder();
     for(final StaticVar var : mqc.vars) {
       if(!var.anns.contains(Annotation.PRIVATE) && Token.eq(var.sc.module.uri(), modUri)) {
-        variables.put(var.name, var.value(mqc));
+        try {
+          variables.put(var.name, var.value(mqc));
+        } catch (QueryException ex) {
+          throw ex;
+        } catch (Exception ex) {
+          Util.debug(ex);
+          throw VAREMPTY_X.get(info, var.name);
+        }
       }
     }
 
@@ -152,6 +165,23 @@ public final class FnLoadXQueryModule extends Parse {
     result.put("functions", functions.map());
     result.put("variables", variables.map());
     return result.map();
+  }
+
+  /**
+   * Return the repository file path of the XQuery module with the given module URI, or
+   * {@code null}, if there is no such module in the repository.
+   * @param modUri module URI
+   * @param context database context
+   * @return the file path of the XQuery module in the repository (maybe {@code null})
+   */
+  private String repoFilePath(final byte[] modUri, final Context context) {
+    final String path = Strings.uri2path(Token.string(modUri));
+    final String repoPath = context.soptions.get(StaticOptions.REPOPATH);
+    for(final String suffix : IO.XQSUFFIXES) {
+      final IOFile file = new IOFile(repoPath, path + suffix);
+      if(file.exists()) return file.path();
+    }
+    return null;
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/var/StaticVar.java
+++ b/basex-core/src/main/java/org/basex/query/var/StaticVar.java
@@ -125,7 +125,7 @@ public final class StaticVar extends StaticDecl {
    * Returns the name of the variable.
    * @return name
    */
-  private String name() {
+  public String name() {
     return Strings.concat(Token.cpToken('$'), name.string());
   }
 

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -1462,6 +1462,11 @@ public final class FnModuleTest extends SandboxTest {
   /** Test method. */
   @Test public void loadXQueryModule() {
     final Function func = LOAD_XQUERY_MODULE;
+    final String module = "src/test/resources/hello.xqm";
+    query(_REPO_INSTALL.args(module));
+
+    query(func.args("world", " {'variables': {QName('world', 'ext'): 42}}")
+        + "?variables(QName('world', 'ext'))", 42);
     query("let $expr := '2 + 2'\n"
         + "let $module := `xquery version '4.0'; \n"
         + "                module namespace dyn='http://example.com/dyn';\n"
@@ -1477,6 +1482,7 @@ public final class FnModuleTest extends SandboxTest {
     error(func.args("x", " {'content': 'module namespace y = \"y\";'}"), MODULE_FOUND_OTHER_X);
     error(func.args("x.xq", " { 'content': 'declare function local:f() {}; ()' }"),
         MODULE_FOUND_MAIN_X);
+    error(func.args("world"), VAREMPTY_X);
   }
 
   /** Test method. */


### PR DESCRIPTION
This change makes `fn:load-xquery-module` load a repository module, when there is no `content` or `location-hints` option.

Also it catches any unknown exceptions from evaluating variable values in `FnLoadXQueryModule` and translates them to  a `No value assigned to ...` error message. This is for handling `%basex:lazy` external variables without a defined value.