### PR TITLE
Implement `fn:schema-type`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -588,6 +588,9 @@ public enum Function implements AFunction {
       params(ITEM_ZM, ITEM_ZM, FuncType.get(ITEM_ZM, ITEM_O, ITEM_ZM, INTEGER_O).seqType()),
       ARRAY_ZM, flag(HOF)),
   /** XQuery function. */
+  SCHEMA_TYPE(FnSchemaType::new, "schema-type(name)",
+      params(QNAME_O), MAP_ZO),
+  /** XQuery function. */
   SECONDS(FnSeconds::new, "seconds(value)",
       params(DECIMAL_ZO), DAY_TIME_DURATION_ZO),
   /** XQuery function. */

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnAtomicTypeAnnotation.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnAtomicTypeAnnotation.java
@@ -1,20 +1,8 @@
 package org.basex.query.func.fn;
 
-import static org.basex.query.value.type.AtomType.*;
-import static org.basex.query.value.type.SeqType.*;
-
 import org.basex.query.*;
-import org.basex.query.expr.*;
-import org.basex.query.func.*;
-import org.basex.query.util.list.*;
 import org.basex.query.value.*;
 import org.basex.query.value.item.*;
-import org.basex.query.value.map.*;
-import org.basex.query.value.seq.*;
-import org.basex.query.value.type.*;
-import org.basex.query.var.*;
-import org.basex.util.*;
-import org.basex.util.hash.*;
 
 /**
  * Function implementation.
@@ -22,169 +10,11 @@ import org.basex.util.hash.*;
  * @author BaseX Team, BSD License
  * @author Gunther Rademacher
  */
