### PR TITLE
Revert recent change with respect to boundary-space

### DIFF
--- a/basex-tests/src/main/java/org/basex/tests/w3c/QT3TS.java
+++ b/basex-tests/src/main/java/org/basex/tests/w3c/QT3TS.java
@@ -740,9 +740,8 @@ public final class QT3TS extends Main {
       options.add("'" + DeepEqualOptions.NAMESPACE_PREFIXES.name() + "':" + !ignorePrefixes + "()");
       options.add("'" + DeepEqualOptions.COMMENTS.name() + "':true()");
       options.add("'" + DeepEqualOptions.PROCESSING_INSTRUCTIONS.name() + "':true()");
-      final String query = "declare boundary-space preserve;\n"
-          + Function.DEEP_EQUAL.args(" <X>" + expctd.trim() + "</X>", " <X>" + rslt.trim() + "</X>",
-          " { " + String.join(", ", options) + " }");
+      final String query = Function.DEEP_EQUAL.args(" <X>" + expctd + "</X>",
+          " <X>" + rslt + "</X>", " { " + String.join(", ", options) + " }");
       return asBoolean(query, expected) ? null : expctd;
     } catch(final IOException ex) {
       return Util.info("% (found: %)", expctd, ex);


### PR DESCRIPTION
In a recent change (6e599973864c5269d1a3ed69d3b172d23204a9e6), test result comparison was changed to run with `declare boundary-space preserve`. This was done after observing that tests [`parse-xml-421`](https://github.com/qt4cg/qt4tests/blob/87590dd60a281151c1dab4ef3f98d1e4a6eb1ac7/fn/parse-xml.xml#L299-L308) and [`parse-xml-fragment-421`](https://github.com/qt4cg/qt4tests/blob/87590dd60a281151c1dab4ef3f98d1e4a6eb1ac7/fn/parse-xml-fragment.xml#L334-L343) were successful regardless of whether option `strip-space` was implemented or not.

This has however caused 8 other tests to fail, because they depend on boundary-space being stripped while comparing results, e.g.

  - [`ForExprType009`](https://github.com/qt4cg/qt4tests/blob/87590dd60a281151c1dab4ef3f98d1e4a6eb1ac7/prod/ForClause.xml#L1725-L1739)
  - [`WhileExpr0006`](https://github.com/qt4cg/qt4tests/blob/87590dd60a281151c1dab4ef3f98d1e4a6eb1ac7/prod/WhileClause.xml#L105-L135)
  - [`WhileExpr007`](https://github.com/qt4cg/qt4tests/blob/87590dd60a281151c1dab4ef3f98d1e4a6eb1ac7/prod/WhileClause.xml#L137-L152)

The change is thus reverted here.