### PR TITLE
Rewrite `prof:variables()` to preserve known variables

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryText.java
+++ b/basex-core/src/main/java/org/basex/query/QueryText.java
@@ -404,7 +404,6 @@ public interface QueryText {
   /** Serialization. */ byte[] MAP_STRING = token("map-string");
 
   /** Debugging info. */ String DEBUG_LOCAL = "Local Variables";
-  /** Debugging info. */ String DEBUG_GLOBAL = "Global Variables";
 
   /** Java prefix. */ String JAVA_PREFIX_COLON = "java:";
   /** Java keyword: new. */ String NEW = "new";

--- a/basex-core/src/main/java/org/basex/query/func/prof/ProfVariables.java
+++ b/basex-core/src/main/java/org/basex/query/func/prof/ProfVariables.java
@@ -2,12 +2,21 @@ package org.basex.query.func.prof;
 
 import static org.basex.util.Token.*;
 
+import java.util.List;
+
 import org.basex.query.*;
+import org.basex.query.expr.*;
 import org.basex.query.func.*;
 import org.basex.query.func.fn.*;
+import org.basex.query.util.*;
+import org.basex.query.util.hash.*;
+import org.basex.query.value.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.seq.*;
+import org.basex.query.value.type.*;
+import org.basex.query.var.*;
 import org.basex.util.*;
+import org.basex.util.hash.*;
 
 /**
  * Function implementation.
@@ -18,7 +27,66 @@ import org.basex.util.*;
 public final class ProfVariables extends StandardFunc {
   @Override
   public Item item(final QueryContext qc, final InputInfo ii) {
-    FnTrace.trace(token(qc.stack.dump()), EMPTY, qc);
-    return Empty.VALUE;
+    throw Util.notExpected();
+  }
+
+  @Override
+  protected Expr opt(final CompileContext cc) throws QueryException {
+    final List<Var> vars = cc.vs().vars;
+    final QNmSet names = new QNmSet();
+    final Expr[] varRefs = new Expr[vars.size()];
+    for(int i = 0; i < vars.size(); ++i) {
+      final Var var = vars.get(i);
+      names.add(var.name);
+      varRefs[i] = new VarRef(info, var);
+    }
+    return new VarHandler(info, names, varRefs);
+  }
+
+  /**
+   * Function implementation for logging defined variables.
+   */
+  private static class VarHandler extends Arr {
+    /** Names of variables. */
+    final QNmSet names;
+
+    /**
+     * Constructor.
+     * @param info input info
+     * @param names variable names
+     * @param varRefs variable references
+     */
+    protected VarHandler(final InputInfo info, final QNmSet names, final Expr... varRefs) {
+      super(info, SeqType.EMPTY_SEQUENCE_Z, varRefs);
+      this.names = names;
+    }
+
+    @Override
+    public Value value(final QueryContext qc) throws QueryException {
+      final TokenBuilder tb = new TokenBuilder().add(QueryText.DEBUG_LOCAL).add(':');
+      int i = 0;
+      for(final QNm name : names) {
+        final Value value = exprs[i++].value(qc);
+        if(value != null) tb.add(Prop.NL).add("  $").add(name).add(" := ").add(value);
+      }
+      FnTrace.trace(token(tb.toString()), EMPTY, qc);
+      return Empty.VALUE;
+    }
+
+    @Override
+    public boolean has(final Flag... flags) {
+      for(final Flag flag : flags) if(flag == Flag.NDT) return true;
+      return super.has(flags);
+    }
+
+    @Override
+    public Expr copy(final CompileContext cc, final IntObjMap<Var> vm) {
+      return copyType(new VarHandler(info, names, copyAll(cc, vm, args())));
+    }
+
+    @Override
+    public void toString(final QueryString qs) {
+      qs.token("prof:variables").params(exprs);
+    }
   }
 }

--- a/basex-core/src/main/java/org/basex/query/var/QueryStack.java
+++ b/basex-core/src/main/java/org/basex/query/var/QueryStack.java
@@ -105,7 +105,7 @@ public final class QueryStack {
    * @return bound value
    */
   public Value get(final Var var) {
-    return stack[start + var.slot];
+    return var.slot == -1 ? null : stack[start + var.slot];
   }
 
   /**
@@ -119,21 +119,6 @@ public final class QueryStack {
     final int pos = start + var.slot;
     stack[pos] = var.checkType(value, qc, null);
     vars[pos] = var;
-  }
-
-  /**
-   * Creates a dump of the current variable stack.
-   * @return string dump
-   */
-  public String dump() {
-    final TokenBuilder tb = new TokenBuilder().add(QueryText.DEBUG_LOCAL).add(':');
-    for(int i = end; --i >= 0;) {
-      if(vars[i] != null) {
-        tb.add(Prop.NL).add("  $").add(vars[i].name).add(" := ").add(stack[i]);
-        if(i == start && i > 0) tb.add(Prop.NL).add(QueryText.DEBUG_GLOBAL).add(':');
-      }
-    }
-    return tb.toString();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/var/VarScope.java
+++ b/basex-core/src/main/java/org/basex/query/var/VarScope.java
@@ -21,7 +21,7 @@ import org.basex.util.hash.*;
  */
 public final class VarScope {
   /** Local variables in this scope. */
-  private final ArrayList<Var> vars = new ArrayList<>();
+  public final ArrayList<Var> vars = new ArrayList<>();
 
   /**
    * Adds a variable to this scope.


### PR DESCRIPTION
This is an attempt to solve #1115, based on the suggestion made there to rewrite the call to `prof:variables()` by fixing the set of variables early.

The approach taken here is to evaluate the `VarScope` obtained from `cc.vs()` at optimization time and replace `prof:variables()` with a new function call that takes the values of the known variables as arguments. The new function is instantiated with the corresponding list of variable names.

One problem with `VarScope` is that it may contain additional variables that are undefined where `prof:variables()` is called. Their references are carried along, but they cannot be evaluated. This is handled by allowing them to be evaluated to Java `null` and filtering them out on that basis. Admittedly, it would be nicer if one could only handle defined variables, but I have not found an equally simple and isolated solution for this.