### PR TITLE
Make `fn:function-annotations` return a sequence of single-entry maps

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -310,7 +310,7 @@ public enum Function implements AFunction {
       params(TIME_ZO, STRING_O, STRING_ZO, STRING_ZO, STRING_ZO), STRING_ZO),
   /** XQuery function. */
   FUNCTION_ANNOTATIONS(FnFunctionAnnotations::new, "function-annotations(function)",
-      params(FUNCTION_O), MAP_O),
+      params(FUNCTION_O), MAP_ZM),
   /** XQuery function. */
   FUNCTION_ARITY(FnFunctionArity::new, "function-arity(function)",
       params(FUNCTION_O), INTEGER_O),

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnFunctionAnnotations.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnFunctionAnnotations.java
@@ -3,9 +3,11 @@ package org.basex.query.func.fn;
 import org.basex.query.*;
 import org.basex.query.ann.*;
 import org.basex.query.func.*;
+import org.basex.query.util.list.*;
+import org.basex.query.value.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.map.*;
-import org.basex.util.*;
+import org.basex.query.value.seq.*;
 
 /**
  * Function implementation.
@@ -15,13 +17,15 @@ import org.basex.util.*;
  */
 public final class FnFunctionAnnotations extends StandardFunc {
   @Override
-  public XQMap item(final QueryContext qc, final InputInfo ii) throws QueryException {
+  public Value value(final QueryContext qc) throws QueryException {
     final FItem function = toFunction(arg(0), qc);
 
-    final MapBuilder mb = new MapBuilder();
-    for(final Ann ann : function.annotations()) {
-      mb.put(ann.name(), ann.value());
+    final AnnList anns = function.annotations();
+    if(anns.isEmpty()) return Empty.VALUE;
+    final ValueBuilder vb = new ValueBuilder(qc);
+    for(final Ann ann : anns) {
+      vb.add(XQMap.singleton(ann.name(), ann.value()));
     }
-    return mb.map();
+    return vb.value();
   }
 }


### PR DESCRIPTION
In order to allow duplicate keys, `fn:function-annotations` has been changed to return a sequence of single-entry maps, rather than a single map.

This fixes QT4 test cases
 - `fn-function-annotations-020`
 - `fn-function-annotations-022`
 - `fn-function-annotations-023`
 - `fo-test-fn-function-annotations-001`