### PR TITLE
Resolved unscoped variable with `localVars`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -1939,7 +1939,7 @@ public class QueryParser extends InputParser {
           int s = 0;
           if(mapping) {
             s = localVars.openScope();
-            fr = new For(new Var(new QNm("item"), null, qc, ii), expr);
+            fr = new For(localVars.add(new Var(new QNm("item"), null, qc, ii)), expr);
             arg = new VarRef(ii, fr.var);
           } else {
             arg = expr;


### PR DESCRIPTION
In method `arrow`, a variable `$item` is created, which is never added to a `VarScope`. This causes its `slot` member to stick to the initial `-1` value and causes the AIOOBE reported in #2359.