-public class FnAtomicTypeAnnotation extends StandardFunc {
+public class FnAtomicTypeAnnotation extends FnSchemaType {
 
   @Override
-  public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
+  public Value value(final QueryContext qc) throws QueryException {
     final Item value = toAtomItem(arg(0), qc);
-    return annotate(value.type.atomic(), qc, ii);
-  }
-
-  /**
-   * Creates a type annotation for the specified atomic type.
-   * @param type the type to be annotated
-   * @param qc query context
-   * @param ii input info
-   * @return the type annotation
-   * @throws QueryException query exception
-   */
-  protected static Item annotate(final AtomType type, final QueryContext qc, final InputInfo ii)
-      throws QueryException {
-    if(type == null) return Empty.VALUE;
-
-    final AtomType baseType;
-    final Variety variety;
-    AtomType primType = null;
-    FuncItem constructor = null;
-    switch(type) {
-      case ANY_TYPE:
-        baseType = null;
-        variety = Variety.mixed;
-        break;
-      case UNTYPED:
-        baseType = ANY_TYPE;
-        variety = Variety.mixed;
-        break;
-      case ANY_SIMPLE_TYPE:
-        baseType = ANY_TYPE;
-        variety = null;
-        break;
-      case ANY_ATOMIC_TYPE:
-        baseType = ANY_SIMPLE_TYPE;
-        variety = Variety.atomic;
-        break;
-      default:
-        final AtomType parent = type.parent();
-        baseType = parent == NUMERIC ? ANY_ATOMIC_TYPE : parent;
-        variety = Variety.atomic;
-        for(primType = type; !primType.parent().oneOf(ANY_ATOMIC_TYPE, NUMERIC, null);)
-          primType = primType.parent();
-        if(!type.oneOf(QNAME, NOTATION))
-          constructor = (FuncItem) Functions.item(type.qname(), 1, true, ii, qc, true);
-    }
-
-    final MapBuilder mb = new MapBuilder();
-    mb.put("name", type.qname());
-    mb.put("is-simple", Bln.get(!type.oneOf(ANY_TYPE, UNTYPED)));
-    mb.put("base-type", TypeAnnotation.funcItem(baseType, ii));
-    if(primType != null) mb.put("primitive-type", TypeAnnotation.funcItem(primType, ii));
-    if(variety != null) mb.put("variety", variety.name());
-    if(type.atomic() != null) mb.put("matches", Matches.funcItem(type, qc, ii));
-    if(constructor != null) mb.put("constructor", constructor);
-    return mb.map();
-  }
-
-  /** The variety of a type. */
-  private enum Variety {
-    /** Mixed.  */ mixed,
-    /** List.   */ list,
-    /** Atomic. */ atomic
-  };
-
-  /**
-   * Function creating the type annotation for a given atomic type.
-   */
-  private static final class TypeAnnotation extends Arr {
-    /** Function type. */
-    private static final FuncType FUNC_TYPE = FuncType.get(MAP_O);
-    /** The type to be annotated. */
-    private final AtomType type;
-
-    /**
-     * Constructor.
-     * @param info input info
-     * @param type the type to be annotated
-     */
-    private TypeAnnotation(final InputInfo info, final AtomType type) {
-      super(info, MAP_O);
-      this.type = type;
-    }
-
-    /**
-     * Create a function item for a new instance.
-     * @param type the type to be matched
-     * @param info input info
-     * @return the function item
-     */
-    public static Value funcItem(final AtomType type, final InputInfo info) {
-      return new FuncItem(info, new TypeAnnotation(info, type), new Var[] { }, AnnList.EMPTY,
-          FUNC_TYPE, 0, null);
-    }
-
-    @Override
-    public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
-      return annotate(type, qc, ii);
-    }
-
-    @Override
-    public Expr copy(final CompileContext cc, final IntObjectMap<Var> vm) {
-      return new TypeAnnotation(info, type);
-    }
-
-    @Override
-    public void toString(final QueryString qs) {
-      qs.token("type-annotation").params(exprs);
-    }
-  }
-
-  /**
-   * Function checking if an item matches a given type.
-   */
-  private static final class Matches extends Arr {
-    /** Function type. */
-    private static final FuncType FUNC_TYPE = FuncType.get(BOOLEAN_O, ANY_ATOMIC_TYPE_O);
-    /** The type to be matched. */
-    final AtomType type;
-
-    /**
-     * Constructor.
-     * @param info input info
-     * @param type the type to be matched
-     * @param args the arguments
-     */
-    private Matches(final InputInfo info, final AtomType type, final Expr... args) {
-      super(info, BOOLEAN_O, args);
-      this.type = type;
-    }
-
-    /**
-     * Create a function item for a new instance.
-     * @param type the type to be matched
-     * @param qc query context
-     * @param info input info
-     * @return the function item
-     */
-    public static Value funcItem(final AtomType type, final QueryContext qc, final InputInfo info) {
-      final Var var = new VarScope().addNew(new QNm("value"), ANY_ATOMIC_TYPE_O, qc, info);
-      final Var[] params = { var };
-      return new FuncItem(info, new Matches(info, type, new VarRef(info, var)), params,
-          AnnList.EMPTY, FUNC_TYPE, params.length, null);
-    }
-
-    @Override
-    public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
-      final Item value = toAtomItem(arg(0), qc);
-      return Bln.get(value.type.instanceOf(type));
-    }
-
-    @Override
-    public Expr copy(final CompileContext cc, final IntObjectMap<Var> vm) {
-      return new Matches(info, type, copyAll(cc, vm, args()));
-    }
-
-    @Override
-    public void toString(final QueryString qs) {
-      qs.token("matches").params(exprs);
-    }
+    return annotate(qc, info, value.type.atomic());
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnNodeTypeAnnotation.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnNodeTypeAnnotation.java
@@ -6,10 +6,9 @@ import static org.basex.query.value.type.SeqType.*;
 import java.util.*;
 
 import org.basex.query.*;
-import org.basex.query.value.item.*;
+import org.basex.query.value.*;
 import org.basex.query.value.node.*;
 import org.basex.query.value.type.*;
-import org.basex.util.*;
 
 /**
  * Function implementation.
@@ -17,15 +16,15 @@ import org.basex.util.*;
  * @author BaseX Team, BSD License
  * @author Gunther Rademacher
  */
-public final class FnNodeTypeAnnotation extends FnAtomicTypeAnnotation {
+public final class FnNodeTypeAnnotation extends FnSchemaType {
   /** The function's argument type. */
   private static final SeqType ARG_TYPE = new ChoiceItemType(
       Arrays.asList(ELEMENT_O, ATTRIBUTE_O)).seqType();
 
   @Override
-  public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
+  public Value value(final QueryContext qc) throws QueryException {
     final ANode node = toNode(arg(0), qc);
-    ARG_TYPE.coerce(node, null, qc, null, ii);
-    return annotate(node.type == NodeType.ATTRIBUTE ? UNTYPED_ATOMIC : UNTYPED, qc, ii);
+    ARG_TYPE.coerce(node, null, qc, null, info);
+    return annotate(qc, info, node.type == NodeType.ATTRIBUTE ? UNTYPED_ATOMIC : UNTYPED);
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnSchemaType.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnSchemaType.java
@@ -1,0 +1,221 @@
+package org.basex.query.func.fn;
+
+import static org.basex.query.value.type.AtomType.*;
+import static org.basex.query.value.type.SeqType.*;
+
+import org.basex.query.*;
+import org.basex.query.expr.*;
+import org.basex.query.func.*;
+import org.basex.query.util.list.*;
+import org.basex.query.value.*;
+import org.basex.query.value.item.*;
+import org.basex.query.value.map.*;
+import org.basex.query.value.type.*;
+import org.basex.query.var.*;
+import org.basex.util.*;
+import org.basex.util.hash.*;
+
+/**
+ * Function implementation.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public class FnSchemaType extends StandardFunc {
+
+  @Override
+  public Value value(final QueryContext qc) throws QueryException {
+    final QNm name = toQNm(arg(0).atomItem(qc, info));
+    Type type = AtomType.find(name, true);
+    if(type == null) type = ListType.find(name);
+    return annotate(qc, info, type);
+  }
+
+  /**
+   * Creates a sequence of type annotations for the specified atomic types.
+   * @param types the types to be annotated
+   * @param qc query context
+   * @param info input info
+   * @return the type annotation sequence
+   * @throws QueryException query exception
+   */
+  protected static Value annotate(final QueryContext qc, final InputInfo info, final Type... types)
+      throws QueryException {
+
+    final ValueBuilder vb = new ValueBuilder(qc);
+    for(final Type type : types) {
+      if(type == null) continue;
+      final QNm name;
+      final AtomType baseType;
+      final Variety variety;
+      AtomType primType = null;
+      FuncItem members = null;
+      FuncItem matches = null;
+      boolean constructor = false;
+      if(type instanceof ListType) {
+        final ListType listType = (ListType) type;
+        name = listType.qname();
+        baseType = ANY_SIMPLE_TYPE;
+        variety = Variety.list;
+        members = TypeAnnotation.funcItem(info, listType.atomic());
+        constructor = true;
+      } else if(type instanceof AtomType) {
+        final AtomType atomType = (AtomType) type;
+        name = atomType.qname();
+        if(atomType.atomic() != null) matches = Matches.funcItem(atomType, qc, info);
+        switch(atomType) {
+          case ANY_TYPE:
+            baseType = null;
+            variety = Variety.mixed;
+            break;
+          case UNTYPED:
+            baseType = ANY_TYPE;
+            variety = Variety.mixed;
+            break;
+          case ANY_SIMPLE_TYPE:
+            baseType = ANY_TYPE;
+            variety = null;
+            break;
+          case ANY_ATOMIC_TYPE:
+            baseType = ANY_SIMPLE_TYPE;
+            variety = Variety.atomic;
+            break;
+          case NUMERIC:
+            baseType = ANY_SIMPLE_TYPE;
+            variety = Variety.union;
+            members = TypeAnnotation.funcItem(info, DOUBLE, FLOAT, DECIMAL);
+            constructor = true;
+            break;
+          default:
+            final AtomType parent = atomType.parent();
+            baseType = parent == NUMERIC ? ANY_ATOMIC_TYPE : parent;
+            variety = Variety.atomic;
+            for(primType = atomType; !primType.parent().oneOf(ANY_ATOMIC_TYPE, NUMERIC, null);)
+              primType = primType.parent();
+            constructor = !type.oneOf(QNAME, NOTATION);
+        }
+      } else {
+        throw Util.notExpected();
+      }
+      final MapBuilder mb = new MapBuilder();
+      mb.put("name", name);
+      mb.put("is-simple", Bln.get(!type.oneOf(ANY_TYPE, UNTYPED)));
+      mb.put("base-type", TypeAnnotation.funcItem(info, baseType));
+      if(primType != null) mb.put("primitive-type", TypeAnnotation.funcItem(info, primType));
+      if(variety != null) mb.put("variety", variety.name());
+      if(members != null) mb.put("members", members);
+      if(matches != null) mb.put("matches", matches);
+      if(constructor) {
+        mb.put("constructor", (FuncItem) Functions.item(name, 1, true, info, qc, true));
+      }
+      vb.add(mb.map());
+    }
+    return vb.value();
+  }
+
+  /** The variety of a type. */
+  private enum Variety {
+    /** Mixed.  */ mixed,
+    /** List.   */ list,
+    /** Atomic. */ atomic,
+    /** Union.  */ union
+  };
+
+  /**
+   * Function creating the type annotations for given atomic types.
+   */
+  private static final class TypeAnnotation extends Arr {
+    /** Function type. */
+    private static final FuncType FUNC_TYPE = FuncType.get(MAP_ZM);
+    /** The types to be annotated. */
+    private final AtomType[] types;
+
+    /**
+     * Constructor.
+     * @param info input info
+     * @param types the types to be annotated
+     */
+    private TypeAnnotation(final InputInfo info, final AtomType... types) {
+      super(info, FUNC_TYPE.declType);
+      this.types = types;
+    }
+
+    /**
+     * Create a function item for a new instance.
+     * @param types the types to be annotated
+     * @param info input info
+     * @return the function item
+     */
+    public static FuncItem funcItem(final InputInfo info, final AtomType... types) {
+      return new FuncItem(info, new TypeAnnotation(info, types), new Var[] { }, AnnList.EMPTY,
+          FUNC_TYPE, 0, null);
+    }
+
+    @Override
+    public Value value(final QueryContext qc) throws QueryException {
+      return annotate(qc, info, types);
+    }
+
+    @Override
+    public Expr copy(final CompileContext cc, final IntObjectMap<Var> vm) {
+      return new TypeAnnotation(info, types);
+    }
+
+    @Override
+    public void toString(final QueryString qs) {
+      qs.token("type-annotation").params(exprs);
+    }
+  }
+
+  /**
+   * Function checking if an item matches a given type.
+   */
+  private static final class Matches extends Arr {
+    /** Function type. */
+    private static final FuncType FUNC_TYPE = FuncType.get(BOOLEAN_O, ANY_ATOMIC_TYPE_O);
+    /** The type to be matched. */
+    final AtomType type;
+
+    /**
+     * Constructor.
+     * @param info input info
+     * @param type the type to be matched
+     * @param args the arguments
+     */
+    private Matches(final InputInfo info, final AtomType type, final Expr... args) {
+      super(info, BOOLEAN_O, args);
+      this.type = type;
+    }
+
+    /**
+     * Create a function item for a new instance.
+     * @param type the type to be matched
+     * @param qc query context
+     * @param info input info
+     * @return the function item
+     */
+    public static FuncItem funcItem(final AtomType type, final QueryContext qc,
+        final InputInfo info) {
+      final Var var = new VarScope().addNew(new QNm("value"), ANY_ATOMIC_TYPE_O, qc, info);
+      final Var[] params = { var };
+      return new FuncItem(info, new Matches(info, type, new VarRef(info, var)), params,
+          AnnList.EMPTY, FUNC_TYPE, params.length, null);
+    }
+
+    @Override
+    public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
+      final Item value = toAtomItem(arg(0), qc);
+      return Bln.get(value.type.instanceOf(type));
+    }
+
+    @Override
+    public Expr copy(final CompileContext cc, final IntObjectMap<Var> vm) {
+      return new Matches(info, type, copyAll(cc, vm, args()));
+    }
+
+    @Override
+    public void toString(final QueryString qs) {
+      qs.token("matches").params(exprs);
+    }
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/value/type/ListType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/ListType.java
@@ -49,6 +49,14 @@ public enum ListType implements Type {
     this.type = type;
   }
 
+  /**
+   * Returns the name of this type.
+   * @return name
+   */
+  public final QNm qname() {
+    return name;
+  }
+
   @Override
   public final boolean isNumber() {
     return false;

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -220,7 +220,7 @@ public final class FnModuleTest extends SandboxTest {
     query(q1 + "?base-type()?base-type()?base-type()?name eq xs:QName('xs:anyType')", true);
     query(q1 + "?base-type()?base-type()?base-type()?is-simple", false);
     query(q1 + "?base-type()?base-type()?base-type()?variety", "mixed");
-    query(q1 + "?base-type()?base-type()?base-type()?base-type()", "");
+    query(q1 + "?base-type()?base-type()?base-type()?base-type() => exists()", false);
     query(q1 + "?primitive-type()?name eq xs:QName('xs:untypedAtomic')", true);
     query(q1 + "=> map:contains('members')", false);
     query(q1 + "=> map:contains('simple-content-type')", false);
@@ -1919,7 +1919,7 @@ public final class FnModuleTest extends SandboxTest {
     query(q2 + "?base-type()?base-type()?base-type()?name eq xs:QName('xs:anyType')", true);
     query(q2 + "?base-type()?base-type()?base-type()?is-simple", false);
     query(q2 + "?base-type()?base-type()?base-type()?variety", "mixed");
-    query(q2 + "?base-type()?base-type()?base-type()?base-type()", "");
+    query(q2 + "?base-type()?base-type()?base-type()?base-type() => exists()", false);
     query(q2 + "?primitive-type()?name eq xs:QName('xs:untypedAtomic')", true);
     query(q2 + "=> map:contains('members')", false);
     query(q2 + "=> map:contains('simple-content-type')", false);
@@ -2671,6 +2671,19 @@ public final class FnModuleTest extends SandboxTest {
 
     check(func.args(" (1 to 6, (7 to " + wrap(13) + ")[. > 12], (14 to " + wrap(20) + ")[. > 18])"),
         "20\n19\n13\n6\n5\n4\n3\n2\n1", count(REVERSE, 2));
+  }
+
+  /** Test method. */
+  @Test public void schemaType() {
+    final Function func = SCHEMA_TYPE;
+
+    query(func.args(" xs:QName('xs:integer')") + " ? name", "integer");
+    query(func.args(" xs:QName('xs:long')") + " ? primitive-type() ? name", "decimal");
+    query(func.args(" xs:QName('xs:positiveInteger')") + " ? base-type() ? name",
+        "nonNegativeInteger");
+    query(func.args(" xs:QName('xs:integer')") + " ? matches(23)", true);
+    query(func.args(" xs:QName('xs:numeric')") + " ? variety", "union");
+    query(func.args(" xs:QName('xs:numeric')") + " ? members() ? name", "double\nfloat\ndecimal");
   }
 
   /** Test method. */


### PR DESCRIPTION
This change adds the implementation of `fn:schema-type`. 

The basic logic for creating `fn:schema-type-record` instances was already present in `FnAtomicTypeAnnotation`. 

It has been moved to new class `FnSchemaType`, which is now the base class of `FnAtomicTypeAnnotation` and `FnNodeTypeAnnotation`, and it was extended to additionally cover `AtomType.NUMERIC` and instances of `ListType`.