### PR TITLE
Make record `fn:key-value-pair` extensible

### DIFF
--- a/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
@@ -236,7 +236,7 @@ public final class SeqType {
     TokenObjectMap<RecordField> map = new TokenObjectMap<>();
     map.put(Str.KEY.string(), new RecordField(false, SeqType.ANY_ATOMIC_TYPE_O));
     map.put(Str.VALUE.string(), new RecordField(false, SeqType.ITEM_ZM));
-    PAIR = new RecordType(false, map, null);
+    PAIR = new RecordType(true, map, null);
     map = new TokenObjectMap<>();
     map.put(Str.VALUE.string(), new RecordField(false, SeqType.ITEM_ZM));
     MEMBER = new RecordType(false, map, null);

--- a/basex-core/src/test/java/org/basex/query/func/MapModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/MapModuleTest.java
@@ -452,6 +452,8 @@ public final class MapModuleTest extends SandboxTest {
 
     check(func.args(" ()") + " => map:keys()", "", empty());
     check(func.args(" { 'key': 1, 'value': 2 }") + " => map:keys()", 1, root(Int.class));
+
+    query(func.args(" { 'key': 1, 'value': 2, 'more': 3 }"), "{1:2}");
   }
 
   /** Test method. */


### PR DESCRIPTION
The spec says that record `fn:key-value-pair` is extensible, but its representation in `SeqType.PAIR` currently is not. This change makes it extensible and adds a test that requires extensibility. This also fixes QT4 test `map-of-pairs-011`.