### PR TITLE
Add timeout and dependency cache to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       # Checkout the repository
@@ -24,6 +25,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+
+      # Cache Maven dependencies
+      - name: Cache Maven dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-${{ runner.os }}-
 
       # Build the project using Maven
       - name: Build with Maven


### PR DESCRIPTION
In my fork, I saw a build action hanging for more than 15 minutes after a test failure ([13028904697/job/36343594493](https://github.com/GuntherRademacher/basex/actions/runs/13028904697/job/36343594493)). So I am adding a job timeout of 10 minutes here.

Also adding dependency caching, which reduces the workflow's runtime by about 20 seconds.