### PR TITLE
Option value atomization

### DIFF
--- a/basex-core/src/main/java/org/basex/build/csv/CsvOptions.java
+++ b/basex-core/src/main/java/org/basex/build/csv/CsvOptions.java
@@ -74,9 +74,9 @@ public class CsvOptions extends Options {
   }
 
   @Override
-  public synchronized void assign(final Item name, final Value value, final InputInfo info)
-      throws QueryException {
-    super.assign(name, value, info);
+  public synchronized void assign(final Item name, final Value value, final QueryContext qc,
+      final InputInfo info) throws QueryException {
+    super.assign(name, value, qc, info);
     if(separator() == -1) throw OPTION_X.get(info, "Invalid separator: '%'", get(SEPARATOR));
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/StandardFunc.java
+++ b/basex-core/src/main/java/org/basex/query/func/StandardFunc.java
@@ -581,7 +581,7 @@ public abstract class StandardFunc extends Arr {
 
     final Item item = expr.item(qc, info);
     if(item instanceof XQMap) {
-      options.assign((XQMap) item, info);
+      options.assign((XQMap) item, qc, info);
     } else if(!item.isEmpty()) {
       options.assign(item, info);
     }
@@ -613,7 +613,7 @@ public abstract class StandardFunc extends Arr {
       final QueryContext qc) throws QueryException {
 
     final Item item = expr.item(qc, info);
-    if(!item.isEmpty()) options.assign(toMap(item), info);
+    if(!item.isEmpty()) options.assign(toMap(item), qc, info);
     return options;
   }
 

--- a/basex-core/src/main/java/org/basex/query/util/DeepEqualOptions.java
+++ b/basex-core/src/main/java/org/basex/query/util/DeepEqualOptions.java
@@ -2,9 +2,9 @@ package org.basex.query.util;
 
 import java.text.*;
 
-import org.basex.query.*;
 import org.basex.query.util.hash.*;
 import org.basex.query.value.item.*;
+import org.basex.query.value.seq.*;
 import org.basex.query.value.type.*;
 import org.basex.util.options.*;
 
@@ -73,8 +73,8 @@ public final class DeepEqualOptions extends Options {
   public static final BooleanOption TYPED_VALUES =
       new BooleanOption("typed-values", true);
   /** Option: unordered-elements. */
-  public static final StringOption UNORDERED_ELEMENTS =
-      new StringOption("unordered-elements", "");
+  public static final ValueOption UNORDERED_ELEMENTS =
+      new ValueOption("unordered-elements", SeqType.QNAME_ZM, Empty.VALUE);
   /** Option: whitespace. */
   public static final EnumOption<Whitespace> WHITESPACE =
       new EnumOption<>("whitespace", Whitespace.PRESERVE);
@@ -98,10 +98,9 @@ public final class DeepEqualOptions extends Options {
    * Checks if the specified QName is among the unordered element names.
    * @param qname QName
    * @return element names
-   * @throws QueryException query exception
    */
-  public boolean unordered(final QNm qname) throws QueryException {
-    if(unordered == null) unordered = QNm.set(get(UNORDERED_ELEMENTS), null);
+  public boolean unordered(final QNm qname) {
+    if(unordered == null) unordered = QNm.set(get(UNORDERED_ELEMENTS));
     return unordered.contains(qname);
   }
 }

--- a/basex-core/src/main/java/org/basex/query/value/item/QNm.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/QNm.java
@@ -14,6 +14,7 @@ import org.basex.query.*;
 import org.basex.query.util.*;
 import org.basex.query.util.collation.*;
 import org.basex.query.util.hash.*;
+import org.basex.query.value.*;
 import org.basex.query.value.type.*;
 import org.basex.util.*;
 import org.basex.util.list.*;
@@ -319,6 +320,17 @@ public final class QNm extends Item {
     for(final byte[] name : distinctTokens(token(value))) {
       if(name.length != 0) set.add(parse(name, sc == null ? null : sc.elemNS, sc, null));
     }
+    return set;
+  }
+
+  /**
+   * Returns the requested value as set of QNames.
+   * @param value value with QNames
+   * @return set with QNames
+   */
+  public static QNmSet set(final Value value) {
+    final QNmSet set = new QNmSet();
+    for(final Item item : value.iter()) set.add((QNm) item);
     return set;
   }
 

--- a/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
@@ -102,6 +102,8 @@ public final class SeqType {
   public static final SeqType QNAME_O = QNAME.seqType();
   /** Zero or one QNames. */
   public static final SeqType QNAME_ZO = QNAME.seqType(ZERO_OR_ONE);
+  /** Zero or more QNames. */
+  public static final SeqType QNAME_ZM = QNAME.seqType(ZERO_OR_MORE);
 
   /** Single xs:boolean. */
   public static final SeqType BOOLEAN_O = BOOLEAN.seqType();

--- a/basex-core/src/test/java/org/basex/query/ModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/ModuleTest.java
@@ -140,9 +140,15 @@ public final class ModuleTest extends SandboxTest {
     // import of m works from m1, m2
     query("fn:load-xquery-module('m',"
         + "{'location-hints': ('" + m1.path() + "', '" + m2.path() + "')})?variables?*", 42);
+    // same as above, put paths in an array rather than a sequence
+    query("fn:load-xquery-module('m',"
+        + "{'location-hints': ['" + m1.path() + "', '" + m2.path() + "']})?variables?*", 42);
     // import of m fails from m1, m2, o
     error("fn:load-xquery-module('m', {'location-hints': ('" + m1.path() + "', '" + m2.path()
         + "', '" + o.path() + "')})", QueryError.MODULE_FOUND_OTHER_X_X);
+    // invalid value of 'content' option
+    error("load-xquery-module('x', {'content': ('module namespace x=''x'';', 'module namespace "
+        + "x=''x'';')})", QueryError.INVALIDOPTION_X_X_X_X);
   }
 
   /** Tests rejection of functions and variables, when their modules are not explicitly imported. */


### PR DESCRIPTION
In a [recent change](https://github.com/BaseXdb/basex/commit/e961a87040900e46c9ee5f6eb1a1f1f0cf405347#diff-184e184e99b0eee9d6d7f02bce510d6bf7abeea9cc0525619837005b0a1c161bL615-L640), the atomization of option values was removed to allow passing values of type `ValueOption` without being atomized. However, this inadvertently caused `StringsOption` values to no longer accept arrays, and the issue was not detected by existing tests.

I now assume that the atomization was meant to implement this part of the [option parameter conventions](https://qt4cg.org/specifications/xpath-functions-40/Overview.html#option-parameter-conventions):

> In cases where an option is list-valued, by convention the function should accept either a sequence or an array: but this rule applies only if the specification of the option explicitly accepts either. Accepting a sequence is convenient if the value is generated programmatically using an XPath expression; while accepting an array allows the options to be held in an external file in JSON format, to be read using a call on the fn:json-doc function.

Though, I could not find any option making use of this:

> ...this rule applies only if the specification of the option explicitly accepts either...

But I think the JSON compatibility note makes sense, and it could well apply to all list-valued options. Does it? If yes, the above clause should possibly be dropped from the spec.

This change now reinstalls atomization to `StringsOption` handling, and adds a test for it.

In addition, for a `StringOption`, a check is added that explicitly rejects a sequence.