### PR TITLE
Update workflow action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Set up Java
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -42,7 +42,7 @@ jobs:
       # Archive test reports and possible dumps in case of failure
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: |


### PR DESCRIPTION
Coincidentally `v3` of the actions used in the build workflow went out of service today, which caused a [recent execution](https://github.com/BaseXdb/basex/actions/runs/13057309382) to fail. So we need to update to `v4`.