### PR TITLE
Update versions of workflow actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       # Archive test reports and possible dumps in case of failure
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Set up Java
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -1483,6 +1483,9 @@ public final class FnModuleTest extends SandboxTest {
     // empty $grammar
     query(func.args(" ()") + "(\"s: 'x'.\")",
         "<ixml><rule name=\"s\"><alt><literal string=\"x\"/></alt></rule></ixml>");
+    // GuntherRademacher/markup-blitz#20
+    query(func.args("s : 'ab'**'cd', 'ef'++'gh'.") + "('abcdabefghef')",
+        "<s>abcdabefghef</s>");
 
     // invalid grammar
     error(func.args("?%$"), IXML_GRM_X_X_X);

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
       <dependency>
         <groupId>de.bottlecaps</groupId>
         <artifactId>markup-blitz</artifactId>
-        <version>1.5</version>
+        <version>1.6</version>
         <scope>runtime</scope>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
Incidentally `v3` of the actions used in the build workflow went out of service today, which caused a [recent execution](https://github.com/BaseXdb/basex/actions/runs/13057309382) to fail. So we need to update to `v4`.