### PR TITLE
Add implementation of  `fn:node-type-annotation`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -474,6 +474,9 @@ public enum Function implements AFunction {
   NODE_NAME(FnNodeName::new, "node-name([node])",
       params(NODE_ZO), QNAME_ZO),
   /** XQuery function. */
+  NODE_TYPE_ANNOTATION(FnNodeTypeAnnotation::new, "node-type-annotation(node)",
+      params(NODE_O), MAP_O),
+  /** XQuery function. */
   NORMALIZE_SPACE(FnNormalizeSpace::new, "normalize-space([value])",
       params(STRING_ZO), STRING_O),
   /** XQuery function. */

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnAtomicTypeAnnotation.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnAtomicTypeAnnotation.java
@@ -22,7 +22,7 @@ import org.basex.util.hash.*;
  * @author BaseX Team, BSD License
  * @author Gunther Rademacher
  */
-public final class FnAtomicTypeAnnotation extends StandardFunc {
+public class FnAtomicTypeAnnotation extends StandardFunc {
 
   @Override
   public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
@@ -51,6 +51,10 @@ public final class FnAtomicTypeAnnotation extends StandardFunc {
         baseType = null;
         variety = Variety.mixed;
         break;
+      case UNTYPED:
+        baseType = ANY_TYPE;
+        variety = Variety.mixed;
+        break;
       case ANY_SIMPLE_TYPE:
         baseType = ANY_TYPE;
         variety = null;
@@ -71,11 +75,11 @@ public final class FnAtomicTypeAnnotation extends StandardFunc {
 
     final MapBuilder mb = new MapBuilder();
     mb.put("name", type.qname());
-    mb.put("is-simple", Bln.get(type != ANY_TYPE));
+    mb.put("is-simple", Bln.get(!type.oneOf(ANY_TYPE, UNTYPED)));
     mb.put("base-type", TypeAnnotation.funcItem(baseType, ii));
     if(primType != null) mb.put("primitive-type", TypeAnnotation.funcItem(primType, ii));
     if(variety != null) mb.put("variety", variety.name());
-    mb.put("matches", Matches.funcItem(type, qc, ii));
+    if(type.atomic() != null) mb.put("matches", Matches.funcItem(type, qc, ii));
     if(constructor != null) mb.put("constructor", constructor);
     return mb.map();
   }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnNodeTypeAnnotation.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnNodeTypeAnnotation.java
@@ -1,0 +1,31 @@
+package org.basex.query.func.fn;
+
+import static org.basex.query.value.type.AtomType.*;
+import static org.basex.query.value.type.SeqType.*;
+
+import java.util.*;
+
+import org.basex.query.*;
+import org.basex.query.value.item.*;
+import org.basex.query.value.node.*;
+import org.basex.query.value.type.*;
+import org.basex.util.*;
+
+/**
+ * Function implementation.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public final class FnNodeTypeAnnotation extends FnAtomicTypeAnnotation {
+  /** The function's argument type. */
+  private static final SeqType ARG_TYPE = new ChoiceItemType(
+      Arrays.asList(ELEMENT_O, ATTRIBUTE_O)).seqType();
+
+  @Override
+  public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
+    final ANode node = toNode(arg(0), qc);
+    ARG_TYPE.coerce(node, null, qc, null, ii);
+    return annotate(node.type == NodeType.ATTRIBUTE ? UNTYPED_ATOMIC : UNTYPED, qc, ii);
+  }
+}


### PR DESCRIPTION
This change adds the implementation of `fn:node-type-annotation` and some tests for it.