### PR TITLE
Fix compile problems in `HtmlParser`

### DIFF
--- a/basex-core/src/main/java/org/basex/build/html/HtmlParser.java
+++ b/basex-core/src/main/java/org/basex/build/html/HtmlParser.java
@@ -337,7 +337,7 @@ public final class HtmlParser extends XMLParser {
      * @param info input info (can be {@code null})
      * @throws QueryException query exception,
      */
-    private static void ensureAvailable(final String className, final byte[] func,
+    static void ensureAvailable(final String className, final byte[] func,
         final InputInfo info) throws QueryException {
       if(!Reflect.available(className)) throw BASEX_CLASSPATH_X_X.get(info, func, className);
     }


### PR DESCRIPTION
`HtmlParser.Parser.ensureAvailable(String, byte[], InputInfo)` is called from a `HtmlParser.Parser.NU`, so it must not be declared as `private`. 