### PR TITLE
Fix #2399 by making `MapType` members `private`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/Lookup.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Lookup.java
@@ -53,7 +53,7 @@ public final class Lookup extends Arr {
     // derive type from input expression
     final Expr keys = exprs[1];
     final SeqType kt = keys.seqType();
-    final SeqType st = map ? ((MapType) tp).valueType : ((ArrayType) tp).valueType;
+    final SeqType st = map ? ((MapType) tp).valueType() : ((ArrayType) tp).valueType();
     Occ occ = st.occ;
     if(inputs.size() != 1 || keys == WILDCARD || !kt.one() || kt.mayBeArray()) {
       // key is wildcard, or expressions yield no single item

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayAppend.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayAppend.java
@@ -29,7 +29,7 @@ public final class ArrayAppend extends ArrayFn {
 
     final Type type = array.seqType().type;
     if(type instanceof ArrayType) {
-      final SeqType mt = ((ArrayType) type).valueType.union(add.seqType());
+      final SeqType mt = ((ArrayType) type).valueType().union(add.seqType());
       exprType.assign(ArrayType.get(mt));
     }
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayFilter.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayFilter.java
@@ -36,7 +36,7 @@ public final class ArrayFilter extends ArrayFn {
 
     final Type type = array.seqType().type;
     if(type instanceof ArrayType) {
-      arg(1, arg -> refineFunc(arg, cc, ((ArrayType) type).valueType, SeqType.INTEGER_O));
+      arg(1, arg -> refineFunc(arg, cc, ((ArrayType) type).valueType(), SeqType.INTEGER_O));
       exprType.assign(type);
     }
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayFlatten.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayFlatten.java
@@ -82,7 +82,7 @@ public final class ArrayFlatten extends ArrayFn {
    * @return result type
    */
   private static Type type(final Type type) {
-    return type instanceof ArrayType ? type(((ArrayType) type).valueType.type) : type;
+    return type instanceof ArrayType ? type(((ArrayType) type).valueType().type) : type;
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayFoot.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayFoot.java
@@ -23,7 +23,7 @@ public final class ArrayFoot extends ArrayFn {
   @Override
   protected Expr opt(final CompileContext cc) {
     final Type type = arg(0).seqType().type;
-    if(type instanceof ArrayType) exprType.assign(((ArrayType) type).valueType);
+    if(type instanceof ArrayType) exprType.assign(((ArrayType) type).valueType());
     return this;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayForEach.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayForEach.java
@@ -36,7 +36,7 @@ public final class ArrayForEach extends ArrayFn {
 
     final Type type = array.seqType().type;
     if(type instanceof ArrayType) {
-      arg(1, arg -> refineFunc(arg, cc, ((ArrayType) type).valueType, SeqType.INTEGER_O));
+      arg(1, arg -> refineFunc(arg, cc, ((ArrayType) type).valueType(), SeqType.INTEGER_O));
     }
 
     // assign type after coercion (expression might have changed)

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayForEachPair.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayForEachPair.java
@@ -40,8 +40,8 @@ public final class ArrayForEachPair extends ArrayFn {
 
     final Type type1 = array1.seqType().type, type2 = array2.seqType().type;
     if(type1 instanceof ArrayType && type2 instanceof ArrayType) {
-      arg(2, arg -> refineFunc(arg, cc, ((ArrayType) type1).valueType,
-          ((ArrayType) type2).valueType, SeqType.INTEGER_O));
+      arg(2, arg -> refineFunc(arg, cc, ((ArrayType) type1).valueType(),
+          ((ArrayType) type2).valueType(), SeqType.INTEGER_O));
     }
 
     // assign type after coercion (expression might have changed)

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayGet.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayGet.java
@@ -32,7 +32,7 @@ public final class ArrayGet extends StandardFunc {
     // combine result type with return type of fallback function
     final Type type = array.seqType().type;
     if(type instanceof ArrayType) {
-      SeqType st = ((ArrayType) type).valueType;
+      SeqType st = ((ArrayType) type).valueType();
       if(defined(2)) {
         final FuncType ft = arg(2).funcType();
         if(ft != null) st = st.union(ft.declType);

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayHead.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayHead.java
@@ -23,7 +23,7 @@ public final class ArrayHead extends ArrayFn {
   @Override
   protected Expr opt(final CompileContext cc) {
     final Type type = arg(0).seqType().type;
-    if(type instanceof ArrayType) exprType.assign(((ArrayType) type).valueType);
+    if(type instanceof ArrayType) exprType.assign(((ArrayType) type).valueType());
     return this;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayIndexWhere.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayIndexWhere.java
@@ -37,7 +37,7 @@ public final class ArrayIndexWhere extends ArrayFn {
 
     final Type type = array.seqType().type;
     if(type instanceof ArrayType) {
-      arg(1, arg -> refineFunc(arg, cc, ((ArrayType) type).valueType, SeqType.INTEGER_O));
+      arg(1, arg -> refineFunc(arg, cc, ((ArrayType) type).valueType(), SeqType.INTEGER_O));
     }
     return this;
   }

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayInsertBefore.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayInsertBefore.java
@@ -25,7 +25,7 @@ public final class ArrayInsertBefore extends ArrayFn {
   protected ArrayInsertBefore opt(final CompileContext cc) {
     final Type type = arg(0).seqType().type;
     if(type instanceof ArrayType) {
-      final SeqType mt = ((ArrayType) type).valueType.union(arg(2).seqType());
+      final SeqType mt = ((ArrayType) type).valueType().union(arg(2).seqType());
       exprType.assign(ArrayType.get(mt));
     }
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayItems.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayItems.java
@@ -58,7 +58,8 @@ public final class ArrayItems extends StandardFunc {
   @Override
   protected Expr opt(final CompileContext cc) {
     final Type tp = arg(0).seqType().type;
-    if(tp instanceof ArrayType) exprType.assign(((ArrayType) tp).valueType().with(Occ.ZERO_OR_MORE));
+    if(tp instanceof ArrayType)
+      exprType.assign(((ArrayType) tp).valueType().with(Occ.ZERO_OR_MORE));
     return this;
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayItems.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayItems.java
@@ -58,7 +58,7 @@ public final class ArrayItems extends StandardFunc {
   @Override
   protected Expr opt(final CompileContext cc) {
     final Type tp = arg(0).seqType().type;
-    if(tp instanceof ArrayType) exprType.assign(((ArrayType) tp).valueType.with(Occ.ZERO_OR_MORE));
+    if(tp instanceof ArrayType) exprType.assign(((ArrayType) tp).valueType().with(Occ.ZERO_OR_MORE));
     return this;
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayMembers.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayMembers.java
@@ -54,7 +54,7 @@ public final class ArrayMembers extends StandardFunc {
   protected Expr opt(final CompileContext cc) {
     final Type tp = arg(0).seqType().type;
     if(tp instanceof ArrayType) {
-      exprType.assign(MapType.get(AtomType.STRING, ((ArrayType) tp).valueType));
+      exprType.assign(MapType.get(AtomType.STRING, ((ArrayType) tp).valueType()));
     }
     return this;
   }

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayOfMembers.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayOfMembers.java
@@ -29,7 +29,7 @@ public final class ArrayOfMembers extends ArrayFn {
   @Override
   protected Expr opt(final CompileContext cc) {
     final Type tp = arg(0).seqType().type;
-    if(tp instanceof MapType) exprType.assign(ArrayType.get(((MapType) tp).valueType));
+    if(tp instanceof MapType) exprType.assign(ArrayType.get(((MapType) tp).valueType()));
     return this;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayPut.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayPut.java
@@ -26,7 +26,7 @@ public final class ArrayPut extends ArrayFn {
   protected Expr opt(final CompileContext cc) {
     final Type type = arg(0).seqType().type;
     if(type instanceof ArrayType) {
-      final SeqType mt = ((ArrayType) type).valueType.union(arg(2).seqType());
+      final SeqType mt = ((ArrayType) type).valueType().union(arg(2).seqType());
       exprType.assign(ArrayType.get(mt));
     }
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/array/ArraySort.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArraySort.java
@@ -47,7 +47,7 @@ public final class ArraySort extends FnSort {
     final Type type = st.type;
     if(type instanceof ArrayType) {
       if(defined(2) && arg(2).size() == 1) {
-        arg(2, arg -> refineFunc(arg, cc, ((ArrayType) type).valueType));
+        arg(2, arg -> refineFunc(arg, cc, ((ArrayType) type).valueType()));
       }
       exprType.assign(type);
     }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnApply.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnApply.java
@@ -51,7 +51,7 @@ public class FnApply extends StandardFunc {
         final SeqType[] at = ft.argTypes;
         if(at != null) {
           final SeqType[] ast = new SeqType[at.length];
-          Arrays.fill(ast, ((ArrayType) tpArgs).valueType);
+          Arrays.fill(ast, ((ArrayType) tpArgs).valueType());
           arg(0, arg -> refineFunc(arg, cc, ast));
         }
       }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnFoldLeft.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnFoldLeft.java
@@ -116,7 +116,7 @@ public class FnFoldLeft extends StandardFunc {
       }
 
       final SeqType zst = zero.seqType(), i1t = array ? ist.type instanceof ArrayType ?
-        ((ArrayType) ist.type).valueType : SeqType.ITEM_O : ist.with(Occ.EXACTLY_ONE);
+        ((ArrayType) ist.type).valueType() : SeqType.ITEM_O : ist.with(Occ.EXACTLY_ONE);
       SeqType st = zst, ost;
       do {
         final SeqType[] types = { left ? st : i1t, left ? i1t : st, SeqType.INTEGER_O };

--- a/basex-core/src/main/java/org/basex/query/func/map/MapFilter.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapFilter.java
@@ -36,8 +36,8 @@ public final class MapFilter extends StandardFunc {
     final Type type = map.seqType().type;
     if(type instanceof MapType) {
       final MapType mtype = (MapType) type;
-      final SeqType declType = SeqType.get(mtype.keyType, Occ.EXACTLY_ONE);
-      arg(1, arg -> refineFunc(arg, cc, declType, mtype.valueType));
+      final SeqType declType = SeqType.get(mtype.keyType(), Occ.EXACTLY_ONE);
+      arg(1, arg -> refineFunc(arg, cc, declType, mtype.valueType()));
       exprType.assign(type);
     }
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/map/MapForEach.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapForEach.java
@@ -60,8 +60,8 @@ public class MapForEach extends StandardFunc {
     final Type type = map.seqType().type;
     if(type instanceof MapType) {
       final MapType mtype = (MapType) type;
-      final SeqType declType = SeqType.get(mtype.keyType, Occ.EXACTLY_ONE);
-      arg(1, arg -> refineFunc(arg, cc, declType, mtype.valueType));
+      final SeqType declType = SeqType.get(mtype.keyType(), Occ.EXACTLY_ONE);
+      arg(1, arg -> refineFunc(arg, cc, declType, mtype.valueType()));
     }
 
     final FuncType ft = arg(1).funcType();

--- a/basex-core/src/main/java/org/basex/query/func/map/MapGet.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapGet.java
@@ -40,7 +40,7 @@ public final class MapGet extends StandardFunc {
     // combine result type with return type of fallback function, or with empty sequence
     final Type type = map.seqType().type;
     if(type instanceof MapType) {
-      SeqType st = ((MapType) type).valueType;
+      SeqType st = ((MapType) type).valueType();
       if(fallback) {
         final FuncType ft = arg(2).funcType();
         if(ft != null) st = st.union(ft.declType);

--- a/basex-core/src/main/java/org/basex/query/func/map/MapItems.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapItems.java
@@ -47,7 +47,7 @@ public final class MapItems extends StandardFunc {
   @Override
   protected Expr opt(final CompileContext cc) {
     final Type tp = arg(0).seqType().type;
-    if(tp instanceof MapType) exprType.assign(((MapType) tp).valueType.with(Occ.ZERO_OR_MORE));
+    if(tp instanceof MapType) exprType.assign(((MapType) tp).valueType().with(Occ.ZERO_OR_MORE));
     return this;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapKeys.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapKeys.java
@@ -29,7 +29,7 @@ public final class MapKeys extends StandardFunc {
   @Override
   protected Expr opt(final CompileContext cc) {
     final Type type = arg(0).seqType().type;
-    if(type instanceof MapType) exprType.assign(((MapType) type).keyType);
+    if(type instanceof MapType) exprType.assign(((MapType) type).keyType());
     return this;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapKeysWhere.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapKeysWhere.java
@@ -33,7 +33,7 @@ public final class MapKeysWhere extends StandardFunc {
     final Type tp = arg(0).seqType().type;
     if(tp instanceof MapType) {
       final MapType mt = (MapType) tp;
-      final Type kt = mt.keyType;
+      final Type kt = mt.keyType();
       arg(1, arg -> refineFunc(arg, cc, kt.seqType()));
       exprType.assign(kt);
     }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapMerge.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapMerge.java
@@ -110,8 +110,8 @@ public class MapMerge extends StandardFunc {
       // consider duplicate handling for value type
       //   map:merge((1 to 2) ! map { 1: 1 }, map { 'duplicates': 'combine' })
       final MapType mt = (MapType) st.type;
-      final Type kt = mt.keyType;
-      final SeqType vt = mt.valueType;
+      final Type kt = mt.keyType();
+      final SeqType vt = mt.valueType();
       exprType.assign(MapType.get(kt, vm != null ? vm.type(vt) : SeqType.ITEM_ZM));
     }
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/map/MapOfPairs.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapOfPairs.java
@@ -39,7 +39,7 @@ public final class MapOfPairs extends MapMerge {
 
     final Type tp = arg(0).seqType().type;
     if(tp instanceof MapType) {
-      final SeqType vt = ((MapType) tp).valueType;
+      final SeqType vt = ((MapType) tp).valueType();
       final AtomType kt = vt.type.atomic();
       exprType.assign(MapType.get(kt != null ? kt : AtomType.ANY_ATOMIC_TYPE,
         vm != null ? vm.type(vt) : SeqType.ITEM_ZM));

--- a/basex-core/src/main/java/org/basex/query/func/map/MapPairs.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapPairs.java
@@ -24,7 +24,7 @@ public final class MapPairs extends MapEntries {
     final Type tp = arg(0).seqType().type;
     if(tp instanceof MapType) {
       final MapType mt = (MapType) tp;
-      exprType.assign(MapType.get(AtomType.STRING, mt.keyType.seqType().union(mt.valueType)));
+      exprType.assign(MapType.get(AtomType.STRING, mt.keyType().seqType().union(mt.valueType())));
     }
     return this;
   }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapRemove.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapRemove.java
@@ -46,7 +46,7 @@ public final class MapRemove extends StandardFunc {
     if(tp == null && type instanceof MapType) {
       // create new map type (to drop potential record type assignment)
       final MapType mt = (MapType) type;
-      tp = MapType.get(mt.keyType, mt.valueType);
+      tp = MapType.get(mt.keyType(), mt.valueType());
     }
     if(tp != null) exprType.assign(tp);
 

--- a/basex-core/src/main/java/org/basex/query/value/array/XQArray.java
+++ b/basex-core/src/main/java/org/basex/query/value/array/XQArray.java
@@ -207,7 +207,7 @@ public abstract class XQArray extends XQStruct {
   public final Value items(final QueryContext qc) throws QueryException {
     final ValueBuilder vb = new ValueBuilder(qc);
     for(final Value value : iterable()) vb.add(value);
-    return vb.value(((ArrayType) type).valueType.type);
+    return vb.value(((ArrayType) type).valueType().type);
   }
 
   /**
@@ -364,7 +364,7 @@ public abstract class XQArray extends XQStruct {
 
     final SeqType mt;
     if(tp instanceof ArrayType) {
-      mt = ((ArrayType) tp).valueType;
+      mt = ((ArrayType) tp).valueType();
     } else if(tp instanceof FuncType) {
       final FuncType ft = (FuncType) tp;
       if(ft.argTypes.length != 1 || !ft.argTypes[0].instanceOf(SeqType.INTEGER_O)) return false;
@@ -397,7 +397,7 @@ public abstract class XQArray extends XQStruct {
     final ArrayBuilder ab = new ArrayBuilder();
     for(final Value value : iterable()) {
       qc.checkStop();
-      ab.append(at.valueType.coerce(value, null, qc, cc, ii));
+      ab.append(at.valueType().coerce(value, null, qc, cc, ii));
     }
     return ab.array();
   }

--- a/basex-core/src/main/java/org/basex/query/value/map/XQItemObjMap.java
+++ b/basex-core/src/main/java/org/basex/query/value/map/XQItemObjMap.java
@@ -38,7 +38,7 @@ public final class XQItemObjMap extends XQHashMap {
 
   @Override
   Value keysInternal() {
-    return ItemSeq.get(map.keys(), (int) structSize(), ((MapType) type).keyType);
+    return ItemSeq.get(map.keys(), (int) structSize(), ((MapType) type).keyType());
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/value/map/XQMap.java
+++ b/basex-core/src/main/java/org/basex/query/value/map/XQMap.java
@@ -210,8 +210,8 @@ public abstract class XQMap extends XQStruct {
     final SeqType vt;
     if(tp instanceof MapType) {
       final MapType mt = (MapType) tp;
-      kt = mt.keyType == AtomType.ANY_ATOMIC_TYPE ? null : mt.keyType;
-      vt = mt.valueType.eq(SeqType.ITEM_ZM) ? null : mt.valueType;
+      kt = mt.keyType() == AtomType.ANY_ATOMIC_TYPE ? null : mt.keyType();
+      vt = mt.valueType().eq(SeqType.ITEM_ZM) ? null : mt.valueType();
     } else if(tp instanceof FuncType) {
       final FuncType ft = (FuncType) tp;
       if(ft.declType.occ.min != 0 || ft.argTypes.length != 1 ||
@@ -239,7 +239,7 @@ public abstract class XQMap extends XQStruct {
   public final Value items(final QueryContext qc) throws QueryException {
     final ValueBuilder vb = new ValueBuilder(qc);
     forEach((key, value) -> vb.add(value));
-    return vb.value(((MapType) type).valueType.type);
+    return vb.value(((MapType) type).valueType().type);
   }
 
   /**
@@ -254,7 +254,7 @@ public abstract class XQMap extends XQStruct {
   public final XQMap coerceTo(final MapType mt, final QueryContext qc, final CompileContext cc,
       final InputInfo ii) throws QueryException {
 
-    final SeqType kt = mt.keyType.seqType(), vt = mt.valueType;
+    final SeqType kt = mt.keyType().seqType(), vt = mt.valueType();
     final MapBuilder mb = new MapBuilder(structSize());
     forEach((key, value) -> {
       qc.checkStop();

--- a/basex-core/src/main/java/org/basex/query/value/type/ArrayType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/ArrayType.java
@@ -19,7 +19,7 @@ import org.basex.util.*;
  */
 public final class ArrayType extends FType {
   /** Type of the array values. */
-  public final SeqType valueType;
+  private final SeqType valueType;
 
   /**
    * Constructor.
@@ -36,6 +36,14 @@ public final class ArrayType extends FType {
    */
   public static ArrayType get(final SeqType valueType) {
     return valueType.arrayType();
+  }
+
+  /**
+   * Getter for the value type.
+   * @return value type
+   */
+  public SeqType valueType() {
+    return valueType;
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/value/type/MapType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/MapType.java
@@ -19,9 +19,11 @@ import org.basex.util.*;
  */
 public class MapType extends FType {
   /** Key type of the map. */
-  public Type keyType;
+  private Type keyType;
   /** Value types (can be {@code null}, indicating that no type was specified). */
-  public SeqType valueType;
+  private SeqType valueType;
+  /** Flag indicating that keyType and valueType are final. */
+  private boolean isFinal;
 
   /**
    * Constructor.
@@ -29,8 +31,19 @@ public class MapType extends FType {
    * @param valueType value type
    */
   MapType(final Type keyType, final SeqType valueType) {
+    this(keyType, valueType, true);
+  }
+
+  /**
+   * Constructor.
+   * @param keyType key type
+   * @param valueType value type
+   * @param isFinal whether keyType and valueType are final
+   */
+  MapType(final Type keyType, final SeqType valueType, final boolean isFinal) {
     this.keyType = keyType;
     this.valueType = valueType;
+    this.isFinal = isFinal;
   }
 
   /**
@@ -40,7 +53,37 @@ public class MapType extends FType {
    * @return map type
    */
   public static MapType get(final Type keyType, final SeqType valueType) {
-    return valueType.mapType(keyType);
+    final MapType mt = valueType.mapType(keyType);
+    if(!mt.isFinal) throw Util.notExpected();
+    return mt;
+  }
+
+  /**
+   * Supply final value of key type and value type.
+   * @param kt key type
+   * @param vt value type
+   */
+  public void finalizeTypes(final Type kt, final SeqType vt) {
+    if(isFinal) throw Util.notExpected();
+    this.keyType = kt;
+    this.valueType = vt;
+    this.isFinal = true;
+  }
+
+  /**
+   * Getter for the key type.
+   * @return key type
+   */
+  public Type keyType() {
+    return keyType;
+  }
+
+  /**
+   * Getter for the value type.
+   * @return value type
+   */
+  public SeqType valueType() {
+    return valueType;
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/value/type/RecordType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/RecordType.java
@@ -67,7 +67,7 @@ public final class RecordType extends MapType implements Iterable<byte[]> {
    * @param info input info
    */
   public RecordType(final QNm name, final InputInfo info) {
-    super(AtomType.ANY_ATOMIC_TYPE, SeqType.ITEM_ZM);
+    super(AtomType.ANY_ATOMIC_TYPE, SeqType.ITEM_ZM, false);
     this.extensible = true;
     this.fields = new TokenObjMap<>();
     this.name = name;
@@ -244,9 +244,9 @@ public final class RecordType extends MapType implements Iterable<byte[]> {
     }
     if(!extensible && type instanceof MapType) {
       final MapType mt = (MapType) type;
-      if(!mt.keyType.oneOf(AtomType.STRING, AtomType.ANY_ATOMIC_TYPE)) return false;
+      if(!mt.keyType().oneOf(AtomType.STRING, AtomType.ANY_ATOMIC_TYPE)) return false;
       for(final byte[] field : fields) {
-        if(!fields.get(field).seqType().instanceOf(mt.valueType)) return false;
+        if(!fields.get(field).seqType().instanceOf(mt.valueType())) return false;
       }
       return true;
     }
@@ -265,7 +265,7 @@ public final class RecordType extends MapType implements Iterable<byte[]> {
 
   @Override
   public MapType union(final Type kt, final SeqType vt) {
-    return get(keyType.union(kt), valueType.union(vt));
+    return get(keyType().union(kt), valueType().union(vt));
   }
 
   /**
@@ -316,7 +316,7 @@ public final class RecordType extends MapType implements Iterable<byte[]> {
       }
       return new RecordType(extensible || rt.extensible, map, null);
     }
-    return type instanceof MapType ? ((MapType) type).union(keyType, valueType) :
+    return type instanceof MapType ? ((MapType) type).union(keyType(), valueType()) :
            type instanceof ArrayType ? SeqType.FUNCTION :
            type instanceof FuncType ? type.union(this) : AtomType.ITEM;
   }
@@ -418,8 +418,7 @@ public final class RecordType extends MapType implements Iterable<byte[]> {
       ref.extensible = dec.extensible;
       ref.fields = dec.fields;
       ref.info = null;
-      ref.keyType = dec.keyType;
-      ref.valueType = dec.valueType;
+      ref.finalizeTypes(dec.keyType(), dec.valueType());
     }
   }
 


### PR DESCRIPTION
#2399 is about the members of `MapType` no longer being `final`. This leaves some uncertainty about their use.

There is one occasion where this is needed: resolving a record type reference.

This change make those members `private`, moving their modifications inside of `MapType`, into new method `finalizeTypes`.

This makes the modification more explicit. The finalization status of cached `MapType`s is also now verified.

The same has been done to `ArrayType`, though not strictly necessary.