### PR TITLE
Implement recent changes in regular expression handling

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/FnAnalyzeString.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnAnalyzeString.java
@@ -83,7 +83,7 @@ public final class FnAnalyzeString extends RegExFn {
       pos[1] = end;
     }
     if(group == 0) {
-      boolean[] assertionFlags = regExpr.getAssertionFlags();
+      final boolean[] assertionFlags = regExpr.getAssertionFlags();
       for(int g = 1; g <= assertionFlags.length; ++g) {
         if(assertionFlags[g - 1] && matcher.start(g) >= 0) {
           final FBuilder lg = FElem.build(Q_LGROUP);

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnAnalyzeString.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnAnalyzeString.java
@@ -40,7 +40,7 @@ public final class FnAnalyzeString extends RegExFn {
     final byte[] pattern = toToken(arg(1), qc);
     final byte[] flags = toZeroToken(arg(2), qc);
 
-    final RegExpr regExpr = regExpr(pattern, flags, false);
+    final RegExpr regExpr = regExpr(pattern, flags);
     final Matcher matcher = regExpr.pattern.matcher(value);
     final FBuilder root = FElem.build(Q_ANALYZE_STRING_RESULT).declareNS();
     int start = 0;

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnAnalyzeString.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnAnalyzeString.java
@@ -26,7 +26,13 @@ public final class FnAnalyzeString extends RegExFn {
   /** QName. */
   private static final QNm Q_MGROUP = new QNm("group", FN_URI);
   /** QName. */
+  private static final QNm Q_LGROUP = new QNm("lookahead-group", FN_URI);
+  /** QName. */
   private static final QNm Q_NR = new QNm("nr");
+  /** QName. */
+  private static final QNm Q_VALUE = new QNm("value");
+  /** QName. */
+  private static final QNm Q_POSITION = new QNm("position");
 
   @Override
   public FNode item(final QueryContext qc, final InputInfo ii) throws QueryException {
@@ -34,7 +40,7 @@ public final class FnAnalyzeString extends RegExFn {
     final byte[] pattern = toToken(arg(1), qc);
     final byte[] flags = toZeroToken(arg(2), qc);
 
-    final RegExpr regExpr = regExpr(pattern, flags, true);
+    final RegExpr regExpr = regExpr(pattern, flags, false);
     final Matcher matcher = regExpr.pattern.matcher(value);
     final FBuilder root = FElem.build(Q_ANALYZE_STRING_RESULT).declareNS();
     int start = 0;
@@ -67,7 +73,7 @@ public final class FnAnalyzeString extends RegExFn {
     while(pos[0] <= gc && matcher.end(pos[0]) <= end
         && (matcher.start(pos[0]) < end || regExpr.getParentGroups()[pos[0] - 1] == group)) {
       final int st = matcher.start(pos[0]);
-      if(st >= 0) { // group matched
+      if(st >= 0 && !regExpr.getAssertionFlags()[pos[0] - 1]) { // group matched
         if(pos[1] < st) node.add(string.substring(pos[1], st));
         pos = match(matcher, string, node, pos[0], regExpr);
       } else pos[0]++; // skip it
@@ -75,6 +81,18 @@ public final class FnAnalyzeString extends RegExFn {
     if(pos[1] < end) {
       node.add(string.substring(pos[1], end));
       pos[1] = end;
+    }
+    if(group == 0) {
+      boolean[] assertionFlags = regExpr.getAssertionFlags();
+      for(int g = 1; g <= assertionFlags.length; ++g) {
+        if(assertionFlags[g - 1] && matcher.start(g) >= 0) {
+          final FBuilder lg = FElem.build(Q_LGROUP);
+          lg.add(Q_NR, g);
+          lg.add(Q_VALUE, string.substring(matcher.start(g), matcher.end(g)));
+          lg.add(Q_POSITION, matcher.start(g) + 1);
+          node.add(lg);
+        }
+      }
     }
     parent.add(node);
     return pos;

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnMatches.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnMatches.java
@@ -32,7 +32,7 @@ public final class FnMatches extends RegExFn {
       final int ch = patternChar(pattern);
       if(ch != -1) return contains(value, ch);
     }
-    return pattern(pattern, flags, false).matcher(string(value)).find();
+    return pattern(pattern, flags).matcher(string(value)).find();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnReplace.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnReplace.java
@@ -33,7 +33,7 @@ public final class FnReplace extends RegExFn {
       final int sp = patternChar(pattern), rp = replace != null ? patternChar(replace) : -1;
       if(sp != -1 && rp != -1) return Str.get(replace(value, sp, rp));
     }
-    final RegExpr regExpr = regExpr(pattern, flags, false);
+    final RegExpr regExpr = regExpr(pattern, flags);
     final Matcher matcher = regExpr.pattern.matcher(string(value));
 
     if(action != null) {

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnReplace.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnReplace.java
@@ -33,7 +33,7 @@ public final class FnReplace extends RegExFn {
       final int sp = patternChar(pattern), rp = replace != null ? patternChar(replace) : -1;
       if(sp != -1 && rp != -1) return Str.get(replace(value, sp, rp));
     }
-    final RegExpr regExpr = regExpr(pattern, flags, true);
+    final RegExpr regExpr = regExpr(pattern, flags, false);
     final Matcher matcher = regExpr.pattern.matcher(string(value));
 
     if(action != null) {

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnTokenize.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnTokenize.java
@@ -96,17 +96,14 @@ public final class FnTokenize extends RegExFn {
     final String string = Token.string(value);
     final int len = string.length();
     int start = 0;
-    boolean emptyEnd = false;
     for(final Matcher matcher = p.matcher(string); matcher.find();) {
       final int ms = matcher.start(), me = matcher.end();
-      emptyEnd = ms == len;
-      if(me != 0) {
+      if(ms != len && me != 0) {
         tl.add(string.substring(start, ms));
         start = me;
       }
     }
-    if(!emptyEnd) tl.add(string.substring(start));
-    return StrSeq.get(tl);
+    return StrSeq.get(tl.add(string.substring(start)));
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnTokenize.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnTokenize.java
@@ -56,7 +56,7 @@ public final class FnTokenize extends RegExFn {
       }
     }
 
-    final Pattern p = pattern(pattern, flags, false);
+    final Pattern p = pattern(pattern, flags);
     return vl == 0 ? Empty.ITER : new Iter() {
       final String string = Token.string(value);
       final Matcher matcher = p.matcher(string);
@@ -89,7 +89,7 @@ public final class FnTokenize extends RegExFn {
       if(ch != -1) return vl == 0 ? Empty.VALUE : StrSeq.get(Token.split(value, ch, true));
     }
 
-    final Pattern p = pattern(pattern, flags, false);
+    final Pattern p = pattern(pattern, flags);
     if(vl == 0) return Empty.VALUE;
 
     final TokenList tl = new TokenList();

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnTokenize.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnTokenize.java
@@ -56,7 +56,7 @@ public final class FnTokenize extends RegExFn {
       }
     }
 
-    final Pattern p = pattern(pattern, flags, true);
+    final Pattern p = pattern(pattern, flags, false);
     return vl == 0 ? Empty.ITER : new Iter() {
       final String string = Token.string(value);
       final Matcher matcher = p.matcher(string);
@@ -89,17 +89,24 @@ public final class FnTokenize extends RegExFn {
       if(ch != -1) return vl == 0 ? Empty.VALUE : StrSeq.get(Token.split(value, ch, true));
     }
 
-    final Pattern p = pattern(pattern, flags, true);
+    final Pattern p = pattern(pattern, flags, false);
     if(vl == 0) return Empty.VALUE;
 
     final TokenList tl = new TokenList();
     final String string = Token.string(value);
+    final int len = string.length();
     int start = 0;
+    boolean emptyEnd = false;
     for(final Matcher matcher = p.matcher(string); matcher.find();) {
-      tl.add(string.substring(start, matcher.start()));
-      start = matcher.end();
+      final int ms = matcher.start(), me = matcher.end();
+      emptyEnd = ms == len;
+      if(me != 0) {
+        tl.add(string.substring(start, ms));
+        start = me;
+      }
     }
-    return StrSeq.get(tl.add(string.substring(start)));
+    if(!emptyEnd) tl.add(string.substring(start));
+    return StrSeq.get(tl);
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/func/fn/RegExFn.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/RegExFn.java
@@ -68,31 +68,29 @@ abstract class RegExFn extends StandardFunc {
    * Returns a regular expression pattern.
    * @param pattern pattern
    * @param flags flags (can be {@code null})
-   * @param check check result for empty strings
    * @return pattern modifier
    * @throws QueryException query exception
    */
-  final Pattern pattern(final byte[] pattern, final byte[] flags, final boolean check)
+  final Pattern pattern(final byte[] pattern, final byte[] flags)
       throws QueryException {
-    return regExpr(pattern, flags, check).pattern;
+    return regExpr(pattern, flags).pattern;
   }
 
   /**
    * Returns a regular expression pattern.
    * @param pattern pattern
    * @param flags flags
-   * @param check check result for empty strings
    * @return pattern modifier
    * @throws QueryException query exception
    */
-  final RegExpr regExpr(final byte[] pattern, final byte[] flags, final boolean check)
+  final RegExpr regExpr(final byte[] pattern, final byte[] flags)
       throws QueryException {
 
     final byte[] key = Token.concat(pattern, '\b', flags);
     synchronized(patterns) {
       RegExpr regExpr = patterns.get(key);
       if(regExpr == null) {
-        regExpr = parse(pattern, flags, check);
+        regExpr = parse(pattern, flags);
         patterns.put(key, regExpr);
       }
       return regExpr;
@@ -113,11 +111,10 @@ abstract class RegExFn extends StandardFunc {
    * Compiles this regular expression to a {@link Pattern}.
    * @param regex regular expression to parse
    * @param modifiers modifiers
-   * @param check check result for empty strings
    * @return the pattern
    * @throws QueryException query exception
    */
-  private RegExpr parse(final byte[] regex, final byte[] modifiers, final boolean check)
+  private RegExpr parse(final byte[] regex, final byte[] modifiers)
       throws QueryException {
 
     // process modifiers
@@ -145,13 +142,6 @@ abstract class RegExFn extends StandardFunc {
         final String string = parser.parse().toString();
 
         pattern = Pattern.compile(string, flags);
-        if(check) {
-          // Circumvent Java RegEx behavior ("If MULTILINE mode is activated"...):
-          // http://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#lt
-          final Pattern p = (pattern.flags() & Pattern.MULTILINE) == 0 ? pattern :
-            Pattern.compile(pattern.pattern());
-          if(p.matcher("").matches()) throw REGEMPTY_X.get(info, string);
-        }
       }
 
       return new RegExpr(pattern);

--- a/basex-core/src/main/java/org/basex/query/util/regex/Escape.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/Escape.java
@@ -23,9 +23,9 @@ public final class Escape extends RegExp {
   /** Everything except name characters. */
   private static final String NOT_CHAR;
   /** Word characters. */
-  private static final String WORD;
+  public static final String WORD;
   /** Everything except word characters. */
-  private static final String NOT_WORD;
+  public static final String NOT_WORD;
   /** Digits. */
   private static final String DIGIT = "\\p{Nd}";
   /** Everything except digits. */

--- a/basex-core/src/main/java/org/basex/query/util/regex/LineBorder.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/LineBorder.java
@@ -36,8 +36,17 @@ public final class LineBorder extends RegExp {
     return INSTANCES[pos];
   }
 
+  /**
+   * Return the end-of-string pattern to be used, depending on multi-line mode.
+   * @param multi multi-line flag
+   * @return end-of-line pattern
+   */
+  public static String eos(final boolean multi) {
+    return multi ? "$" : "(?:$(?!\\s))";
+  }
+
   @Override
   void toRegEx(final StringBuilder sb) {
-    sb.append(start ? "^" : multi ? "$" : "(?:$(?!\\s))");
+    sb.append(start ? "^" : eos(multi));
   }
 }

--- a/basex-core/src/main/java/org/basex/query/util/regex/LookAround.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/LookAround.java
@@ -1,0 +1,48 @@
+package org.basex.query.util.regex;
+
+/**
+ * Lookahaead or lookbehind assertion.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public final class LookAround extends RegExp {
+  /** Behind flag. */
+  private final boolean behind;
+  /** Positive flag. */
+  private final boolean positive;
+  /** Regular expression. */
+  private final RegExp regExp;
+
+  /**
+   * Constructor.
+   * @param behind 'behind' flag
+   * @param positive 'positive' flag
+   * @param regExp regular expression
+   */
+  private LookAround(final boolean behind, final boolean positive, final RegExp regExp) {
+    this.behind = behind;
+    this.positive = positive;
+    this.regExp = regExp;
+  }
+
+  /**
+   * Creates a regular expression from the given lookahead or lookbehind assertion.
+   * @param behind 'behind' flag
+   * @param positive 'positive' flag
+   * @param regExp regular expression
+   * @return regular expression
+   */
+  public static LookAround get(final boolean behind, final boolean positive, final RegExp regExp) {
+    return new LookAround(behind, positive, regExp);
+  }
+
+  @Override
+  void toRegEx(final StringBuilder sb) {
+    sb.append("(?");
+    if(behind) sb.append("<");
+    sb.append(positive ? '=' : '!');
+    regExp.toRegEx(sb);
+    sb.append(')');
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/util/regex/WordBoundary.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/WordBoundary.java
@@ -20,15 +20,15 @@ public final class WordBoundary extends RegExp {
    * @param multi multi-line flag
    */
   private WordBoundary(final boolean positive, final boolean multi) {
-    final String eol = LineBorder.eos(multi);
+    final String eos = LineBorder.eos(multi);
     if(positive) {
-      img = "(?:(?<=["      + Escape.WORD     + "])(?:(?=[" + Escape.NOT_WORD + "])|" + eol + ")"
+      img = "(?:(?<=["      + Escape.WORD     + "])(?:(?=[" + Escape.NOT_WORD + "])|" + eos + ")"
           +   "|(?<=(?:^|[" + Escape.NOT_WORD + "]))(?=["   + Escape.WORD     + "])"
           + ")";
     } else {
       img = "(?:(?<=["      + Escape.WORD     + "])(?=["     + Escape.WORD     + "])"
-          +   "|(?<=(?:^|[" + Escape.NOT_WORD + "]))(?:(?=[" + Escape.NOT_WORD + "])|" + eol + ")"
-          +   "|^" + eol
+          +   "|(?<=(?:^|[" + Escape.NOT_WORD + "]))(?:(?=[" + Escape.NOT_WORD + "])|" + eos + ")"
+          +   "|^" + eos
           + ")";
     }
   }

--- a/basex-core/src/main/java/org/basex/query/util/regex/WordBoundary.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/WordBoundary.java
@@ -1,0 +1,58 @@
+package org.basex.query.util.regex;
+
+import org.basex.util.*;
+
+/**
+ * Word-boundary ({@code \b}) or non-word-boundary ({@code \B}) assertion.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public final class WordBoundary extends RegExp {
+  /** Image. */
+  private final String img;
+  /** Cached instances. */
+  private static final WordBoundary[] INSTANCES = new WordBoundary[4];
+
+  /**
+   * Constructor.
+   * @param positive true for word-boundary, false for non-word-boundary
+   * @param multi multi-line flag
+   */
+  private WordBoundary(final boolean positive, final boolean multi) {
+    final String eol = LineBorder.eos(multi);
+    if(positive) {
+      img = "(?:(?<=["      + Escape.WORD     + "])(?:(?=[" + Escape.NOT_WORD + "])|" + eol + ")"
+          +   "|(?<=(?:^|[" + Escape.NOT_WORD + "]))(?=["   + Escape.WORD     + "])"
+          + ")";
+    } else {
+      img = "(?:(?<=["      + Escape.WORD     + "])(?=["     + Escape.WORD     + "])"
+          +   "|(?<=(?:^|[" + Escape.NOT_WORD + "]))(?:(?=[" + Escape.NOT_WORD + "])|" + eol + ")"
+          +   "|^" + eol
+          + ")";
+    }
+  }
+
+  /**
+   * Creates a regular expression from the given word boundary escape sequence.
+   * @param esc escape sequence
+   * @param multi multi-line flag
+   * @return regular expression
+   */
+  public static WordBoundary get(final String esc, final boolean multi) {
+    final boolean positive;
+    switch(esc.charAt(1)) {
+      case 'b': positive = true;  break;
+      case 'B': positive = false; break;
+      default: throw Util.notExpected();
+    }
+    final int pos = (positive ? 2 : 0) + (multi ? 1 : 0);
+    if(INSTANCES[pos] == null) INSTANCES[pos] = new WordBoundary(positive, multi);
+    return INSTANCES[pos];
+  }
+
+  @Override
+  void toRegEx(final StringBuilder sb) {
+    sb.append(img);
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParser.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParser.java
@@ -1091,7 +1091,7 @@ re = LookAround.get(behind, positive, re);
 	   p = p.next;
 	 }
 
-	 p.gen = jj_gen + xla - jj_la; 
+	 p.gen = jj_gen + xla - jj_la;
 	 p.first = token;
 	 p.arg = xla;
   }

--- a/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParserConstants.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/parse/RegExParserConstants.java
@@ -41,23 +41,33 @@ public interface RegExParserConstants {
   /** RegularExpression Id. */
   int WILDCARD = 15;
   /** RegularExpression Id. */
-  int LINE_START = 16;
+  int SINGLE_ESC = 16;
   /** RegularExpression Id. */
-  int LINE_END = 17;
+  int MULTI_ESC = 17;
   /** RegularExpression Id. */
-  int SINGLE_ESC = 18;
+  int CAT_ESC = 18;
   /** RegularExpression Id. */
-  int MULTI_ESC = 19;
+  int BR_OPEN = 19;
   /** RegularExpression Id. */
-  int CAT_ESC = 20;
+  int NEG = 20;
   /** RegularExpression Id. */
-  int BR_OPEN = 21;
+  int TO = 21;
   /** RegularExpression Id. */
-  int NEG = 22;
+  int BR_CLOSE = 22;
   /** RegularExpression Id. */
-  int TO = 23;
+  int LINE_START = 23;
   /** RegularExpression Id. */
-  int BR_CLOSE = 24;
+  int LINE_END = 24;
+  /** RegularExpression Id. */
+  int WORD_BOUNDARY = 25;
+  /** RegularExpression Id. */
+  int POS_LOOKAHEAD = 26;
+  /** RegularExpression Id. */
+  int NEG_LOOKAHEAD = 27;
+  /** RegularExpression Id. */
+  int POS_LOOKBEHIND = 28;
+  /** RegularExpression Id. */
+  int NEG_LOOKBEHIND = 29;
 
   /** Literal token values. */
   String[] tokenImage = {
@@ -77,8 +87,6 @@ public interface RegExParserConstants {
     "<DIGIT>",
     "<BACK_REF>",
     "<WILDCARD>",
-    "<LINE_START>",
-    "<LINE_END>",
     "<SINGLE_ESC>",
     "<MULTI_ESC>",
     "<CAT_ESC>",
@@ -86,6 +94,13 @@ public interface RegExParserConstants {
     "<NEG>",
     "<TO>",
     "<BR_CLOSE>",
+    "<LINE_START>",
+    "<LINE_END>",
+    "<WORD_BOUNDARY>",
+    "<POS_LOOKAHEAD>",
+    "<NEG_LOOKAHEAD>",
+    "<POS_LOOKBEHIND>",
+    "<NEG_LOOKBEHIND>",
   };
 
 }

--- a/basex-core/src/main/javacc/regex.jj
+++ b/basex-core/src/main/javacc/regex.jj
@@ -66,26 +66,27 @@ PARSER_END(RegExParser)
   RegExp parse() : {
     RegExp regex;
   } {
-    regex = regExp() <EOF> {
+    regex = regExp(false) <EOF> {
       return regex;
     }
   }
 
   /**
    * Parses the "regExp" rule.
+   * @param lookbehind flag indicating lookbehind expression
    * @return expression
    * @throws ParseException parsing exception
    */
-  RegExp regExp() : {
+  RegExp regExp(final boolean lookbehind) : {
     final RegExpList brs = new RegExpList();
     RegExp br;
     atomPath.push(0);
   } {
     (
-      br = branch() { brs.add(br); }
+      br = branch(lookbehind) { brs.add(br); }
       (
         <OR> { atomPath.push(atomPath.pop() + 1); }
-        br = branch() { brs.add(br); }
+        br = branch(lookbehind) { brs.add(br); }
       )*
     ) {
       atomPath.pop();
@@ -96,21 +97,31 @@ PARSER_END(RegExParser)
   /**
    * Parses the "branch" rule.
    * Parses the "piece" rule.
+   * @param lookbehind flag indicating lookbehind expression
    * @return expression
    * @throws ParseException parsing exception
    */
-  RegExp branch() : {
+  RegExp branch(final boolean lookbehind) : {
     RegExp atom;
     final RegExpList pieces = new RegExpList();
     Quantifier qu = null;
     atomPath.push(0);
   } {
     (
-      ( atom = atom() [ qu = quantifier() ] ) {
-        pieces.add(qu == null ? atom : new Piece(atom, qu));
-        qu = null;
-        atomPath.push(atomPath.pop() + 1);
-      }
+      (
+        ( atom = atom(lookbehind) [ qu = quantifier() {
+            if(lookbehind) throw new ParseException("Lookbehind assertions must not contain quantifiers.");
+          } ] ) {
+            pieces.add(qu == null ? atom : new Piece(atom, qu));
+            qu = null;
+          }
+        | atom = assertion() {
+            if(lookbehind) throw new ParseException("Lookbehind assertions must not contain nested assertions.");
+            pieces.add(atom);
+          }
+        ) {
+          atomPath.push(atomPath.pop() + 1);
+        }
     )* {
       atomPath.pop();
       return pieces.size() == 1 ? pieces.get(0) : new Branch(pieces.finish());
@@ -175,25 +186,30 @@ PARSER_END(RegExParser)
 
   /**
    * Parses the "atom" rule.
+   * @param lookbehind flag indicating lookbehind expression
    * @return expression
    * @throws ParseException parsing exception
    */
-  RegExp atom() : {
+  RegExp atom(final boolean lookbehind) : {
     RegExp nd = null;
   } {
     ( nd = Char()
     | nd = charClass()
-    | (<NPAR_OPEN> nd = regExp() <PAR_CLOSE>) {
+    | (<NPAR_OPEN> nd = regExp(false) <PAR_CLOSE>) {
+        if(lookbehind) throw new ParseException("Lookbehind assertions must not contain parenthesized expressions.");
         nd = new Group(nd, false, atomPath.toArray(new Integer[atomPath.size()]));
       }
     | (<PAR_OPEN> { final int grp = ++groups; }
-        nd = regExp()
+        nd = regExp(false)
       <PAR_CLOSE>) {
+        if(lookbehind) throw new ParseException("Lookbehind assertions must not contain parenthesized expressions.");
         final Group g = new Group(nd, true, atomPath.toArray(new Integer[atomPath.size()]));
         closed.put(grp, g);
         nd = g;
       }
-    | nd = backReference()
+    | nd = backReference() {
+        if(lookbehind) throw new ParseException("Lookbehind assertions must not contain backward references.");
+      }
     ) {
       return nd;
     }
@@ -256,8 +272,6 @@ PARSER_END(RegExParser)
     ( nd = charClassEsc()
     | nd = charClassExpr()
     | <WILDCARD>   { nd = Wildcard.get(dotAll); }
-    | <LINE_START> { nd = LineBorder.get(true, multiLine); }
-    | <LINE_END>   { nd = LineBorder.get(false, multiLine); }
     ) {
       return nd;
     }
@@ -370,3 +384,23 @@ PARSER_END(RegExParser)
     }
   }
 
+  /**
+   * Parsers the "assertion" rule.
+   * @return expression
+   */
+  RegExp assertion(): {
+    RegExp re;
+    boolean behind, positive;
+  } {
+    ( <LINE_START>                      { re = LineBorder.get(true, multiLine); }
+    | <LINE_END>                        { re = LineBorder.get(false, multiLine); }
+    | <WORD_BOUNDARY>                   { re = WordBoundary.get(token.image, multiLine); }
+    | ( <POS_LOOKAHEAD>                 { behind = false; positive = true; }
+      | <NEG_LOOKAHEAD>                 { behind = false; positive = false; }
+      | <POS_LOOKBEHIND>                { behind = true;  positive = true; }
+      | <NEG_LOOKBEHIND>                { behind = true;  positive = false; }
+      ) re = regExp(behind) <PAR_CLOSE> { re = LookAround.get(behind, positive, re); }
+    ) {
+      return re;
+    }
+  }

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -2524,7 +2524,7 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args("a", ".", "b"), "b");
 
     query(func.args("a", "", "x", "j"), "xax");
-    error(func.args("a", "", "x"), REGEMPTY_X);
+    query(func.args("a", "", "x"), "xax");
 
     // GH-573
     query(func.args("aaaaa bbbbbbbb ddd ", "(.{6,15}) ", "$1@"), "aaaaa bbbbbbbb@ddd ");
@@ -2581,7 +2581,7 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args("abcde", "b(.)d", "$1"), "ace");
     query(func.args("abcde", "b(.)d", "$1", "j"), "ace");
 
-    error(func.args("W", ".*", " ()", " ()", " function($k, $g) { }"), REGEMPTY_X);
+    query(func.args("W", ".*", " ()", " ()", " function($k, $g) { '~' }"), "~~");
   }
 
   /** Test method. */

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -3276,10 +3276,10 @@ public final class FnModuleTest extends SandboxTest {
   /** Test method. */
   @Test public void tokenize() {
     final Function func = TOKENIZE;
-    query(func.args("a", "", "j"), "\na\n");
-    query(func.args(wrap("a"), "", "j"), "\na\n");
-    query(func.args("a", wrap(""), "j"), "\na\n");
-    query(func.args(wrap("a"), wrap(""), "j"), "\na\n");
+    query(func.args("a", "", "j"), "a");
+    query(func.args(wrap("a"), "", "j"), "a");
+    query(func.args("a", wrap(""), "j"), "a");
+    query(func.args(wrap("a"), wrap(""), "j"), "a");
 
     query("subsequence(" + func.args(wrap("a b c d")) + ", 3)", "c\nd");
     query("subsequence(" + func.args(wrap("a,b,c,d"), ",") + ", 3)", "c\nd");
@@ -3294,6 +3294,7 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args(wrap("a!!b!!c!!d"), "!!"), "a\nb\nc\nd");
     query(func.args(wrap("")), "");
     query(func.args(wrap(""), "!!"), "");
+    query(func.args("a", ""), "a");
 
     check(func.args(" normalize-space(" + wrap("A") + ")", " ' '"), "A", empty(NORMALIZE_SPACE));
     check("(<_>A</_>, <_>B</_>) ! " + func.args(" normalize-space()", " ' '"), "A\nB",
@@ -3302,8 +3303,6 @@ public final class FnModuleTest extends SandboxTest {
         exists(NORMALIZE_SPACE));
     check(func.args(" normalize-space(" + wrap("A") + ")", ";"), "A",
         exists(NORMALIZE_SPACE));
-
-    error(func.args("a", ""), REGEMPTY_X);
   }
 
   /** Test method. */

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -159,8 +159,6 @@ public final class FnModuleTest extends SandboxTest {
           + "\"http://www.w3.org/2005/xpath-functions\"><match><group nr=\"1\">b<group nr=\"2\"/>"
           + "</group></match><non-match>anana</non-match></analyze-string-result>");
     }
-
-    error(func.args("a", ""), REGEMPTY_X);
   }
 
   /** Test method. */

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -159,6 +159,9 @@ public final class FnModuleTest extends SandboxTest {
           + "\"http://www.w3.org/2005/xpath-functions\"><match><group nr=\"1\">b<group nr=\"2\"/>"
           + "</group></match><non-match>anana</non-match></analyze-string-result>");
     }
+
+    query(func.args("a", ""), "<analyze-string-result xmlns=\"http://www.w3.org/2005/xpath-"
+        + "functions\"><match/><non-match>a</non-match><match/></analyze-string-result>");
   }
 
   /** Test method. */
@@ -3294,7 +3297,6 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args(wrap("a!!b!!c!!d"), "!!"), "a\nb\nc\nd");
     query(func.args(wrap("")), "");
     query(func.args(wrap(""), "!!"), "");
-    query(func.args("a", ""), "a");
 
     check(func.args(" normalize-space(" + wrap("A") + ")", " ' '"), "A", empty(NORMALIZE_SPACE));
     check("(<_>A</_>, <_>B</_>) ! " + func.args(" normalize-space()", " ' '"), "A\nB",
@@ -3303,6 +3305,8 @@ public final class FnModuleTest extends SandboxTest {
         exists(NORMALIZE_SPACE));
     check(func.args(" normalize-space(" + wrap("A") + ")", ";"), "A",
         exists(NORMALIZE_SPACE));
+
+    query(func.args("a", ""), "a");
   }
 
   /** Test method. */

--- a/basex-core/src/test/java/org/basex/query/func/fn/RegexTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/fn/RegexTest.java
@@ -26,7 +26,7 @@ public final class RegexTest extends SandboxTest {
   @ParameterizedTest
   @MethodSource
   public void testParentGroups(final String regex, final int[] parentGroups) {
-    final int[] actualGroups = RegExFn.GroupScanner.parentGroups(regex);
+    final int[] actualGroups = RegExFn.GroupScanner.groupInfo(regex).parentGroups;
     assertArrayEquals(parentGroups, actualGroups,
         () -> "Unexpected result: " + Arrays.toString(actualGroups));
     assertEquals(Pattern.compile(regex).matcher("").groupCount(), parentGroups.length);


### PR DESCRIPTION
This change implements the following changes of regular expression handling

- word boundary assertions
- lookahead and lookbehind assertions
- representation of lookahead groups in `fn:analyze-string` results
- removal of matches-empty restriction for `fn:analyze-string`, `fn:tokenize`, `fn:replace`
