### PR TITLE
Add function fn:html-doc

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -349,6 +349,9 @@ public enum Function implements AFunction {
   HOURS_FROM_TIME(FnHoursFromTime::new, "hours-from-time(value)",
       params(TIME_ZO), INTEGER_ZO),
   /** XQuery function. */
+  HTML_DOC(FnHtmlDoc::new, "html-doc(source[,options])",
+      params(STRING_ZO, MAP_O), DOCUMENT_NODE_ZO, flag(NDT)),
+  /** XQuery function. */
   ID(FnId::new, "id(values[,node])",
       params(STRING_ZM, NODE_ZO), ELEMENT_ZM),
   /** XQuery function. */

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnHtmlDoc.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnHtmlDoc.java
@@ -1,0 +1,22 @@
+package org.basex.query.func.fn;
+
+import org.basex.build.html.HtmlParser;
+import org.basex.query.*;
+import org.basex.query.func.html.*;
+import org.basex.query.value.item.*;
+import org.basex.query.value.seq.*;
+import org.basex.util.*;
+
+/**
+ * Function implementation.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public class FnHtmlDoc extends HtmlParse {
+  @Override
+  public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
+    final String source = toStringOrNull(arg(0), qc);
+    return source != null ? parse(toIO(source), HtmlParser.Parser.NU, qc) : Empty.VALUE;
+  }
+}

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -1313,6 +1313,20 @@ public final class FnModuleTest extends SandboxTest {
   }
 
   /** Test method. */
+  @Test public void htmlDoc() {
+    final Function func = HTML_DOC;
+    query(func.args(" ()"), "");
+    query(func.args(" []"), "");
+    query(func.args(" <_/>/text()"), "");
+
+    final String path = "src/test/resources/input.html";
+    query(func.args(path) + "//Q{http://www.w3.org/1999/xhtml}body ! name()", "body");
+    query(func.args(path, " {'method': 'tagsoup', 'nons': false()}")
+        + "//Q{http://www.w3.org/1999/xhtml}body ! name()", "body");
+    query(func.args(path, " {'method': 'tagsoup'}") + "//body ! name()", "body");
+  }
+
+  /** Test method. */
   @Test public void id() {
     final Function func = ID;
     final String doc = "<foo xml:id=\"a1\" x=\"x\"><bar xml:id=\"a1\" y=\"y\"/></foo>";


### PR DESCRIPTION
This change adds `fn:html-doc($source as xs:string?, $options as map(*) := {})`.

The first parameter was named `$source` to be consistent with `fn:doc` and `fn:json-doc`.