### PR TITLE
Use Validator.nu as default parser when TagSoup is unavailable

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/html/HtmlParse.java
+++ b/basex-core/src/main/java/org/basex/query/func/html/HtmlParse.java
@@ -50,7 +50,8 @@ public class HtmlParse extends StandardFunc {
   /**
    * Parses the input and creates an XML document.
    * @param io input data
-   * @param defaultParser default HTML parser to be used in absence of the METHOD option
+   * @param defaultParser default HTML parser to be used in absence of the METHOD option (can be
+   *          {@code null})
    * @param qc query context
    * @return node
    * @throws QueryException query exception
@@ -60,7 +61,7 @@ public class HtmlParse extends StandardFunc {
     if(io == null) return Empty.VALUE;
     final HtmlOptions options = toOptions(arg(1), new HtmlOptions(), qc);
     final Parser parser = Parser.of(options, defaultParser);
-    if(!parser.fallbackToXml()) parser.ensureAvailable(options, definition.local(), info);
+    if(parser != null) parser.ensureAvailable(options, definition.local(), info);
     try {
       return new DBNode(
           new org.basex.build.html.HtmlParser(io, parser, new MainOptions(), options));

--- a/basex-core/src/main/java/org/basex/query/func/html/HtmlParser.java
+++ b/basex-core/src/main/java/org/basex/query/func/html/HtmlParser.java
@@ -1,6 +1,5 @@
 package org.basex.query.func.html;
 
-import org.basex.build.html.*;
 import org.basex.build.html.HtmlParser.*;
 import org.basex.query.*;
 import org.basex.query.func.*;
@@ -16,8 +15,7 @@ import org.basex.util.*;
 public final class HtmlParser extends StandardFunc {
   @Override
   public Item item(final QueryContext qc, final InputInfo ii) {
-    final HtmlOptions options = new HtmlOptions();
-    final Parser parser = Parser.of(options);
-    return Str.get(parser.available(options) ? parser.toString() : "");
+    final Parser parser = Parser.DEFAULT;
+    return Str.get(parser != null ? parser.toString() : "");
   }
 }


### PR DESCRIPTION
This change will use Validator.nu as the default HTML parser, when TagSoup is unavailable, or fall back to XML parsing, if Validator.nu is unavailable, too.

When `HTMLPARSER` option `method` is used to override the default, then an error message is produced, if the specified parser is unavailable.