### PR TITLE
Method annotation

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -1248,6 +1248,8 @@ public enum QueryError {
   /** Error code. */
   DUPLNSCONS_X(XQDY, 102, "Duplicate declaration of namespace '%'."),
   /** Error code. */
+  NOMETHOD(XPST, 107, "The annotation %method is not allowed here."),
+  /** Error code. */
   MAPDUPLKEY_X(XQDY, 137, "Map contains duplicate key: %."),
 
   /** Error code. */
@@ -1360,6 +1362,8 @@ public enum QueryError {
   DUPLUPD(XQST, 106, "More than one updating annotation declared."),
   /** Error code. */
   DUPLFUNVIS(XQST, 106, "More than one visibility annotation declared."),
+  /** Error code. */
+  DUPLMETHOD(XQST, 106, "More than one %method annotation declared."),
   /** Error code. */
   OUTPUTLIB_X(XQST, 108, "Declaration not allowed in library module: output:%."),
   /** Error code. */

--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -389,17 +389,17 @@ public class QueryParser extends InputParser {
         if(wsConsumeWs(VARIABLE)) {
           // variables cannot be updating
           if(anns.contains(Annotation.UPDATING)) throw error(UPDATINGVAR);
-          varDecl(anns.check(true, true));
+          varDecl(anns.check(true, true, false));
         } else if(wsConsumeWs(FUNCTION)) {
-          functionDecl(anns.check(false, true));
+          functionDecl(anns.check(false, true, false));
         } else if(wsConsumeWs(TYPE)) {
           // types cannot be updating
           if(anns.contains(Annotation.UPDATING)) throw error(UPDATINGTYPE);
-          typeDecl(anns.check(false, true));
+          typeDecl(anns.check(false, true, false));
         } else if(wsConsumeWs(RECORD)) {
           // types cannot be updating
           if(anns.contains(Annotation.UPDATING)) throw error(UPDATINGTYPE);
-          namedRecordTypeDecl(anns.check(false, true));
+          namedRecordTypeDecl(anns.check(false, true, false));
         } else if(!anns.isEmpty()) {
           throw error(VARFUNC);
         } else {
@@ -2541,7 +2541,7 @@ public class QueryParser extends InputParser {
 
     // inline function
     final int p = pos;
-    final AnnList anns = annotations(false).check(false, true);
+    final AnnList anns = annotations(false).check(false, true, true);
     if(wsConsume(FUNCTION) || wsConsume(FN)) {
       final boolean args = wsConsume("("), focus = !args && current('{');
       if(args || focus) {
@@ -2553,6 +2553,8 @@ public class QueryParser extends InputParser {
           expr = enclosedExpr();
         } else {
           // focus function
+          Ann method = anns.get(Annotation.METHOD);
+          if(method != null) throw NOMETHOD.get(method.info);
           final InputInfo ii = info();
           final QNm name = new QNm("arg");
           params = new Params().add(name, SeqType.ITEM_ZM, null, ii).finish(qc, localVars);
@@ -3353,7 +3355,7 @@ public class QueryParser extends InputParser {
     if(wsConsume("(")) return choiceItemType();
 
     // parse annotations and type name
-    final AnnList anns = annotations(false).check(false, false);
+    final AnnList anns = annotations(false).check(false, false, true);
     skipWs();
     SeqType st = null;
     Type type;

--- a/basex-core/src/main/java/org/basex/query/ann/Annotation.java
+++ b/basex-core/src/main/java/org/basex/query/ann/Annotation.java
@@ -19,6 +19,8 @@ import org.basex.util.hash.*;
  */
 public enum Annotation {
   /** XQuery annotation. */
+  METHOD("method()", params(), XQ_URI, false),
+  /** XQuery annotation. */
   PUBLIC("public()", params(), XQ_URI, false),
   /** XQuery annotation. */
   PRIVATE("private()", params(), XQ_URI, false),

--- a/basex-core/src/main/java/org/basex/query/util/list/AnnList.java
+++ b/basex-core/src/main/java/org/basex/query/util/list/AnnList.java
@@ -140,11 +140,13 @@ public final class AnnList implements Iterable<Ann> {
    * Checks all annotations for parsing errors.
    * @param variable variable flag (triggers different error codes)
    * @param visible check visibility annotations
+   * @param allowMethod allow method annotations
    * @return self reference
    * @throws QueryException query exception
    */
-  public AnnList check(final boolean variable, final boolean visible) throws QueryException {
-    boolean up = false, vis = false;
+  public AnnList check(final boolean variable, final boolean visible, final boolean allowMethod)
+      throws QueryException {
+    boolean up = false, vis = false, meth = false;
     for(final Ann ann : anns) {
       final Annotation def = ann.definition;
       if(def == Annotation.UPDATING) {
@@ -154,6 +156,10 @@ public final class AnnList implements Iterable<Ann> {
         // only one visibility modifier allowed
         if(vis) throw (variable ? DUPLVARVIS : DUPLFUNVIS).get(ann.info);
         vis = true;
+      } else if(def == Annotation.METHOD) {
+        if(!allowMethod) throw NOMETHOD.get(ann.info);
+        if(meth) throw DUPLMETHOD.get(ann.info);
+        meth = true;
       }
     }
     return this;

--- a/basex-core/src/main/java/org/basex/query/value/item/FuncItem.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/FuncItem.java
@@ -86,6 +86,19 @@ public final class FuncItem extends FItem implements Scope {
     this.simple = !expr.has(Flag.CTX);
   }
 
+  /**
+   * Construct a new function item from an existing one, with replaced annotations and focus.
+   * @param funcItem the existing function item
+   * @param anns the new annotations
+   * @param focus the new focus
+   */
+  public FuncItem(final FuncItem funcItem, final AnnList anns, final QueryFocus focus) {
+    this(
+        funcItem.info, funcItem.expr, funcItem.params, anns, FuncType.get(anns,
+            ((FuncType) funcItem.type).declType, ((FuncType) funcItem.type).argTypes),
+        funcItem.stackSize, funcItem.name, focus);
+  }
+
   @Override
   public int arity() {
     return params.length;

--- a/basex-core/src/test/java/org/basex/query/expr/XQuery4Test.java
+++ b/basex-core/src/test/java/org/basex/query/expr/XQuery4Test.java
@@ -52,6 +52,24 @@ public final class XQuery4Test extends SandboxTest {
     query("declare variable $_ := 1; [ 9 ]?$_", 9);
   }
 
+  /** Method annotation. */
+  @Test public void method() {
+    final String rect = "{ 'height': 3, 'width': 4, 'area': %method fn() { ?height × ?width } }";
+    query(rect + "?area()", 12);
+    query(rect + "?area instance of %method fn() as item()*", false);
+    query(rect + "('area') instance of %method fn() as item()*", true);
+
+    query("declare record local:rect(height, width, area := %method fn() { ?height × ?width }); "
+        + "let $r := local:rect(3, 4) return local:rect(5, 6, $r?area)?area()", 12);
+    query("{'self': %method fn() { . } }?*() => map:keys()", "self");
+    query("let $f := %method fn() {?i}, $h := ({'i': 7, 'f': $f}, {'i': 11, 'g': $f})?('f', 'g') "
+        + "return $h[1]() * $h[2]()", 77);
+
+    error("(" + rect + "=> map:get('area'))()", NOCTX_X);
+    error(rect + "('area')()", NOCTX_X);
+    error("%method fn { . }", NOMETHOD);
+  }
+
   /** Otherwise expression. */
   @Test public void otherwise() {
     query("() otherwise ()", "");


### PR DESCRIPTION
This change implements the [`%method`](https://qt4cg.org/specifications/xquery-40/xquery-40.html#id-methods) annotation for function items.

The context of a `%method` function item is bound to the relevant map from within `Lookup.valueFor`. Some optimizations have to be omitted if there is a possibility that the context binding must take place.