### PR TITLE
Update to markup-blitz 1.6

### DIFF
--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -1483,6 +1483,9 @@ public final class FnModuleTest extends SandboxTest {
     // empty $grammar
     query(func.args(" ()") + "(\"s: 'x'.\")",
         "<ixml><rule name=\"s\"><alt><literal string=\"x\"/></alt></rule></ixml>");
+    // GuntherRademacher/markup-blitz#20
+    query(func.args("s : 'ab'**'cd', 'ef'++'gh'.") + "('abcdabefghef')",
+        "<s>abcdabefghef</s>");
 
     // invalid grammar
     error(func.args("?%$"), IXML_GRM_X_X_X);

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
       <dependency>
         <groupId>de.bottlecaps</groupId>
         <artifactId>markup-blitz</artifactId>
-        <version>1.5</version>
+        <version>1.6</version>
         <scope>runtime</scope>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
[1.6](https://github.com/GuntherRademacher/markup-blitz/releases/tag/1.6) is a bugfix release.