### PR TITLE
Fix `fn:document-uri` for documents obtained from `fn:collection`

### DIFF
--- a/basex-core/src/main/java/org/basex/data/MetaData.java
+++ b/basex-core/src/main/java/org/basex/data/MetaData.java
@@ -30,6 +30,8 @@ public final class MetaData {
 
   /** Path to initially imported resources. */
   public String original = "";
+  /** Whether this instance is for a single document. */
+  public boolean single = true;
   /** Size of initially imported resources. */
   public long inputsize;
   /** Database timestamp. */

--- a/basex-core/src/main/java/org/basex/query/QueryResources.java
+++ b/basex-core/src/main/java/org/basex/query/QueryResources.java
@@ -473,6 +473,7 @@ public final class QueryResources {
     final Data data;
     try {
       data = CreateDB.create(io.dbName(), parser, context, opts, mem);
+      data.meta.single = single;
     } catch(final IOException ex) {
       throw IOERR_X.get(info, ex);
     }

--- a/basex-core/src/main/java/org/basex/query/value/node/DBNode.java
+++ b/basex-core/src/main/java/org/basex/query/value/node/DBNode.java
@@ -191,7 +191,16 @@ public class DBNode extends ANode {
       final String base = Token.string(data.text(pre, true));
       if(data.inMemory()) {
         final String path = data.meta.original;
-        return Token.token(path.isEmpty() ? base : IO.get(path).url());
+        final String url;
+        if(path.isEmpty()) {
+          url = base;
+        }
+        else {
+          IO io = IO.get(path);
+          if(!data.meta.single) io = io.merge(base);
+          url = io.url();
+        }
+        return Token.token(url);
       }
       return Token.concat('/', data.meta.name, '/', base);
     }

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -4,6 +4,7 @@ import static org.basex.query.QueryError.*;
 import static org.basex.query.func.Function.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.*;
 import java.util.*;
 
 import org.basex.*;
@@ -291,6 +292,21 @@ public final class FnModuleTest extends SandboxTest {
     error(func.args(" true#0"), FIATOMIZE_X);
     error(func.args(REPLICATE.args(" true#0", 2)), FIATOMIZE_X);
     error(func.args(" (1 to 999999) ! true#0"), FIATOMIZE_X);
+  }
+
+  /**
+   * Test method.
+   * @throws IOException IO exception
+   */
+  @Test public void baseUri() throws IOException {
+    final Function func = BASE_URI;
+    final String cd = new File(".").getCanonicalFile().toURI().toString().replaceFirst(
+        "^file:/(?!/)", "file:///");
+    query(func.args(" parse-xml('<x/>')"), cd);
+    query(func.args(" document{<x/>}"), cd);
+    query(func.args(" doc('src/test/resources/test.xml')"), cd + "src/test/resources/test.xml");
+    query("collection('src/test/resources/catalog')!" + func.args(" .")
+        + "[ends-with(., '/doc.xml')]", cd + "src/test/resources/catalog/doc.xml");
   }
 
   /** Test method. */
@@ -738,6 +754,21 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args(TEXT), true);
     query(func.args("/"), false);
     query(func.args("/a/b/c/d/e"), false);
+  }
+
+  /**
+   * Test method.
+   * @throws IOException IO exception
+   */
+  @Test public void documentUri() throws IOException {
+    final Function func = DOCUMENT_URI;
+    final String cd = new File(".").getCanonicalFile().toURI().toString().replaceFirst(
+        "^file:/(?!/)", "file:///");
+    query(func.args(" parse-xml('<x/>')"), "");
+    query(func.args(" document{<x/>}"), "");
+    query(func.args(" doc('src/test/resources/test.xml')"), cd + "src/test/resources/test.xml");
+    query("collection('src/test/resources/catalog')!" + func.args(" .")
+        + "[ends-with(., '/doc.xml')]", cd + "src/test/resources/catalog/doc.xml");
   }
 
   /** Test method. */


### PR DESCRIPTION
As reported by [Yitzhak Khabinsky on basex-talk](https://www.mail-archive.com/basex-talk@mailman.uni-konstanz.de/msg16100.html), `fn:document-uri` in 11.8 returns incomplete results, when applied to documents obtained from `fn:collection`. The issue was introduced by commit 83acbb74f9419d50a4c03c5793647d449b5577c1, which attempted to fix the duplication of path elements in cases where the original URI ends with a slash. For example,

```xquery
base-uri(doc('https://www.w3.org/TR/xml/'))
```

Up to 11.7, this used to return `https://www.w3.org/TR/xml/xml`, with an extra `xml` at the end.

That change was made under the assumption that `MetaData.original` already contained the full path of the document, which however does not hold for `fn:collection` documents.

The change in this PR now adds a new flag `MetaData.single`, providing the information whether a `MetaData` instance is used for a single document. If the flag is set, `MetaData.original` contains the full path to be returnd by `DBNode.baseURI`, otherwise it must be combined  with the name stored in the document.

I have also explored other approaches to fix the issue, but without success. The name stored in the document originates from `IO.nm`, and I tried to set this to an empty token for paths ending in a slash. While this resolved the specific issue, it caused numerous failures in other tests.