### PR TITLE
qt1528: Implement constraint "unreserved name"

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryText.java
+++ b/basex-core/src/main/java/org/basex/query/QueryText.java
@@ -68,6 +68,7 @@ public interface QueryText {
   /** Parser token. */ String EXTERNAL = "external";
   /** Parser token. */ String FALSE = "false";
   /** Parser token. */ String FIRST = "first";
+  /** Parser token. */ String FIXED = "fixed";
   /** Parser token. */ String FN = "fn";
   /** Parser token. */ String FOR = "for";
   /** Parser token. */ String FROM = "from";
@@ -91,7 +92,9 @@ public interface QueryText {
   /** Parser token. */ String INTO = "into";
   /** Parser token. */ String INVOKE = "invoke";
   /** Parser token. */ String ITEM = "item";
+  /** Parser token. */ String ITEMS = "items";
   /** Parser token. */ String KEY = "key";
+  /** Parser token. */ String KEYS = "keys";
   /** Parser token. */ String LANGUAGE = "language";
   /** Parser token. */ String LAST = "last";
   /** Parser token. */ String LAX = "lax";
@@ -124,6 +127,7 @@ public interface QueryText {
   /** Parser token. */ String ORDERED = "ordered";
   /** Parser token. */ String ORDERING = "ordering";
   /** Parser token. */ String OTHERWISE = "otherwise";
+  /** Parser token. */ String PAIRS = "pairs";
   /** Parser token. */ String PARAGRAPH = "paragraph";
   /** Parser token. */ String PARAGRAPHS = "paragraphs";
   /** Parser token. */ String PHRASE = "phrase";
@@ -176,6 +180,7 @@ public interface QueryText {
   /** Parser token. */ String USING = "using";
   /** Parser token. */ String VALIDATE = "validate";
   /** Parser token. */ String VALUEE = "value";
+  /** Parser token. */ String VALUESS = "values";
   /** Parser token. */ String VARIABLE = "variable";
   /** Parser token. */ String VERSION = "version";
   /** Parser token. */ String WEIGHT = "weight";


### PR DESCRIPTION
This change implements [constraint "unreserved name"](https://qt4cg.org/specifications/xquery-40/xquery-40.html#extra-grammatical-constraints), by disallowing keywords as plain names in computed node constructors.

The specification says about this:

>  To ease transition, implementations may provide an option to allow such names to be accepted with a warning that the construct is deprecated.

If you think that we need such an option, please let me know.