### PR TITLE
CSV serialization for result formats of new W3C parsing functions

### DIFF
--- a/basex-core/src/main/java/org/basex/io/parse/csv/CsvXmlConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/csv/CsvXmlConverter.java
@@ -14,17 +14,19 @@ import org.basex.util.*;
  */
 public final class CsvXmlConverter extends CsvConverter {
   /** QName. */
-  protected static final QNm Q_FN_CSV = new QNm("csv", QueryText.FN_URI);
+  public static final QNm Q_FN_CSV = new QNm("csv", QueryText.FN_URI);
   /** QName. */
   protected static final QNm Q_FN_ROWS = new QNm("rows", QueryText.FN_URI);
   /** QName. */
-  protected static final QNm Q_FN_ROW = new QNm("row", QueryText.FN_URI);
+  public static final QNm Q_FN_ROW = new QNm("row", QueryText.FN_URI);
   /** QName. */
   protected static final QNm Q_FN_FIELD = new QNm("field", QueryText.FN_URI);
   /** QName. */
   protected static final QNm Q_FN_COLUMNS = new QNm("columns", QueryText.FN_URI);
   /** QName. */
-  protected static final QNm Q_FN_COLUMN = new QNm("column", QueryText.FN_URI);
+  public static final QNm Q_FN_COLUMN = new QNm("column", QueryText.FN_URI);
+  /** QName. */
+  public static final QNm Q_COLUMN = new QNm("column");
 
   /** Document node. */
   private FBuilder doc;
@@ -71,7 +73,7 @@ public final class CsvXmlConverter extends CsvConverter {
 
     final FBuilder elem = FElem.build(Q_FN_FIELD);
     final byte[] name = headers.get(column);
-    if(name != null && name.length > 0) elem.add(Q_FN_COLUMN, name);
+    if(name != null && name.length > 0) elem.add(Q_COLUMN, name);
     record.add(elem.add(shared.token(value)));
   }
 

--- a/basex-core/src/main/java/org/basex/io/serial/Serializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/Serializer.java
@@ -6,8 +6,6 @@ import static org.basex.util.Token.*;
 import java.io.*;
 import java.util.*;
 
-import org.basex.build.csv.*;
-import org.basex.build.csv.CsvOptions.*;
 import org.basex.build.json.*;
 import org.basex.build.json.JsonOptions.*;
 import org.basex.data.*;
@@ -81,11 +79,7 @@ public abstract class Serializer implements Closeable {
       case XHTML: return new XHTMLSerializer(os, so);
       case HTML:  return new HTMLSerializer(os, so);
       case TEXT:  return new TextSerializer(os, so);
-      case CSV:
-        final CsvOptions copts = so.get(SerializerOptions.CSV);
-        return copts.get(CsvOptions.FORMAT) == CsvFormat.XQUERY
-               ? new CsvXQuerySerializer(os, so)
-               : new CsvDirectSerializer(os, so);
+      case CSV:   return new CsvSerializer.Delegator(os, so);
       case JSON:
         final JsonSerialOptions jopts = so.get(SerializerOptions.JSON);
         final JsonFormat jformat = jopts.get(JsonOptions.FORMAT);

--- a/basex-core/src/main/java/org/basex/io/serial/Serializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/Serializer.java
@@ -79,7 +79,7 @@ public abstract class Serializer implements Closeable {
       case XHTML: return new XHTMLSerializer(os, so);
       case HTML:  return new HTMLSerializer(os, so);
       case TEXT:  return new TextSerializer(os, so);
-      case CSV:   return new CsvSerializer.Delegator(os, so);
+      case CSV:   return CsvSerializer.get(os, so);
       case JSON:
         final JsonSerialOptions jopts = so.get(SerializerOptions.JSON);
         final JsonFormat jformat = jopts.get(JsonOptions.FORMAT);

--- a/basex-core/src/main/java/org/basex/io/serial/SerializerOptions.java
+++ b/basex-core/src/main/java/org/basex/io/serial/SerializerOptions.java
@@ -7,7 +7,6 @@ import static org.basex.util.Token.*;
 import java.io.*;
 import java.util.function.*;
 
-import org.basex.build.csv.*;
 import org.basex.build.json.*;
 import org.basex.core.*;
 import org.basex.io.*;
@@ -15,6 +14,7 @@ import org.basex.query.*;
 import org.basex.query.expr.path.*;
 import org.basex.query.util.hash.*;
 import org.basex.query.value.item.*;
+import org.basex.query.value.map.*;
 import org.basex.query.value.node.*;
 import org.basex.query.value.type.*;
 import org.basex.util.*;
@@ -102,8 +102,8 @@ public final class SerializerOptions extends Options {
       new EnumOption<>("json-lines", YesNo.NO);
 
   /** Specific serialization parameter. */
-  public static final OptionsOption<CsvOptions> CSV =
-      new OptionsOption<>("csv", new CsvOptions());
+  public static final ValueOption CSV =
+      new ValueOption("csv", SeqType.MAP_ZO, XQMap.empty());
   /** Specific serialization parameter. */
   public static final OptionsOption<JsonSerialOptions> JSON =
       new OptionsOption<>("json", new JsonSerialOptions());

--- a/basex-core/src/main/java/org/basex/io/serial/csv/CsvArraysSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/csv/CsvArraysSerializer.java
@@ -1,0 +1,51 @@
+package org.basex.io.serial.csv;
+
+import static org.basex.query.QueryError.*;
+
+import java.io.*;
+
+import org.basex.build.csv.*;
+import org.basex.io.serial.*;
+import org.basex.query.*;
+import org.basex.query.value.*;
+import org.basex.query.value.array.*;
+import org.basex.query.value.item.*;
+import org.basex.util.list.*;
+
+/**
+ * This class serializes a sequence of arrays as CSV. The input must conform to the result
+ * format of fn:csv-to-arrays.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public final class CsvArraysSerializer extends CsvSerializer {
+  /**
+   * Constructor.
+   * @param os output stream
+   * @param sopts serialization parameters
+   * @param copts csv options
+   * @throws IOException I/O exception
+   */
+  public CsvArraysSerializer(final OutputStream os, final SerializerOptions sopts,
+      final CsvOptions copts) throws IOException {
+    super(os, sopts, copts);
+  }
+
+  @Override
+  public void serialize(final Item item) throws IOException {
+    if(!(item instanceof XQArray))
+      throw CSV_SERIALIZE_X_X.getIO("Array expected, found " + item.seqType(), item);
+    final TokenList tl = new TokenList();
+    try {
+      for(final Value value : ((XQArray) item).iterable()) {
+        if(!value.isItem()) throw CSV_SERIALIZE_X_X.getIO(
+            "Item expected, found " + value.seqType(), value);
+        tl.add(((Item) value).string(null));
+      }
+    } catch(final QueryException ex) {
+      throw new QueryIOException(ex);
+    }
+    record(tl);
+  }
+}

--- a/basex-core/src/main/java/org/basex/io/serial/csv/CsvDirectSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/csv/CsvDirectSerializer.java
@@ -37,12 +37,13 @@ public final class CsvDirectSerializer extends CsvSerializer {
    * Constructor.
    * @param os output stream
    * @param sopts serialization parameters
+   * @param copts csv options
    * @throws IOException I/O exception
    */
-  public CsvDirectSerializer(final OutputStream os, final SerializerOptions sopts)
-      throws IOException {
+  public CsvDirectSerializer(final OutputStream os, final SerializerOptions sopts,
+      final CsvOptions copts) throws IOException {
 
-    super(os, sopts);
+    super(os, sopts, copts);
     headers = header ? new TokenList() : null;
     atts = copts.get(CsvOptions.FORMAT) == CsvFormat.ATTRIBUTES;
     lax = copts.get(CsvOptions.LAX) || atts;

--- a/basex-core/src/main/java/org/basex/io/serial/csv/CsvSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/csv/CsvSerializer.java
@@ -233,7 +233,7 @@ public abstract class CsvSerializer extends StandardSerializer {
         }
 
         if(!(item instanceof XQMap)) {
-          throw CSV_SERIALIZE_X_X.getIO("Cannot serialize items of type " + item.type);
+          throw CSV_SERIALIZE_X_X.getIO("Cannot serialize items of type " + item.type, item);
         }
 
         if(((XQMap) item).contains(FnParseCsv.ROWS)) {

--- a/basex-core/src/main/java/org/basex/io/serial/csv/CsvSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/csv/CsvSerializer.java
@@ -6,8 +6,15 @@ import static org.basex.util.Token.*;
 import java.io.*;
 
 import org.basex.build.csv.*;
+import org.basex.io.parse.csv.*;
 import org.basex.io.serial.*;
+import org.basex.query.*;
+import org.basex.query.func.fn.FnCsvToArrays.*;
+import org.basex.query.func.fn.FnParseCsv.*;
+import org.basex.query.value.array.*;
 import org.basex.query.value.item.*;
+import org.basex.query.value.map.*;
+import org.basex.query.value.node.*;
 import org.basex.util.*;
 import org.basex.util.list.*;
 
@@ -17,7 +24,7 @@ import org.basex.util.list.*;
  * @author BaseX Team, BSD License
  * @author Christian Gruen
  */
-abstract class CsvSerializer extends StandardSerializer {
+public abstract class CsvSerializer extends StandardSerializer {
   /** CSV options. */
   final CsvOptions copts;
   /** Separator. */
@@ -26,6 +33,14 @@ abstract class CsvSerializer extends StandardSerializer {
   final boolean quotes;
   /** Generate backslashes. */
   final boolean backslashes;
+  /** Row delimiter (see {@link CsvOptions#ROW_DELIMITER}). */
+  private final int rowDelimiter;
+  /** Quote character (see {@link CsvOptions#QUOTE_CHARACTER}). */
+  private final int quoteCharacter;
+  /** Select columns (see {@link CsvOptions#SELECT_COLUMNS}). */
+  private final int[] selectColumns;
+  /** Maximum select columns value. */
+  private int maxCol;
 
   /** Header flag. */
   boolean header;
@@ -34,15 +49,22 @@ abstract class CsvSerializer extends StandardSerializer {
    * Constructor.
    * @param os output stream
    * @param sopts serialization parameters
+   * @param copts csv options
    * @throws IOException I/O exception
    */
-  CsvSerializer(final OutputStream os, final SerializerOptions sopts) throws IOException {
+  CsvSerializer(final OutputStream os, final SerializerOptions sopts, final CsvOptions copts)
+      throws IOException {
     super(os, sopts);
-    copts = sopts.get(SerializerOptions.CSV);
+    this.copts = copts;
     quotes = copts.get(CsvOptions.QUOTES);
     backslashes = copts.get(CsvOptions.BACKSLASHES);
     header = copts.get(CsvOptions.HEADER);
     separator = copts.separator();
+    rowDelimiter = copts.rowDelimiter();
+    quoteCharacter = copts.quoteCharacter();
+    selectColumns = copts.get(CsvOptions.SELECT_COLUMNS);
+    maxCol = -1;
+    for(final int col : selectColumns) if(col > maxCol) maxCol = col;
   }
 
   /**
@@ -51,48 +73,139 @@ abstract class CsvSerializer extends StandardSerializer {
    * @throws IOException I/O exception
    */
   final void record(final TokenList entries) throws IOException {
-    // print fields, skip trailing empty contents
-    final int fs = entries.size();
-    for(int i = 0; i < fs; i++) {
-      final byte[] v = entries.get(i);
-      if(i != 0) out.print(separator);
-
-      byte[] txt = v != null ? v : EMPTY;
-      final boolean delim = contains(txt, separator) || contains(txt, '\n');
-      final boolean special = contains(txt, '\r') || contains(txt, '\t') || contains(txt, '"');
-      if(delim || special || backslashes && contains(txt, '\\')) {
-        final TokenBuilder tb = new TokenBuilder();
-        if(delim && !backslashes && !quotes)
-          throw CSV_SERIALIZE_X_X.getIO("Output must be put into quotes", txt);
-
-        if(quotes && (delim || special)) tb.add('"');
-        final TokenParser tp = new TokenParser(txt);
-        while(tp.more()) {
-          final int cp = tp.next();
-          if(backslashes) {
-            if(cp == '\n') tb.add("\\n");
-            else if(cp == '\r') tb.add("\\r");
-            else if(cp == '\t') tb.add("\\t");
-            else if(cp == '"') tb.add("\\\"");
-            else if(cp == '\\') tb.add("\\\\");
-            else if(cp == separator && !quotes) tb.add('\\').add(cp);
-            else tb.add(cp);
-          } else {
-            if(cp == '"') tb.add('"');
-            tb.add(cp);
-          }
-        }
-        if(quotes && (delim || special)) tb.add('"');
-        txt = tb.finish();
+    int f = 0;
+    if(maxCol < 0) {
+      for(final byte[] val : entries) field(f++, val);
+    } else {
+      final byte[][] row = new byte[maxCol + 1][];
+      int i = 0;
+      for(final byte[] val : entries) {
+        final int j = selectColumns[i++] - 1;
+        if(row[j] == null) row[j] = val;
       }
-      out.print(txt);
+      for(final byte[] val : row) field(f++, val == null ? Token.EMPTY : val);
     }
-    out.print('\n');
+    out.print(rowDelimiter);
     entries.reset();
+  }
+
+  /**
+   * Prints a field value.
+   * @param seqNo field sequence number
+   * @param value field value
+   * @throws IOException I/O exception
+   */
+  final void field(final int seqNo, final byte[] value) throws IOException {
+    // print fields, skip trailing empty contents
+    if(seqNo != 0) out.print(separator);
+
+    byte[] txt = value != null ? value : Token.EMPTY;
+    final boolean delim = contains(txt, separator) || contains(txt, rowDelimiter);
+    final boolean special = contains(txt, '\r') || contains(txt, '\t')
+        || contains(txt, quoteCharacter);
+    if(delim || special || backslashes && contains(txt, '\\')) {
+      final TokenBuilder tb = new TokenBuilder();
+      if(delim && !backslashes && !quotes)
+        throw CSV_SERIALIZE_X_X.getIO("Output must be put into quotes", txt);
+
+      if(quotes && (delim || special)) tb.add(quoteCharacter);
+      final TokenParser tp = new TokenParser(txt);
+      while(tp.more()) {
+        final int cp = tp.next();
+        if(backslashes) {
+          if(cp == '\n') tb.add("\\").add(separator == '\n' ? "n" : cp);
+          else if(cp == '\r') tb.add("\\r");
+          else if(cp == '\t') tb.add("\\t");
+          else if(cp == quoteCharacter) tb.add("\\").add(cp);
+          else if(cp == '\\') tb.add("\\\\");
+          else if(cp == separator && !quotes) tb.add('\\').add(cp);
+          else tb.add(cp);
+        } else {
+          if(cp == quoteCharacter) tb.add(quoteCharacter);
+          tb.add(cp);
+        }
+      }
+      if(quotes && (delim || special)) tb.add(quoteCharacter);
+      txt = tb.finish();
+    }
+    out.print(txt);
   }
 
   @Override
   protected void atomic(final Item value) throws IOException {
     throw CSV_SERIALIZE_X.getIO("Atomic items cannot be serialized");
+  }
+
+  /**
+   * This delegator class allows lazy instantiation of the concrete CSV serializer, depending on
+   * the item to be serialized.
+   */
+  public static class Delegator extends Serializer {
+    /** Output stream. */
+    private final OutputStream os;
+    /** Serializer options. */
+    private final SerializerOptions so;
+    /** Concrete CSV serializer. */
+    private CsvSerializer delegate;
+
+    /**
+     * Constructor.
+     * @param os output stream
+     * @param sopts serializer options
+     */
+    public Delegator(final OutputStream os, final SerializerOptions sopts) {
+      this.os = os;
+      this.so = sopts;
+    }
+
+    @Override
+    public void serialize(final Item item) throws IOException {
+      if(delegate == null) {
+        try {
+          final XQMap opts = (XQMap) so.get(SerializerOptions.CSV);
+          if(item instanceof FNode) {
+            final FElem root;
+            if(item instanceof FElem) {
+              root = (FElem) item;
+            } else if(item instanceof FDoc) {
+              final FDoc doc = (FDoc) item;
+              root = doc.hasChildren() ? (FElem) doc.childIter().next() : null;
+            } else {
+              root = null;
+            }
+            if(root != null && root.qname().eq(CsvXmlConverter.Q_FN_CSV)) {
+              final ParseCsvOptions popts = new ParseCsvOptions();
+              popts.assign(opts, null);
+              popts.validate(null);
+              delegate = new CsvXmlSerializer(os, so, popts.toCsvParserOptions());
+            } else {
+              final CsvParserOptions copts = new CsvParserOptions();
+              copts.assign(opts, null);
+              delegate = new CsvDirectSerializer(os, so, copts);
+            }
+          } else if(item instanceof XQArray) {
+            final CsvToArraysOptions aopts = new CsvToArraysOptions();
+            aopts.assign(opts, null);
+            aopts.validate(null);
+            delegate = new CsvArraysSerializer(os, so, aopts.toCsvParserOptions());
+          } else if(!(item instanceof XQMap)) {
+            throw new UnsupportedOperationException(
+                "Cannot serialize items of type " + item.getClass());
+          } else if(((XQMap) item).contains(CsvXQueryConverter.RECORDS)) {
+            final CsvParserOptions copts = new CsvParserOptions();
+            copts.assign(opts, null);
+            delegate = new CsvXQuerySerializer(os, so, copts);
+          } else {
+            final ParseCsvOptions popts = new ParseCsvOptions();
+            popts.assign(opts, null);
+            popts.validate(null);
+            delegate = new CsvMapSerializer(os, so, popts.toCsvParserOptions());
+          }
+        } catch(final QueryException ex) {
+          throw new QueryIOException(ex);
+        }
+      }
+      delegate.serialize(item);
+    }
   }
 }

--- a/basex-core/src/main/java/org/basex/io/serial/csv/CsvXmlSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/csv/CsvXmlSerializer.java
@@ -1,0 +1,91 @@
+package org.basex.io.serial.csv;
+
+import static org.basex.query.QueryError.*;
+import static org.basex.util.Token.*;
+
+import java.io.*;
+
+import org.basex.build.csv.*;
+import org.basex.io.parse.csv.*;
+import org.basex.io.serial.*;
+import org.basex.query.util.ft.*;
+import org.basex.query.value.item.*;
+import org.basex.util.*;
+import org.basex.util.list.*;
+
+/**
+ * This class serializes items as CSV.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public final class CsvXmlSerializer extends CsvSerializer {
+  /** Names of header elements. */
+  private final TokenList headers;
+  /** Contents of current row. */
+  private TokenList data;
+
+  /**
+   * Constructor.
+   * @param os output stream
+   * @param sopts serialization parameters
+   * @param copts csv options
+   * @throws IOException I/O exception
+   */
+  public CsvXmlSerializer(final OutputStream os, final SerializerOptions sopts,
+      final CsvOptions copts) throws IOException {
+
+    super(os, sopts, copts);
+    headers = header ? new TokenList() : null;
+  }
+
+  @Override
+  protected void startOpen(final QNm name) {
+    if(level == 2) data = new TokenList();
+  }
+
+  @Override
+  protected void finishEmpty() throws IOException {
+    finishOpen();
+    switch(level) {
+      case 2:
+        if(header && elem.eq(CsvXmlConverter.Q_FN_COLUMN)) headers.add(EMPTY);
+        break;
+      case 3:
+        data.add(EMPTY);
+        break;
+    }
+    finishClose();
+  }
+
+  @Override
+  protected void text(final byte[] value, final FTPos ftp) throws IOException {
+    switch(level) {
+      case 3:
+        if(header && elem.eq(CsvXmlConverter.Q_FN_COLUMN)) headers.add(value);
+        break;
+      case 4:
+        data.add(value);
+        break;
+    }
+  }
+
+  @Override
+  protected void finishClose() throws IOException {
+    if(level != 2 || !elem.eq(CsvXmlConverter.Q_FN_ROW)) return;
+    if(header) {
+      record(headers);
+      header = false;
+    }
+    final TokenList line = data;
+    record(line);
+  }
+
+  @Override
+  protected void attribute(final byte[] name, final byte[] value, final boolean standalone)
+      throws IOException {
+    if(headers == null || !name.equals(CsvXmlConverter.Q_COLUMN.local())) return;
+    if(data.size() < headers.size() && Token.eq(value, headers.get(data.size()))) return;
+    throw CSV_SERIALIZE_X_X.getIO("Unexpected column", value);
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/expr/ParseExpr.java
+++ b/basex-core/src/main/java/org/basex/query/expr/ParseExpr.java
@@ -347,7 +347,7 @@ public abstract class ParseExpr extends Expr {
   /**
    * Converts an item to a boolean.
    * @param item item to be converted
-   * @param info input info
+   * @param info input info (can be {@code null})
    * @return boolean
    * @throws QueryException query exception
    */

--- a/basex-core/src/main/java/org/basex/query/func/csv/CsvSerialize.java
+++ b/basex-core/src/main/java/org/basex/query/func/csv/CsvSerialize.java
@@ -2,12 +2,12 @@ package org.basex.query.func.csv;
 
 import static org.basex.query.QueryError.*;
 
-import org.basex.build.csv.*;
 import org.basex.io.serial.*;
 import org.basex.query.*;
 import org.basex.query.func.*;
 import org.basex.query.iter.*;
 import org.basex.query.value.item.*;
+import org.basex.query.value.map.*;
 import org.basex.util.*;
 
 /**
@@ -20,11 +20,10 @@ public final class CsvSerialize extends StandardFunc {
   @Override
   public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
     final Iter input = arg(0).iter(qc);
-    final CsvOptions options = toOptions(arg(1), new CsvOptions(), qc);
-
+    final Item options = arg(1).item(qc, ii);
     final SerializerOptions sopts = new SerializerOptions();
     sopts.set(SerializerOptions.METHOD, SerialMethod.CSV);
-    sopts.set(SerializerOptions.CSV, options);
+    sopts.set(SerializerOptions.CSV, options.isEmpty() ? XQMap.empty() : toMap(options));
     return Str.get(serialize(input, sopts, INVALIDOPT_X, qc));
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnCsvToArrays.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnCsvToArrays.java
@@ -55,10 +55,10 @@ public class FnCsvToArrays extends Parse {
 
     /**
      * Check for error conditions in the current settings.
-     * @param ii input info
+     * @param ii input info (can be {@code null})
      * @throws QueryException query exception
      */
-    void validate(final InputInfo ii) throws QueryException {
+    public void validate(final InputInfo ii) throws QueryException {
       final IntSet delim = new IntSet();
       for(final StringOption opt : Arrays.asList(FIELD_DELIMITER, ROW_DELIMITER, QUOTE_CHARACTER)) {
         final String val = get(opt);
@@ -73,7 +73,7 @@ public class FnCsvToArrays extends Parse {
      * Convert the options to a CsvParserOptions object.
      * @return the CsvParserOptions object
      */
-    CsvParserOptions toCsvParserOptions() {
+    public CsvParserOptions toCsvParserOptions() {
       final CsvParserOptions copts = new CsvParserOptions();
       copts.set(CsvOptions.SEPARATOR, get(FIELD_DELIMITER));
       copts.set(CsvOptions.ROW_DELIMITER, get(ROW_DELIMITER));

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnParseCsv.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnParseCsv.java
@@ -29,6 +29,11 @@ import org.basex.util.options.*;
  * @author Gunther Rademacher
  */
 public class FnParseCsv extends Parse {
+  /** Columns. */
+  public static final Str COLUMNS = Str.get("columns");
+  /** Rows. */
+  public static final Str ROWS = Str.get("rows");
+
   @Override
   public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
     final byte[] value = toZeroToken(arg(0), qc);
@@ -65,9 +70,9 @@ public class FnParseCsv extends Parse {
       final Value rows = map.get(CsvXQueryConverter.RECORDS);
 
       final MapBuilder result = new MapBuilder();
-      result.put("columns", columns);
+      result.put(COLUMNS, columns);
       result.put("column-index", columnIndex);
-      result.put("rows", rows);
+      result.put(ROWS, rows);
       result.put("get", Get.funcItem(rows, columnIndex, qc, ii));
       return result.map();
     } catch(final IOException ex) {
@@ -166,7 +171,7 @@ public class FnParseCsv extends Parse {
     private boolean extractHeader;
 
     @Override
-    void validate(final InputInfo ii) throws QueryException {
+    public void validate(final InputInfo ii) throws QueryException {
       super.validate(ii);
       final Value header = get(HEADER);
       if(BOOLEAN_O.instance(header)) extractHeader = toBoolean((Item) header, ii);
@@ -175,7 +180,7 @@ public class FnParseCsv extends Parse {
     }
 
     @Override
-    CsvParserOptions toCsvParserOptions() {
+    public CsvParserOptions toCsvParserOptions() {
       final CsvParserOptions copts = super.toCsvParserOptions();
       copts.set(CsvOptions.TRIM_ROWS, get(TRIM_ROWS));
       copts.set(CsvOptions.SELECT_COLUMNS, get(SELECT_COLUMNS));

--- a/basex-core/src/main/java/org/basex/util/options/Options.java
+++ b/basex-core/src/main/java/org/basex/util/options/Options.java
@@ -361,6 +361,15 @@ public class Options implements Iterable<Option<?>> {
   }
 
   /**
+   * Sets the value of an option.
+   * @param option option to be set
+   * @param value value to be set
+   */
+  public final synchronized void set(final ValueOption option, final Value value) {
+    put(option, value);
+  }
+
+  /**
    * Assigns a value after casting it to the correct type. If the option is unknown,
    * it will be added as free option.
    * @param name name of option

--- a/basex-core/src/test/java/org/basex/query/func/CsvRoundtripTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/CsvRoundtripTest.java
@@ -1,0 +1,450 @@
+package org.basex.query.func;
+
+import static org.basex.query.func.Function.*;
+
+import org.basex.*;
+import org.junit.jupiter.api.*;
+
+/**
+ * This class roundtrips CSV data through parsing and serialization.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public final class CsvRoundtripTest extends SandboxTest {
+  /** Test method. */
+  @Test public void csvParse() {
+    final Function func = _CSV_PARSE;
+    roundtrip(func, "1,2,3,4|11,12,13,14", "'select-columns': (1, 4, 17), 'row-"
+        + "delimiter': '|'", "<csv><record><entry>1</entry><entry>4</entry><entry/></record><record"
+            + "><entry>11</entry><entry>14</entry><entry/></record></csv>");
+    roundtrip(func, "a,b,c,d|1,2,3,4|11,12,13,14", "'format': 'attributes', 'header': true(), 'sele"
+        + "ct-columns': (1, 4, 2), 'row-delimiter': '|'", "<csv><record><entry name=\"a\">1</entry>"
+        + "<entry name=\"d\">4</entry><entry name=\"b\">2</entry></record><record><entry name=\"a\""
+        + ">11</entry><entry name=\"d\">14</entry><entry name=\"b\">12</entry></record></csv>");
+    roundtrip(func, "1,2,3,4|11,12,13,14", "'format': 'xquery', 'select-columns': (1, 4, 17), 'row-"
+        + "delimiter': '|'", "{\"records\":([\"1\",\"4\",\"\"],[\"11\",\"14\",\"\"])}");
+  }
+
+  /** Test method. */
+  @Test public void csvToArrays() {
+    final Function func = CSV_TO_ARRAYS;
+    roundtrip(func, "", "", "");
+    roundtrip(func, "one", "", "[\"one\"]");
+    roundtrip(func, "one,two", "", "[\"one\",\"two\"]");
+    roundtrip(func, "one,two&#xA;three,four", "", "[\"one\",\"two\"]\n[\"three\",\"four\"]");
+    roundtrip(func, "one,two&#xA;three,four&#xA;", "", "[\"one\",\"two\"]\n[\"three\",\"four\"]");
+    roundtrip(func, "one,two&#xA;three,four,five", "", "[\"one\",\"two\"]\n[\"three\",\"four\",\"fi"
+        + "ve\"]");
+    roundtrip(func, "one,two&#xA;&#xA;three,four", "", "[\"one\",\"two\"]\n[]\n[\"three\",\"four\"]"
+        );
+    roundtrip(func, "one,two&#xA;\"three,four\",five", "", "[\"one\",\"two\"]\n[\"three,four\",\"fi"
+        + "ve\"]");
+    roundtrip(func, "one,two&#xA;\"three,\"\"four\"\"\",five", "", "[\"one\",\"two\"]\n[\"three,\""
+        + "\"four\"\"\",\"five\"]");
+    roundtrip(func, "one,&#xA;,four&#xA;,&#xA;,,,", "", "[\"one\",\"\"]\n[\"\",\"four\"]\n[\"\",\""
+        + "\"]\n[\"\",\"\",\"\",\"\"]");
+    roundtrip(func, "one,\"\"&#xA;\"\",\"four\"", "", "[\"one\",\"\"]\n[\"\",\"four\"]");
+    roundtrip(func, "one,\"[&#xA;]\"&#xA;\"\",\"four\"", "", "[\"one\",\"[&#xA;]\"]\n[\"\",\"four\""
+        + "]");
+    roundtrip(func, "one;two&#xA;three;four", "'field-delimiter': ';'", "[\"one\",\"two\"]\n[\"thre"
+        + "e\",\"four\"]");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|'", "[\"one\",\"two\"]\n[\"three\",\""
+        + "four\"]");
+    roundtrip(func, "one.two|three.four", "'row-delimiter': '|', 'field-delimiter': '.'", "[\"one\""
+        + ",\"two\"]\n[\"three\",\"four\"]");
+    roundtrip(func, "one,'two,2'|three,'four,4'", "'row-delimiter': '|', 'quote-character': ''''",
+        "[\"one\",\"two,2\"]\n[\"three\",\"four,4\"]");
+    roundtrip(func, "one,'two,''2'''|three,'four,''4'''", "'row-delimiter': '|', 'quote-character':"
+        + " ''''", "[\"one\",\"two,'2'\"]\n[\"three\",\"four,'4'\"]");
+    roundtrip(func, "one ,two | three, four", "'row-delimiter': '|'", "[\"one \",\"two \"]\n[\" thr"
+        + "ee\",\" four\"]");
+    roundtrip(func, "one ,two | three, four", "'row-delimiter': '|', 'trim-whitespace': false()",
+        "[\"one \",\"two \"]\n[\" three\",\" four\"]");
+    roundtrip(func, "one ,two | three, twenty  four ", "'row-delimiter': '|', 'trim-whitespace': tr"
+        + "ue()", "[\"one\",\"two\"]\n[\"three\",\"twenty  four\"]");
+    roundtrip(func, "&#xA;", "", "[]");
+    roundtrip(func, "&#xA; ", "", "[]\n[\" \"]");
+    roundtrip(func, "&#xA; ", "'trim-whitespace': true()", "[]");
+    roundtrip(func, "&#xA;&#xA;", "'trim-whitespace': true()", "[]\n[]");
+    roundtrip(func, "&#xA;&#xA;&#xA;", "'trim-whitespace': true()", "[]\n[]\n[]");
+    roundtrip(func, "one,two,\"z\"", "", "[\"one\",\"two\",\"z\"]");
+    roundtrip(func, "one,two,\"z\"&#xA;", "", "[\"one\",\"two\",\"z\"]");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|'", "[\"a\",\"b\",\"c\",\"d\",\""
+        + "e\",\"f\"]\n[\"p\",\"q\",\"r\",\"s\",\"t\",\"u\"]");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|'", "[\"a\",\"b\",\"c\",\"d\",\""
+        + "e\",\"f\"]\n[\"p\",\"q\",\"r\",\"s\",\"t\",\"u\"]");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|'", "[\"a\",\"b\",\"c\",\"d\",\""
+        + "e\",\"f\"]\n[\"p\",\"q\",\"r\",\"s\",\"t\",\"u\"]");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|'", "[\"a\",\"b\",\"c\",\"d\",\""
+        + "e\",\"f\"]\n[\"p\",\"q\",\"r\",\"s\",\"t\",\"u\"]");
+    roundtrip(func, "a,b,c|p,q,r", "'row-delimiter': '|'", "[\"a\",\"b\",\"c\"]\n[\"p\",\"q\",\"r\""
+        + "]");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|'", "[\"a\",\"b\",\"c\",\"d\",\""
+        + "e\",\"f\"]\n[\"p\",\"q\",\"r\",\"s\",\"t\",\"u\"]");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|'", "[\"a\",\"b\",\"c\",\"d\",\""
+        + "e\",\"f\"]\n[\"p\",\"q\",\"r\",\"s\",\"t\",\"u\"]");
+  }
+
+  /** Test method. */
+  @Test public void parseCsv() {
+    final Function func = PARSE_CSV;
+    roundtrip(func, " ()", "", "{\"columns\":(),\"column-index\":{},\"rows\":(),\"get\":(anonymous-"
+        + "function)#2}");
+    roundtrip(func, "", "", "{\"columns\":(),\"column-index\":{},\"rows\":(),\"get\":(anonymous-fun"
+        + "ction)#2}");
+    roundtrip(func, "one", "", "{\"columns\":(),\"column-index\":{},\"rows\":[\"one\"],\"get\":(ano"
+        + "nymous-function)#2}");
+    roundtrip(func, "one,two", "", "{\"columns\":(),\"column-index\":{},\"rows\":[\"one\",\"two\"],"
+        + "\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one,two&#xA;three,four", "", "{\"columns\":(),\"column-index\":{},\"rows\":(["
+        + "\"one\",\"two\"],[\"three\",\"four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one,two&#xA;three,four&#xA;", "", "{\"columns\":(),\"column-index\":{},\"rows"
+        + "\":([\"one\",\"two\"],[\"three\",\"four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one,two&#xA;three,four,five", "", "{\"columns\":(),\"column-index\":{},\"rows"
+        + "\":([\"one\",\"two\"],[\"three\",\"four\",\"five\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one,two&#xA;&#xA;three,four", "", "{\"columns\":(),\"column-index\":{},\"rows"
+        + "\":([\"one\",\"two\"],[],[\"three\",\"four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one,two&#xA;\"three,four\",five", "", "{\"columns\":(),\"column-index\":{},\"r"
+        + "ows\":([\"one\",\"two\"],[\"three,four\",\"five\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one,two&#xA;\"three,\"\"four\"\"\",five", "", "{\"columns\":(),\"column-index"
+        + "\":{},\"rows\":([\"one\",\"two\"],[\"three,\"\"four\"\"\",\"five\"]),\"get\":(anonymous"
+        + "-function)#2}");
+    roundtrip(func, "one,&#xA;,four&#xA;,&#xA;,,,", "", "{\"columns\":(),\"column-index\":{},\"rows"
+        + "\":([\"one\",\"\"],[\"\",\"four\"],[\"\",\"\"],[\"\",\"\",\"\",\"\"]),\"get\":(anonymous"
+        + "-function)#2}");
+    roundtrip(func, "one,\"\"&#xA;\"\",\"four\"", "", "{\"columns\":(),\"column-index\":{},\"rows\""
+        + ":([\"one\",\"\"],[\"\",\"four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one,\"[&#xA;]\"&#xA;\"\",\"four\"", "", "{\"columns\":(),\"column-index\":{},"
+        + "\"rows\":([\"one\",\"[&#xA;]\"],[\"\",\"four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one;two&#xA;three;four", "'field-delimiter': ';'", "{\"columns\":(),\"column-i"
+        + "ndex\":{},\"rows\":([\"one\",\"two\"],[\"three\",\"four\"]),\"get\":(anonymous-function)"
+        + "#2}");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|'", "{\"columns\":(),\"column-index\""
+        + ":{},\"rows\":([\"one\",\"two\"],[\"three\",\"four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one.two|three.four", "'row-delimiter': '|', 'field-delimiter': '.'", "{\"colum"
+        + "ns\":(),\"column-index\":{},\"rows\":([\"one\",\"two\"],[\"three\",\"four\"]),\"get\":(a"
+        + "nonymous-function)#2}");
+    roundtrip(func, "one,'two,2'|three,'four,4'", "'row-delimiter': '|', 'quote-character': ''''",
+        "{\"columns\":(),\"column-index\":{},\"rows\":([\"one\",\"two,2\"],[\"three\",\"four,4\"]),"
+        + "\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one,'two,''2'''|three,'four,''4'''", "'row-delimiter': '|', 'quote-character':"
+        + " ''''", "{\"columns\":(),\"column-index\":{},\"rows\":([\"one\",\"two,'2'\"],[\"three\","
+        + "\"four,'4'\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one ,two | three, four", "'row-delimiter': '|'", "{\"columns\":(),\"column-ind"
+        + "ex\":{},\"rows\":([\"one \",\"two \"],[\" three\",\" four\"]),\"get\":(anonymous-functio"
+        + "n)#2}");
+    roundtrip(func, "one ,two | three, four", "'row-delimiter': '|', 'trim-whitespace': false()", ""
+        + "{\"columns\":(),\"column-index\":{},\"rows\":([\"one \",\"two \"],[\" three\",\" four\"]"
+        + "),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one ,two | three, twenty  four ", "'row-delimiter': '|', 'trim-whitespace': tr"
+        + "ue()", "{\"columns\":(),\"column-index\":{},\"rows\":([\"one\",\"two\"],[\"three\",\"twe"
+        + "nty  four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "&#xA;", "", "{\"columns\":(),\"column-index\":{},\"rows\":[],\"get\":(anonymou"
+        + "s-function)#2}");
+    roundtrip(func, "&#xA; ", "", "{\"columns\":(),\"column-index\":{},\"rows\":([],[\" \"]),\"get"
+        + "\":(anonymous-function)#2}");
+    roundtrip(func, "&#xA; ", "'trim-whitespace': true()", "{\"columns\":(),\"column-index\":{},\"r"
+        + "ows\":[],\"get\":(anonymous-function)#2}");
+    roundtrip(func, "&#xA;&#xA;", "'trim-whitespace': true()", "{\"columns\":(),\"column-index\":{}"
+        + ",\"rows\":([],[]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "&#xA;&#xA;&#xA;", "'trim-whitespace': true()", "{\"columns\":(),\"column-index"
+        + "\":{},\"rows\":([],[],[]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "left,right|one,two|three,four", "'row-delimiter': '|', 'header': true()", "{\""
+        + "columns\":(\"left\",\"right\"),\"column-index\":{\"left\":1,\"right\":2},\"rows\":([\"on"
+        + "e\",\"two\"],[\"three\",\"four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|', 'header': ('left', 'right')", "{\""
+        + "columns\":(\"left\",\"right\"),\"column-index\":{\"left\":1,\"right\":2},\"rows\":([\"on"
+        + "e\",\"two\"],[\"three\",\"four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|', 'header': false()", "{\"columns\":"
+        + "(),\"column-index\":{},\"rows\":([\"one\",\"two\"],[\"three\",\"four\"]),\"get\":(anonym"
+        + "ous-function)#2}");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|', 'header': 'left'", "{\"columns\":"
+        + "\"left\",\"column-index\":{\"left\":1},\"rows\":([\"one\",\"two\"],[\"three\",\"four\"])"
+        + ",\"get\":(anonymous-function)#2}");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|', 'header': ('', 'right')", "{\"colu"
+        + "mns\":(\"\",\"right\"),\"column-index\":{\"right\":2},\"rows\":([\"one\",\"two\"],[\"thr"
+        + "ee\",\"four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "left,left|one,two|three,four", "'row-delimiter': '|', 'header': true()", "{\"c"
+        + "olumns\":(\"left\",\"left\"),\"column-index\":{\"left\":1},\"rows\":([\"one\",\"two\"],["
+        + "\"three\",\"four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, ",right|one,two|three,four", "'row-delimiter': '|', 'header': true()", "{\"colu"
+        + "mns\":(\"\",\"right\"),\"column-index\":{\"right\":2},\"rows\":([\"one\",\"two\"],[\"thr"
+        + "ee\",\"four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, ",|one,two|three,four", "'row-delimiter': '|', 'header': true()", "{\"columns\""
+        + ":(\"\",\"\"),\"column-index\":{},\"rows\":([\"one\",\"two\"],[\"three\",\"four\"]),\"get"
+        + "\":(anonymous-function)#2}");
+    roundtrip(func, "left,right", "'row-delimiter': '|', 'header': true()", "{\"columns\":(\"left\""
+        + ",\"right\"),\"column-index\":{\"left\":1,\"right\":2},\"rows\":(),\"get\":(anonymous-fun"
+        + "ction)#2}");
+    roundtrip(func, "1,2,3,4,5,6,7,8,9,10|11,12,13,14,15,16,17,18,19,20", "'row-delimiter': '|', 's"
+        + "elect-columns': (1 to 4)", "{\"columns\":(),\"column-index\":{},\"rows\":([\"1\",\"2\","
+            + "\"3\",\"4\"],[\"11\",\"12\",\"13\",\"14\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "a,b,c,d,e,f,g,h,i|1,2,3,4,5,6,7,8,9,10|11,12,13,14,15,16,17,18,19,20", "'row-d"
+        + "elimiter': '|', 'select-columns': (1 to 4), 'header': true()", "{\"columns\":(\"a\",\"b"
+        + "\",\"c\",\"d\"),\"column-index\":{\"a\":1,\"b\":2,\"c\":3,\"d\":4},\"rows\":([\"1\",\"2"
+        + "\",\"3\",\"4\"],[\"11\",\"12\",\"13\",\"14\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "1,2,3,4|11,12,13,14,15,16,17,18,19,20", "'row-delimiter': '|', 'trim-rows': tr"
+        + "ue()", "{\"columns\":(),\"column-index\":{},\"rows\":([\"1\",\"2\",\"3\",\"4\"],[\"11\","
+            + "\"12\",\"13\",\"14\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "a,b,c,d|1,2,3,4,5,6,7,8,9,10|11,12,13,14,15,16,17,18,19,20", "'row-delimiter':"
+        + " '|', 'trim-rows': true(), 'header': true()", "{\"columns\":(\"a\",\"b\",\"c\",\"d\"),\""
+        + "column-index\":{\"a\":1,\"b\":2,\"c\":3,\"d\":4},\"rows\":([\"1\",\"2\",\"3\",\"4\"],[\""
+        + "11\",\"12\",\"13\",\"14\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "1,2,3,4|11,12,13,14,15,16", "'row-delimiter': '|', 'trim-rows': false(), 'head"
+        + "er': false()", "{\"columns\":(),\"column-index\":{},\"rows\":([\"1\",\"2\",\"3\",\"4\"],"
+        + "[\"11\",\"12\",\"13\",\"14\",\"15\",\"16\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "1,2,3,4,5,6|14,15,16", "'row-delimiter': '|', 'select-columns': (1 to 4)", "{"
+        + "\"columns\":(),\"column-index\":{},\"rows\":([\"1\",\"2\",\"3\",\"4\"],[\"14\",\"15\",\""
+        + "16\",\"\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "1,2,3,4,5,6|14,15,16", "'row-delimiter': '|', 'trim-rows': true()", "{\"column"
+        + "s\":(),\"column-index\":{},\"rows\":([\"1\",\"2\",\"3\",\"4\",\"5\",\"6\"],[\"14\",\"15"
+        + "\",\"16\",\"\",\"\",\"\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "a,b,c,d,e|1,2,3|14,15,16", "'row-delimiter': '|', 'trim-rows': true(), 'header"
+        + "': true()", "{\"columns\":(\"a\",\"b\",\"c\",\"d\",\"e\"),\"column-index\":{\"a\":1,\"b"
+        + "\":2,\"c\":3,\"d\":4,\"e\":5},\"rows\":([\"1\",\"2\",\"3\",\"\",\"\"],[\"14\",\"15\",\"1"
+        + "6\",\"\",\"\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "1,2,3,4|11,12,13,14", "'select-columns': (4, 3, 2, 1), 'row-delimiter': '|'",
+        "{\"columns\":(),\"column-index\":{},\"rows\":([\"4\",\"3\",\"2\",\"1\"],[\"14\",\"13\",\"1"
+        + "2\",\"11\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "1,2,3,4|11,12,13,14", "'select-columns': (1, 4), 'row-delimiter': '|'", "{\"co"
+        + "lumns\":(),\"column-index\":{},\"rows\":([\"1\",\"4\"],[\"11\",\"14\"]),\"get\":(anonymo"
+        + "us-function)#2}");
+    roundtrip(func, "1,2,3,4|11,12,13,14", "'select-columns': (1, 4, 17), 'row-delimiter': '|'", "{"
+        + "\"columns\":(),\"column-index\":{},\"rows\":([\"1\",\"4\",\"\"],[\"11\",\"14\",\"\"]),\""
+        + "get\":(anonymous-function)#2}");
+    roundtrip(func, "1,2,3,4|11,12,13,14", "'select-columns': (1, 17, 4), 'row-delimiter': '|'", "{"
+        + "\"columns\":(),\"column-index\":{},\"rows\":([\"1\",\"\",\"4\"],[\"11\",\"\",\"14\"]),\""
+        + "get\":(anonymous-function)#2}");
+    roundtrip(func, "1,2,3,4|11,12,13,14,15", "'select-columns': (1, 4, 5), 'row-delimiter': '|'",
+        "{\"columns\":(),\"column-index\":{},\"rows\":([\"1\",\"4\",\"\"],[\"11\",\"14\",\"15\"]),"
+        + "\"get\":(anonymous-function)#2}");
+    roundtrip(func, "first,second,third,fourth|1,2,3,4|11,12,13,14", "'select-columns': (1, 4, 3), "
+        + "'header': true(), 'row-delimiter': '|'", "{\"columns\":(\"first\",\"fourth\",\"third\"),"
+        + "\"column-index\":{\"first\":1,\"fourth\":2,\"third\":3},\"rows\":([\"1\",\"4\",\"3\"],["
+        + "\"11\",\"14\",\"13\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|', 'select-columns': (1 to 3)",
+        "{\"columns\":(),\"column-index\":{},\"rows\":([\"a\",\"b\",\"c\"],[\"p\",\"q\",\"r\"]),\"g"
+        + "et\":(anonymous-function)#2}");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|', 'select-columns': (2 to 4)",
+        "{\"columns\":(),\"column-index\":{},\"rows\":([\"b\",\"c\",\"d\"],[\"q\",\"r\",\"s\"]),\"g"
+        + "et\":(anonymous-function)#2}");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|', 'select-columns': (4, 3, 2)",
+        "{\"columns\":(),\"column-index\":{},\"rows\":([\"d\",\"c\",\"b\"],[\"s\",\"r\",\"q\"]),\"g"
+        + "et\":(anonymous-function)#2}");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|', 'select-columns': (4, 3, 1)",
+        "{\"columns\":(),\"column-index\":{},\"rows\":([\"d\",\"c\",\"a\"],[\"s\",\"r\",\"p\"]),\"g"
+        + "et\":(anonymous-function)#2}");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|', 'select-columns': (4, 3, 1)",
+        "{\"columns\":(),\"column-index\":{},\"rows\":([\"d\",\"c\",\"a\"],[\"s\",\"r\",\"p\"]),\"g"
+        + "et\":(anonymous-function)#2}");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|', 'select-columns': (4, 3, 1)",
+        "{\"columns\":(),\"column-index\":{},\"rows\":([\"d\",\"c\",\"a\"],[\"s\",\"r\",\"p\"]),\"g"
+        + "et\":(anonymous-function)#2}");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|', 'select-columns': (4, 3, 1)",
+        "{\"columns\":(),\"column-index\":{},\"rows\":([\"d\",\"c\",\"a\"],[\"s\",\"r\",\"p\"]),\""
+        + "get\":(anonymous-function)#2}");
+    roundtrip(func, "left,right|one,two|three,four", "'row-delimiter': '|', 'header': true()", "{\""
+        + "columns\":(\"left\",\"right\"),\"column-index\":{\"left\":1,\"right\":2},\"rows\":([\"on"
+        + "e\",\"two\"],[\"three\",\"four\"]),\"get\":(anonymous-function)#2}");
+    roundtrip(func, "a,b,c,d,e,f|p,q,r,s,t,u", "'row-delimiter': '|', 'select-columns': (4, 3, 1)",
+        "{\"columns\":(),\"column-index\":{},\"rows\":([\"d\",\"c\",\"a\"],[\"s\",\"r\",\"p\"]),\"g"
+        + "et\":(anonymous-function)#2}");
+  }
+
+  /** Test method. */
+  @Test public void csvToXml() {
+    final Function func = CSV_TO_XML;
+    roundtrip(func, "", "", "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows/></csv>");
+    roundtrip(func, "one", "", "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><f"
+        + "ield>one</field></row></rows></csv>");
+    roundtrip(func, "one,two", "", "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><ro"
+        + "w><field>one</field><field>two</field></row></rows></csv>");
+    roundtrip(func, "one,two&#xA;three,four", "", "<csv xmlns=\"http://www.w3.org/2005/xpath-functi"
+        + "ons\"><rows><row><field>one</field><field>two</field></row><row><field>three</field><fie"
+        + "ld>four</field></row></rows></csv>");
+    roundtrip(func, "one,two&#xA;three,four&#xA;", "", "<csv xmlns=\"http://www.w3.org/2005/xpath-f"
+        + "unctions\"><rows><row><field>one</field><field>two</field></row><row><field>three</field"
+        + "><field>four</field></row></rows></csv>");
+    roundtrip(func, "one,two&#xA;three,four,five", "", "<csv xmlns=\"http://www.w3.org/2005/xpath-f"
+        + "unctions\"><rows><row><field>one</field><field>two</field></row><row><field>three</field"
+        + "><field>four</field><field>five</field></row></rows></csv>");
+    roundtrip(func, "one,two&#xA;&#xA;three,four", "", "<csv xmlns=\"http://www.w3.org/2005/xpath-f"
+        + "unctions\"><rows><row><field>one</field><field>two</field></row><row/><row><field>three<"
+        + "/field><field>four</field></row></rows></csv>");
+    roundtrip(func, "one,two&#xA;\"three,four\",five", "", "<csv xmlns=\"http://www.w3.org/2005/xpa"
+        + "th-functions\"><rows><row><field>one</field><field>two</field></row><row><field>three,fo"
+        + "ur</field><field>five</field></row></rows></csv>");
+    roundtrip(func, "one,two&#xA;\"three,\"\"four\"\"\",five", "", "<csv xmlns=\"http://www.w3.org/"
+        + "2005/xpath-functions\"><rows><row><field>one</field><field>two</field></row><row><field>"
+        + "three,\"four\"</field><field>five</field></row></rows></csv>");
+    roundtrip(func, "one,&#xA;,four&#xA;,&#xA;,,,", "", "<csv xmlns=\"http://www.w3.org/2005/xpath-"
+        + "functions\"><rows><row><field>one</field><field/></row><row><field/><field>four</field><"
+        + "/row><row><field/><field/></row><row><field/><field/><field/><field/></row></rows></csv>"
+        );
+    roundtrip(func, "one,\"\"&#xA;\"\",\"four\"", "", "<csv xmlns=\"http://www.w3.org/2005/xpath-fu"
+        + "nctions\"><rows><row><field>one</field><field/></row><row><field/><field>four</field></r"
+        + "ow></rows></csv>");
+    roundtrip(func, "one;two&#xA;three;four", "'field-delimiter': ';'", "<csv xmlns=\"http://www.w3"
+        + ".org/2005/xpath-functions\"><rows><row><field>one</field><field>two</field></row><row><f"
+        + "ield>three</field><field>four</field></row></rows></csv>");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|'", "<csv xmlns=\"http://www.w3.org/2"
+        + "005/xpath-functions\"><rows><row><field>one</field><field>two</field></row><row><field>t"
+        + "hree</field><field>four</field></row></rows></csv>");
+    roundtrip(func, "one.two|three.four", "'row-delimiter': '|', 'field-delimiter': '.'", "<csv xml"
+        + "ns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>one</field><field>two</f"
+        + "ield></row><row><field>three</field><field>four</field></row></rows></csv>");
+    roundtrip(func, "one,'two,2'|three,'four,4'", "'row-delimiter': '|', 'quote-character': ''''",
+        "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>one</field><field>"
+        + "two,2</field></row><row><field>three</field><field>four,4</field></row></rows></csv>");
+    roundtrip(func, "one,'two,''2'''|three,'four,''4'''", "'row-delimiter': '|', 'quote-character':"
+        + " ''''",
+        "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>one</field><field>"
+        + "two,'2'</field></row><row><field>three</field><field>four,'4'</field></row></rows></csv>"
+        );
+    roundtrip(func, "one ,two | three, four", "'row-delimiter': '|'", "<csv xmlns=\"http://www.w3.o"
+        + "rg/2005/xpath-functions\"><rows><row><field>one </field><field>two </field></row><row><f"
+        + "ield> three</field><field> four</field></row></rows></csv>");
+    roundtrip(func, "one ,two | three, four", "'row-delimiter': '|', 'trim-whitespace': false()",
+        "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>one </field><field"
+        + ">two </field></row><row><field> three</field><field> four</field></row></rows></csv>");
+    roundtrip(func, "one ,two | three, twenty  four ", "'row-delimiter': '|', 'trim-whitespace': tr"
+        + "ue()", "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>one</fie"
+        + "ld><field>two</field></row><row><field>three</field><field>twenty  four</field></row></r"
+        + "ows></csv>");
+    roundtrip(func, "&#xA;", "", "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row/"
+        + "></rows></csv>");
+    roundtrip(func, "left,right|one,two|three,four", "'row-delimiter': '|', 'header': true()", "<cs"
+        + "v xmlns=\"http://www.w3.org/2005/xpath-functions\"><columns><column>left</column><column"
+        + ">right</column></columns><rows><row><field column=\"left\">one</field><field column=\"ri"
+        + "ght\">two</field></row><row><field column=\"left\">three</field><field column=\"right\">"
+        + "four</field></row></rows></csv>");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|', 'header': ('left', 'right')", "<cs"
+        + "v xmlns=\"http://www.w3.org/2005/xpath-functions\"><columns><column>left</column><column"
+        + ">right</column></columns><rows><row><field column=\"left\">one</field><field column=\"ri"
+        + "ght\">two</field></row><row><field column=\"left\">three</field><field column=\"right\">"
+        + "four</field></row></rows></csv>");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|', 'header': false()", "<csv xmlns=\""
+        + "http://www.w3.org/2005/xpath-functions\"><rows><row><field>one</field><field>two</field>"
+        + "</row><row><field>three</field><field>four</field></row></rows></csv>");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|', 'header': 'left'", "<csv xmlns=\"h"
+        + "ttp://www.w3.org/2005/xpath-functions\"><columns><column>left</column></columns><rows><r"
+        + "ow><field column=\"left\">one</field><field>two</field></row><row><field column=\"left\""
+        + ">three</field><field>four</field></row></rows></csv>");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|', 'header': ('', 'right')", "<csv xm"
+        + "lns=\"http://www.w3.org/2005/xpath-functions\"><columns><column/><column>right</column><"
+        + "/columns><rows><row><field>one</field><field column=\"right\">two</field></row><row><fie"
+        + "ld>three</field><field column=\"right\">four</field></row></rows></csv>");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|', 'header': ()", "<csv xmlns=\"http:"
+        + "//www.w3.org/2005/xpath-functions\"><rows><row><field>one</field><field>two</field></row"
+        + "><row><field>three</field><field>four</field></row></rows></csv>");
+    roundtrip(func, "left,left|one,two|three,four", "'row-delimiter': '|', 'header': true()", "<csv"
+        + " xmlns=\"http://www.w3.org/2005/xpath-functions\"><columns><column>left</column><column>"
+        + "left</column></columns><rows><row><field column=\"left\">one</field><field column=\"left"
+        + "\">two</field></row><row><field column=\"left\">three</field><field column=\"left\">four"
+        + "</field></row></rows></csv>");
+    roundtrip(func, ",right|one,two|three,four", "'row-delimiter': '|', 'header': true()", "<csv xm"
+        + "lns=\"http://www.w3.org/2005/xpath-functions\"><columns><column/><column>right</column><"
+        + "/columns><rows><row><field>one</field><field column=\"right\">two</field></row><row><fie"
+        + "ld>three</field><field column=\"right\">four</field></row></rows></csv>");
+    roundtrip(func, ",|one,two|three,four", "'row-delimiter': '|', 'header': true()", "<csv xmlns="
+        + "\"http://www.w3.org/2005/xpath-functions\"><columns><column/><column/></columns><rows><r"
+        + "ow><field>one</field><field>two</field></row><row><field>three</field><field>four</field"
+        + "></row></rows></csv>");
+    roundtrip(func, "1,2,3,4,5,6,7,8,9,10|11,12,13,14,15,16,17,18,19,20", "'row-delimiter': '|', 's"
+        + "elect-columns': (1 to 4)", "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows>"
+        + "<row><field>1</field><field>2</field><field>3</field><field>4</field></row><row><field>1"
+        + "1</field><field>12</field><field>13</field><field>14</field></row></rows></csv>");
+    roundtrip(func, "a,b,c,d,e,f,g,h,i|1,2,3,4,5,6,7,8,9,10|11,12,13,14,15,16,17,18,19,20", "'row-d"
+        + "elimiter': '|', 'select-columns': (1 to 4), 'header': true()", "<csv xmlns=\"http://www."
+        + "w3.org/2005/xpath-functions\"><columns><column>a</column><column>b</column><column>c</co"
+        + "lumn><column>d</column></columns><rows><row><field column=\"a\">1</field><field column="
+        + "\"b\">2</field><field column=\"c\">3</field><field column=\"d\">4</field></row><row><fie"
+        + "ld column=\"a\">11</field><field column=\"b\">12</field><field column=\"c\">13</field><f"
+        + "ield column=\"d\">14</field></row></rows></csv>");
+    roundtrip(func, "1,2,3,4|11,12,13,14,15,16,17,18,19,20", "'row-delimiter': '|', 'trim-rows': tr"
+        + "ue()", "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>1</field"
+        + "><field>2</field><field>3</field><field>4</field></row><row><field>11</field><field>12</"
+        + "field><field>13</field><field>14</field></row></rows></csv>");
+    roundtrip(func, "a,b,c,d|1,2,3,4,5,6,7,8,9,10|11,12,13,14,15,16,17,18,19,20", "'row-delimiter':"
+        + " '|', 'trim-rows': true(), 'header': true()", "<csv xmlns=\"http://www.w3.org/2005/xpath"
+        + "-functions\"><columns><column>a</column><column>b</column><column>c</column><column>d</c"
+        + "olumn></columns><rows><row><field column=\"a\">1</field><field column=\"b\">2</field><fi"
+        + "eld column=\"c\">3</field><field column=\"d\">4</field></row><row><field column=\"a\">11"
+        + "</field><field column=\"b\">12</field><field column=\"c\">13</field><field column=\"d\">"
+        + "14</field></row></rows></csv>");
+    roundtrip(func, "1,2,3,4|11,12,13,14,15,16", "'row-delimiter': '|', 'trim-rows': false(), 'head"
+        + "er': false()", "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>"
+        + "1</field><field>2</field><field>3</field><field>4</field></row><row><field>11</field><fi"
+        + "eld>12</field><field>13</field><field>14</field><field>15</field><field>16</field></row>"
+        + "</rows></csv>");
+    roundtrip(func, "1,2,3,4,5,6|14,15,16", "'row-delimiter': '|', 'select-columns': (1 to 4)", "<c"
+        + "sv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>1</field><field>2<"
+        + "/field><field>3</field><field>4</field></row><row><field>14</field><field>15</field><fie"
+        + "ld>16</field><field/></row></rows></csv>");
+    roundtrip(func, "1,2,3,4,5,6|14,15,16", "'row-delimiter': '|', 'trim-rows': true()", "<csv xmln"
+        + "s=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>1</field><field>2</field>"
+        + "<field>3</field><field>4</field><field>5</field><field>6</field></row><row><field>14</fi"
+        + "eld><field>15</field><field>16</field><field/><field/><field/></row></rows></csv>");
+    roundtrip(func, "a,b,c,d,e|1,2,3,4,5|14,15,16", "'row-delimiter': '|', 'trim-rows': true(), 'he"
+        + "ader': true()", "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><columns><column>"
+        + "a</column><column>b</column><column>c</column><column>d</column><column>e</column></colu"
+        + "mns><rows><row><field column=\"a\">1</field><field column=\"b\">2</field><field column="
+        + "\"c\">3</field><field column=\"d\">4</field><field column=\"e\">5</field></row><row><fie"
+        + "ld column=\"a\">14</field><field column=\"b\">15</field><field column=\"c\">16</field><f"
+        + "ield column=\"d\"/><field column=\"e\"/></row></rows></csv>");
+    roundtrip(func, "1,2,3,4|11,12,13,14", "'select-columns': (4, 3, 2, 1), 'row-delimiter': '|'",
+        "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>4</field><field>3<"
+        + "/field><field>2</field><field>1</field></row><row><field>14</field><field>13</field><fie"
+        + "ld>12</field><field>11</field></row></rows></csv>");
+    roundtrip(func, "1,2,3,4|11,12,13,14", "'select-columns': (1, 4), 'row-delimiter': '|'", "<csv "
+        + "xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>1</field><field>4</fi"
+        + "eld></row><row><field>11</field><field>14</field></row></rows></csv>");
+    roundtrip(func, "1,2,3,4|11,12,13,14", "'select-columns': (1, 4, 17), 'row-delimiter': '|'", "<"
+        + "csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>1</field><field>4"
+        + "</field><field/></row><row><field>11</field><field>14</field><field/></row></rows></csv>"
+        );
+    roundtrip(func, "1,2,3,4|11,12,13,14", "'select-columns': (1, 17, 4), 'row-delimiter': '|'", "<"
+        + "csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>1</field><field/>"
+        + "<field>4</field></row><row><field>11</field><field/><field>14</field></row></rows></csv>"
+        );
+    roundtrip(func, "1,2,3,4|11,12,13,14,15", "'select-columns': (1, 4, 5), 'row-delimiter': '|'",
+        "<csv xmlns=\"http://www.w3.org/2005/xpath-functions\"><rows><row><field>1</field><field>4<"
+        + "/field><field/></row><row><field>11</field><field>14</field><field>15</field></row></row"
+        + "s></csv>");
+    roundtrip(func, "first,second,third,fourth|1,2,3,4|11,12,13,14", "'select-columns': (1, 4, 3),"
+        + " 'header': true(), 'row-delimiter': '|'", "<csv xmlns=\"http://www.w3.org/2005/xpath-fu"
+        + "nctions\"><columns><column>first</column><column>fourth</column><column>third</column><"
+        + "/columns><rows><row><field column=\"first\">1</field><field column=\"fourth\">4</field>"
+        + "<field column=\"third\">3</field></row><row><field column=\"first\">11</field><field co"
+        + "lumn=\"fourth\">14</field><field column=\"third\">13</field></row></rows></csv>");
+    roundtrip(func, "one,two|three,four", "'row-delimiter': '|'", "<csv xmlns=\"http://www.w3.org/"
+        + "2005/xpath-functions\"><rows><row><field>one</field><field>two</field></row><row><field"
+        + ">three</field><field>four</field></row></rows></csv>");
+  }
+
+  /**
+   * Parses csv with the given function and verifies that the result is as expected. Then
+   * serializes the result, parses the serialization, and verifies that this also returns
+   * the expected result.
+   * @param function function
+   * @param input csv input
+   * @param options options
+   * @param expected expected result
+   */
+  private void roundtrip(final Function function, final String input, final String options,
+      final String expected) {
+    final String parseQuery = function.args(input, " { " + options + " }");
+    final String result = query(parseQuery);
+    compare(parseQuery, result, expected, null);
+    final String serializeQuery = _CSV_SERIALIZE.args(
+      result.startsWith("<") ? ' ' + result :
+      result.startsWith("[") ? " (" + result.replace('\n', ',') + ")" :
+      result.startsWith("{") ? " " + result.replaceAll(",\"get\":\\(anonymous-function\\)#2", "") :
+      result.isEmpty() ? " ()" : " " + result, " { " + options + " }");
+    final String serialization = query(serializeQuery);
+    final String roundtripQuery = function.args(" \"" + serialization.replace("\"", "\"\"") + "\"",
+        " { " + options + " }");
+    compare(roundtripQuery, query(roundtripQuery), expected, null);
+  }
+}


### PR DESCRIPTION
These changes add support for the new CSV parsing result formats to `csv:serialize`. As for `csv:parse` result formats, the options that are used at parsing time can be supplied for serialization. For the new functions, these are the options conforming to `FnCsvToArrays.CsvToArraysOptions` and `FnParseCsv.ParseCsvOptions`. The actual options class and the serializer implementation are determined by inspecting the first item to be serialized:

Item Type             | Options Class                      | Serializer
----------------------|------------------------------------|----------------------
`element(fn:csv)` <br/>`document-node(element(fn:csv))`    | `FnParseCsv.ParseCsvOptions`       | `CsvXmlSerializer`
`element()`<br/>`document-node()`           | `CsvParserOptions`                 | `CsvDirectSerializer`
`array(*)`            | `FnCsvToArrays.CsvToArraysOptions` | `CsvArraysSerializer`
`record(records, *)`  | `CsvParserOptions`                 | `CsvXQuerySerializer`
`record(*)`           | `FnParseCsv.ParseCsvOptions`       | `CsvMapSerializer`

Class `CsvSerializer.Delegator` has been added to delay this distiction until the first item is presented to `serialize(Item)`.

Test cases have been added in new class `CsvRoundtripTest`. These have been generated semi-atomatically by adding some temporary code to collect them while executing QT4 tests. The test cases
  - do some CSV parsing
  - verify that the expected result was returned
  - do CSV serialization of the result
  - parse the result of the serialization
  - verify that the same expected result was returned as was from the initial parsing.