### PR TITLE
Java 13 compatibility for `FileSystems.newFileSystem`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/archive/ArchiveRefresh.java
+++ b/basex-core/src/main/java/org/basex/query/func/archive/ArchiveRefresh.java
@@ -32,7 +32,7 @@ public final class ArchiveRefresh extends ArchiveCreate {
     try {
       if(!localZip(io)) throw ARCHIVE_ZIP_X.get(info, io);
 
-      try(FileSystem fs = FileSystems.newFileSystem(Paths.get(io.path()), null)) {
+      try(FileSystem fs = FileSystems.newFileSystem(Paths.get(io.path()), (ClassLoader /* needed for JDK 13 and up */) null)) {
         for(final Entry<String, Entry<Item, Item>> file : files.entrySet()) {
           final Path path = fs.getPath(file.getKey());
           final Entry<Item, Item> entry = file.getValue();


### PR DESCRIPTION
Since Java 13 there are two `FileSystems.newFileSystem` methods which accept a null second parameter. This makes a call with `null` ambiguous. See [https://errorprone.info/bugpattern/NewFileSystem].

The proposed change casts the null parameter to the intended type.
