### PR TITLE
Add implementation of `fn:partial-apply`, update `fn:apply`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -525,6 +525,9 @@ public enum Function implements AFunction {
   PARSE_XML_FRAGMENT(FnParseXmlFragment::new, "parse-xml-fragment(value[,options])",
       params(ANY_ATOMIC_TYPE_ZO, MAP_ZO), DOCUMENT_NODE_ZO, flag(CNS)),
   /** XQuery function. */
+  PARTIAL_APPLY(FnPartialApply::new, "partial-apply(function,arguments)",
+      params(FUNCTION_O, MAP_O), FUNCTION_O, flag(HOF)),
+  /** XQuery function. */
   PARTITION(FnPartition::new, "partition(input,split-when)",
       params(ITEM_ZM, FuncType.get(BOOLEAN_ZO, ITEM_ZM, ITEM_O, INTEGER_O).seqType()),
       ARRAY_ZM, flag(HOF)),

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnApply.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnApply.java
@@ -73,7 +73,7 @@ public class FnApply extends StandardFunc {
   protected final Value apply(final FItem func, final ValueList args, final QueryContext qc)
       throws QueryException {
     final long ar = func.arity(), as = args.size();
-    if(ar != as) throw APPLY_X_X.get(info, arguments(as), func, args);
+    if(ar > as) throw APPLY_X_X.get(info, arguments(as), func, args);
     return func.invoke(qc, info, args.finish());
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnPartialApply.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnPartialApply.java
@@ -1,0 +1,81 @@
+package org.basex.query.func.fn;
+
+import static org.basex.query.value.type.SeqType.*;
+
+import java.util.*;
+
+import org.basex.query.*;
+import org.basex.query.expr.*;
+import org.basex.query.func.*;
+import org.basex.query.util.list.*;
+import org.basex.query.value.*;
+import org.basex.query.value.item.*;
+import org.basex.query.value.map.*;
+import org.basex.query.value.seq.*;
+import org.basex.query.value.type.*;
+import org.basex.query.var.*;
+
+/**
+ * Function implementation.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public class FnPartialApply extends StandardFunc {
+  /** The type of parameter "arguments". */
+  private static final SeqType ARGS_TYPE = MapType.get(AtomType.POSITIVE_INTEGER,
+      ITEM_ZM).seqType();
+  /** The name of parameter "arguments". */
+  private static final QNm ARGS_NAME = new QNm("arguments");
+
+  @Override
+  public Value value(final QueryContext qc) throws QueryException {
+    final FItem function = toFunction(arg(0), qc);
+    final XQMap arguments = toMap(ARGS_TYPE.coerce(arg(1).value(qc), ARGS_NAME, qc, null, info),
+        qc);
+    final int arity = function.arity();
+    if(arity == 0 || arguments == XQMap.empty()) return function;
+
+    final FuncType ft = function.funcType();
+    final Expr[] funcArgs = new Expr[arity];
+    Arrays.fill(funcArgs, Empty.UNDEFINED);
+    int placeholders = arity;
+    for(final Item key : arguments.keys()) {
+      final long index = toLong(key);
+      if(index <= arity) {
+        final int i = (int) index - 1;
+        funcArgs[i] = ft.argTypes[i].coerce(arguments.get(key), function.paramName(i), qc, null,
+            info);
+        --placeholders;
+      }
+    }
+    if(placeholders == arity) return function;
+
+    final DynFuncCall funcCall;
+    final Var[] params = new Var[placeholders];
+    final SeqType[] argTypes = new SeqType[placeholders];
+    if(placeholders == 0) {
+      funcCall = new DynFuncCall(info, function, funcArgs);
+    } else {
+      final VarScope vs = new VarScope();
+      final Expr[] args = new Expr[placeholders];
+      int p = 0;
+      for(int i = 0; i < arity; ++i) {
+        if(funcArgs[i] == Empty.UNDEFINED) {
+          final Var var = vs.addNew(function.paramName(i), ft.argTypes[i], qc, info);
+          params[p] = var;
+          args[p++] = new VarRef(info, var);
+        }
+      }
+      funcCall = new DynFuncCall(info,
+          new PartFunc(info, ExprList.concat(funcArgs, function), placeholders, null), args);
+    }
+    return new FuncItem(info, funcCall, params, AnnList.EMPTY, FuncType.get(ft.declType, argTypes),
+        params.length, null);
+  }
+
+  @Override
+  public int hofIndex() {
+    return 0;
+  }
+}

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -180,7 +180,7 @@ public final class FnModuleTest extends SandboxTest {
     query("for $a in 2 to 3 "
         + "let $f := function-lookup(xs:QName('fn:concat'), $a) "
         + "return " + func.args(" $f", " array { 1 to $a }"), "12\n123");
-    error(func.args(" false#0", " ['x']"), APPLY_X_X);
+    query(func.args(" false#0", " ['x']"), false);
     error(func.args(" string-length#1", " [ ('a', 'b') ]"), INVCONVERT_X_X_X);
 
     // no pre-evaluation (higher-order arguments), but type adjustment
@@ -194,7 +194,7 @@ public final class FnModuleTest extends SandboxTest {
 
     // code coverage tests
     query("string-length(" + func.args(" reverse#1", " ['a']") + ")", 1);
-    error(func.args(" true#0", " [1]"), APPLY_X_X);
+    query(func.args(" true#0", " [1]"), true);
     error(func.args(" put#2", " [<_/>, '']"), FUNCUP_X);
   }
 
@@ -2348,6 +2348,15 @@ public final class FnModuleTest extends SandboxTest {
         + "'?><x/><y/>", Strings.UTF16LE)), "<x/><y/>");
     query(func.args(_CONVERT_STRING_TO_BASE64.args("<?xml version='1.0' encoding='ISO-8859-7'?><x>"
         + "\u20AC</x><y>\u20AF</y>", "ISO-8859-7")), "<x>\u20AC</x><y>\u20AF</y>");
+  }
+
+  /** Test method. */
+  @Test public void partialApply() {
+    final Function func = PARTIAL_APPLY;
+
+    query("let $f := " + func.args(" dateTime#2", " {2: xs:time('00:00:00')}") + " return $f("
+        + "xs:date('2025-03-01'))", "2025-03-01T00:00:00");
+    error(func.args(" string-length#1", " {1: 42}"), INVCONVERT_X_X_X);
   }
 
   /** Test method. */

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -195,6 +195,7 @@ public final class FnModuleTest extends SandboxTest {
     // code coverage tests
     query("string-length(" + func.args(" reverse#1", " ['a']") + ")", 1);
     query(func.args(" true#0", " [1]"), true);
+    error(func.args(" concat#2", " ['x']"), APPLY_X_X);
     error(func.args(" put#2", " [<_/>, '']"), FUNCUP_X);
   }
 


### PR DESCRIPTION
This change
  - adds the implementation of `fn:partial-apply`,
  - updates `fn:apply` to ignore excess function arguments.