### PR TITLE
Remove support for TagSoup options `html` and `method`

### DIFF
--- a/basex-core/src/main/java/org/basex/build/html/HtmlOptions.java
+++ b/basex-core/src/main/java/org/basex/build/html/HtmlOptions.java
@@ -9,8 +9,6 @@ import org.basex.util.options.*;
  * @author Christian Gruen
  */
 public final class HtmlOptions extends Options {
-  /** TagSoup option: html. */
-  public static final BooleanOption HTML = new BooleanOption("html", false);
   /** TagSoup option: omit-xml-declaration. */
   public static final BooleanOption OMIT_XML_DECLARATION =
       new BooleanOption("omit-xml-declaration", false);

--- a/basex-core/src/main/java/org/basex/build/html/HtmlParser.java
+++ b/basex-core/src/main/java/org/basex/build/html/HtmlParser.java
@@ -101,10 +101,8 @@ public final class HtmlParser extends XMLParser {
 
   /** Method option values. */
   public enum Method {
-    /** TagSoup parser with method 'xml'. */
-    xml(Parser.TAGSOUP),
-    /** TagSoup parser with method 'html'. */
-    html(Parser.TAGSOUP),
+    /** TagSoup parser. */
+    tagsoup(Parser.TAGSOUP),
     /** Validator.nu parser. */
     nu(Parser.NU);
 
@@ -141,11 +139,6 @@ public final class HtmlParser extends XMLParser {
         reader.setContentHandler(writer);
 
         // set TagSoup options
-        if(hopts.get(HTML)) {
-          reader.setFeature("http://xml.org/sax/features/namespaces", false);
-          writer.setOutputProperty(METHOD.name(), "html");
-          writer.setOutputProperty(OMIT_XML_DECLARATION.name(), "yes");
-        }
         if(hopts.get(NONS))
           reader.setFeature("http://xml.org/sax/features/namespaces", false);
         if(hopts.get(NOBOGONS))
@@ -170,8 +163,6 @@ public final class HtmlParser extends XMLParser {
           reader.setProperty("http://xml.org/sax/properties/lexical-handler", writer);
         if(hopts.get(OMIT_XML_DECLARATION))
           writer.setOutputProperty(OMIT_XML_DECLARATION.name(), "yes");
-        if(hopts.contains(METHOD))
-          writer.setOutputProperty(METHOD.name(), hopts.get(METHOD).name());
         if(hopts.contains(DOCTYPE_SYSTEM))
           writer.setOutputProperty(DOCTYPE_SYSTEM.name(), hopts.get(DOCTYPE_SYSTEM));
         if(hopts.contains(DOCTYPE_PUBLIC))

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -1915,6 +1915,7 @@ public final class FnModuleTest extends SandboxTest {
         + "<body>\u20AC</body></html>");
     query(func.args("42", " map {'heuristics': 'ICU'}"),
         "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head/><body>42</body></html>");
+    query(func.args("42", " {'method': 'tagsoup'}"), "<html><body>42</body></html>");
 
     error(func.args(42), STRBIN_X_X);
     error(func.args("42", 42), INVCONVERT_X_X_X);


### PR DESCRIPTION
The only purpose of TagSoup options `html` and `method` is instructing TagSoup's serializer to generate HTML instead of XML. However HTML as an ouptut from TagSoup cannot be processed afterwards.

Thus these options are no longer supported with these changes. Rather the valid values of `HtmlOption.METHOD` now are `tagsoup` and `nu` for selecting the HTML parser to be used.