### PR TITLE
Fix `fn:base-uri` for remote URLs ending in a slash (follow-up to #2404)

### DIFF
--- a/basex-core/src/main/java/org/basex/io/IOUrl.java
+++ b/basex-core/src/main/java/org/basex/io/IOUrl.java
@@ -103,7 +103,7 @@ public final class IOUrl extends IO {
    * @param url url
    */
   public IOUrl(final String url) {
-    super(normalize(url), false);
+    super(normalize(url), true);
   }
 
   @Override


### PR DESCRIPTION
Commit e92e650929722f016cb1c73adf7fcb842eff2036 does not yet solve the original problem that 83acbb74f9419d50a4c03c5793647d449b5577c1 was addressing, when the source is a remote URL. For example, 

```xquery
base-uri(doc('https://www.w3.org/TR/xml/'))
```

This still returns `https://www.w3.org/TR/xml/xml`. I had not added that to the tests to avoid the remote access. Even tried a catalog to resolve it locally, but that does not help, because then the local URI is returned.

I think that `single` must be set to `true` in `IOUrl` as well to fix this.

