### PR TITLE
New options for `fn:doc`, `fn:doc-available`, and `fn:parse-xml`

### DIFF
--- a/basex-core/src/main/java/org/basex/build/xml/SAXWrapper.java
+++ b/basex-core/src/main/java/org/basex/build/xml/SAXWrapper.java
@@ -54,8 +54,10 @@ public final class SAXWrapper extends SingleParser {
       if(reader == null) {
         reader = XmlParser.reader(options);
       }
-      final EntityResolver er = Resolver.entities(options);
-      if(er != null) reader.setEntityResolver(er);
+      if(reader.getEntityResolver() == null) {
+        final EntityResolver er = Resolver.entities(options);
+        if(er != null) reader.setEntityResolver(er);
+      }
 
       saxh = new SAXHandler(builder, options.get(MainOptions.STRIPWS),
           options.get(MainOptions.STRIPNS));

--- a/basex-core/src/main/java/org/basex/core/MainOptions.java
+++ b/basex-core/src/main/java/org/basex/core/MainOptions.java
@@ -6,6 +6,8 @@ import org.basex.build.csv.*;
 import org.basex.build.html.*;
 import org.basex.build.json.*;
 import org.basex.io.serial.*;
+import org.basex.query.value.seq.*;
+import org.basex.query.value.type.*;
 import org.basex.util.options.*;
 
 /**
@@ -55,6 +57,9 @@ public final class MainOptions extends Options {
   public static final BooleanOption STRIPWS = new BooleanOption("STRIPWS", false);
   /** Strip namespaces. */
   public static final BooleanOption STRIPNS = new BooleanOption("STRIPNS", false);
+  /** Whether external entities are permitted or rejected. */
+  public static final BooleanOption ALLOWEXTERNALENTITIES = new BooleanOption(
+      "ALLOWEXTERNALENTITIES", true);
   /** Flag for parsing DTDs. */
   public static final BooleanOption DTD = new BooleanOption("DTD", false);
   /** Flag for DTD validation. */
@@ -65,6 +70,12 @@ public final class MainOptions extends Options {
   public static final String STRICT = "strict";
   /** XSD validation. */
   public static final StringOption XSDVALIDATION = new StringOption("XSDVALIDATION", SKIP);
+  /** Flag for handling xsi:schemaLocation and xsi:noNamespaceSchemaLocation attributes. */
+  public static final BooleanOption XSISCHEMALOCATION = new BooleanOption("XSISCHEMALOCATION",
+      true);
+  /** Limit on the maximum number of entity references that may be expanded. */
+  public static final ValueOption ENTITYEXPANSIONLIMIT = new ValueOption("ENTITYEXPANSIONLIMIT",
+      SeqType.INTEGER_ZO, Empty.VALUE);
   /** Flag for using XInclude. */
   public static final BooleanOption XINCLUDE = new BooleanOption("XINCLUDE", true);
   /** Path to XML Catalog file. */
@@ -189,7 +200,7 @@ public final class MainOptions extends Options {
 
   /** XML Parsing options. */
   private static final Option<?>[] XMLPARSING = { INTPARSE, STRIPWS, STRIPNS, DTD, DTDVALIDATION,
-      XINCLUDE, CATALOG};
+      XINCLUDE, CATALOG, ENTITYEXPANSIONLIMIT, XSDVALIDATION, XSISCHEMALOCATION };
   /** Extended parsing options. */
   public static final Option<?>[] EXTPARSING = { CREATEFILTER, ADDARCHIVES, ARCHIVENAME,
       SKIPCORRUPT, ADDRAW, ADDCACHE, CSVPARSER, JSONPARSER, HTMLPARSER, PARSER };

--- a/basex-core/src/main/java/org/basex/data/MetaData.java
+++ b/basex-core/src/main/java/org/basex/data/MetaData.java
@@ -14,6 +14,7 @@ import org.basex.index.resource.*;
 import org.basex.io.*;
 import org.basex.io.in.DataInput;
 import org.basex.io.out.DataOutput;
+import org.basex.query.*;
 import org.basex.util.*;
 import org.basex.util.ft.*;
 import org.basex.util.list.*;
@@ -103,6 +104,8 @@ public final class MetaData {
   private final IOFile dir;
   /** Flag for out-of-date indexes. */
   private boolean oldindex;
+  /** The options that where used by fn:doc or fn:catalog (only set for external documents). */
+  public DocOptions docOpts;
 
   /**
    * Constructor for a main-memory database instance.

--- a/basex-core/src/main/java/org/basex/query/DocOptions.java
+++ b/basex-core/src/main/java/org/basex/query/DocOptions.java
@@ -1,0 +1,73 @@
+package org.basex.query;
+
+import org.basex.core.*;
+import org.basex.query.value.seq.*;
+import org.basex.query.value.type.*;
+import org.basex.util.options.*;
+
+/**
+ * Options for fn:doc and fn:doc-available.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public class DocOptions extends Options {
+  /** DTD validation. */
+  public static final BooleanOption DTD_VALIDATION = new BooleanOption("dtd-validation", false);
+  /** Whether external entities are permitted or rejected. */
+  public static final BooleanOption ALLOW_EXTERNAL_ENTITIES = new BooleanOption(
+      "allow-external-entities", true);
+  /** Limit on the maximum number of entity references that may be expanded. */
+  public static final ValueOption ENTITY_EXPANSION_LIMIT = new ValueOption("entity-expansion-limit",
+      SeqType.INTEGER_ZO, Empty.VALUE);
+  /** Whether two calls with same URI and options return the same node. */
+  public static final BooleanOption STABLE = new BooleanOption("stable", true);
+  /** Remove whitespace-only text nodes. */
+  public static final BooleanOption STRIP_SPACE = new BooleanOption("strip-space", false);
+  /** Flag for using XInclude. */
+  public static final BooleanOption XINCLUDE = new BooleanOption("xinclude", false);
+  /** XSD validation. */
+  public static final StringOption XSD_VALIDATION = new StringOption("xsd-validation",
+      MainOptions.SKIP);
+  /** Flag for using XInclude. */
+  public static final BooleanOption XSI_SCHEMA_LOCATION = new BooleanOption("xsi-schema-location",
+      false);
+
+  /** Custom option (see {@link MainOptions#DTD}). */
+  public static final BooleanOption DTD = new BooleanOption("dtd", true);
+  /** Custom option (see {@link MainOptions#STRIPNS}). */
+  public static final BooleanOption STRIPNS = new BooleanOption("stripns", false);
+  /** Custom option (see {@link MainOptions#INTPARSE}). */
+  public static final BooleanOption INTPARSE = new BooleanOption("intparse", false);
+
+  /** Default options. */
+  public static final DocOptions DEFAULT_DOC_OPTIONS = new DocOptions();
+  /** Default options. */
+  private static final MainOptions DEFAULT_MAIN_OPTIONS = new DocOptions().toMainOptions(null);
+
+  /**
+   * Convert this DocOptions instance to a MainOptions instance.
+   * @param mainOpts static main options
+   * @return main options
+   */
+  public MainOptions toMainOptions(final MainOptions mainOpts) {
+    if(this == DEFAULT_DOC_OPTIONS && mainOpts.get(MainOptions.CATALOG).isEmpty()) {
+      return DEFAULT_MAIN_OPTIONS;
+    }
+    final MainOptions opts = new MainOptions();
+    opts.set(MainOptions.DTDVALIDATION, get(DocOptions.DTD_VALIDATION));
+    opts.set(MainOptions.ALLOWEXTERNALENTITIES, get(DocOptions.ALLOW_EXTERNAL_ENTITIES));
+    opts.set(MainOptions.ENTITYEXPANSIONLIMIT, get(DocOptions.ENTITY_EXPANSION_LIMIT));
+    opts.set(MainOptions.STRIPWS, get(DocOptions.STRIP_SPACE));
+    opts.set(MainOptions.XINCLUDE, get(DocOptions.XINCLUDE));
+    opts.set(MainOptions.XSDVALIDATION, get(DocOptions.XSD_VALIDATION));
+    opts.set(MainOptions.XSISCHEMALOCATION, get(DocOptions.XSI_SCHEMA_LOCATION));
+    opts.set(MainOptions.DTD, get(DocOptions.DTD));
+    opts.set(MainOptions.STRIPNS, get(DocOptions.STRIPNS));
+    opts.set(MainOptions.INTPARSE, get(DocOptions.INTPARSE));
+    if(mainOpts != null) {
+      opts.set(MainOptions.CATALOG, mainOpts.get(MainOptions.CATALOG));
+    }
+    return opts;
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -1104,6 +1104,8 @@ public enum QueryError {
   /** Error code. */
   FUNCNOIMPL_X(XPST, 17, "External function not implemented: %."),
   /** Error code. */
+  NO_OPTIONS_WITH_DB(XPST, 17, "The 'options' argument must not be used with a database URI."),
+  /** Error code. */
   JAVAINIT_X_X(XPST, 17, "%: %."),
   /** Error code. */
   JAVACLASS_X(XPST, 17, "Unknown class: %."),

--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -213,11 +213,11 @@ public enum Function implements AFunction {
   DIVIDE_DECIMALS(FnDivideDecimals::new, "divide-decimals(value,divisor[,precision])",
       params(DECIMAL_O, DECIMAL_O, INTEGER_ZO), MAP_O),
   /** XQuery function. */
-  DOC(FnDoc::new, "doc(source)",
-      params(STRING_ZO), DOCUMENT_NODE_ZO, flag(NDT)),
+  DOC(FnDoc::new, "doc(source[,options])",
+      params(STRING_ZO, MAP_ZO), DOCUMENT_NODE_ZO, flag(NDT)),
   /** XQuery function. */
-  DOC_AVAILABLE(FnDocAvailable::new, "doc-available(source)",
-      params(STRING_ZO), BOOLEAN_O, flag(NDT)),
+  DOC_AVAILABLE(FnDocAvailable::new, "doc-available(source[,options])",
+      params(STRING_ZO, MAP_ZO), BOOLEAN_O, flag(NDT)),
   /** XQuery function. */
   DOCUMENT_URI(FnDocumentUri::new, "document-uri([node])",
       params(NODE_ZO), ANY_URI_ZO),

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnDocAvailable.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnDocAvailable.java
@@ -4,6 +4,8 @@ import static org.basex.query.QueryError.*;
 
 import java.util.*;
 
+import org.basex.core.*;
+import org.basex.core.users.*;
 import org.basex.query.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.seq.*;
@@ -17,8 +19,8 @@ import org.basex.util.*;
  */
 public class FnDocAvailable extends Docs {
   /** Possible failures. */
-  private static final EnumSet<QueryError> ERRORS = EnumSet.of(
-      BASEX_DBPATH1_X, BASEX_DBPATH2_X, IOERR_X, WHICHRES_X, RESDIR_X, INVDOC_X);
+  private static final EnumSet<QueryError> ERRORS = EnumSet.of(BASEX_DBPATH1_X, BASEX_DBPATH2_X,
+      IOERR_X, WHICHRES_X, RESDIR_X, INVDOC_X, DTDVALIDATIONERR_X, XSDVALIDATIONERR_X);
 
   @Override
   public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
@@ -37,6 +39,30 @@ public class FnDocAvailable extends Docs {
    * @throws QueryException query exception
    */
   final Item doc(final QueryContext qc) throws QueryException {
+    final Item options = arg(1).item(qc, info);
+    final DocOptions docOpts;
+    if(options.isEmpty()) {
+      docOpts = null;
+    } else {
+      docOpts = toOptions(options, new DocOptions(), qc);
+      if(docOpts.get(DocOptions.DTD) || docOpts.get(DocOptions.XINCLUDE)
+          || docOpts.get(DocOptions.ALLOW_EXTERNAL_ENTITIES)) {
+        checkPerm(qc, Perm.CREATE);
+      }
+      final boolean dtdVal = docOpts.get(DocOptions.DTD_VALIDATION);
+      final String xsdVal = docOpts.get(DocOptions.XSD_VALIDATION);
+      final boolean skip = MainOptions.SKIP.equals(xsdVal);
+      final boolean strict = MainOptions.STRICT.equals(xsdVal);
+      final boolean intparse = docOpts.get(DocOptions.INTPARSE);
+      if(intparse) {
+        if(dtdVal) throw NODTDVALIDATION.get(info);
+        if(!skip) throw NOXSDVALIDATION_X.get(info, xsdVal);
+      } else if(!skip) {
+        if(!strict) throw INVALIDXSDOPT_X.get(info, xsdVal);
+        if(dtdVal) throw NOXSDANDDTD_X.get(info, xsdVal);
+      }
+    }
+
     QueryInput qi = queryInput;
     if(qi == null) {
       final Item source = arg(0).atomItem(qc, info);
@@ -44,6 +70,6 @@ public class FnDocAvailable extends Docs {
       qi = queryInput(toToken(source));
       if(qi == null) throw INVDOC_X.get(info, source);
     }
-    return qc.resources.doc(qi, qc.user, info);
+    return qc.resources.doc(qi, docOpts, qc.user, info);
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnParseXml.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnParseXml.java
@@ -3,6 +3,8 @@ package org.basex.query.func.fn;
 import org.basex.core.*;
 import org.basex.query.*;
 import org.basex.query.value.item.*;
+import org.basex.query.value.seq.*;
+import org.basex.query.value.type.*;
 import org.basex.util.*;
 import org.basex.util.options.*;
 
@@ -17,6 +19,14 @@ public final class FnParseXml extends FnParseXmlFragment {
   public static final class ParseXmlOptions extends ParseXmlFragmentOptions {
     /** DTD validation. */
     public static final BooleanOption DTD_VALIDATION = new BooleanOption("dtd-validation", false);
+    /** Whether external entities are permitted. */
+    public static final BooleanOption ALLOW_EXTERNAL_ENTITIES = new BooleanOption(
+        "allow-external-entities", true);
+    /** Limit on the maximum number of entity references that may be expanded. */
+    public static final ValueOption ENTITY_EXPANSION_LIMIT = new ValueOption(
+        "entity-expansion-limit", SeqType.INTEGER_ZO, Empty.VALUE);
+    /** Whether any xi:include elements in the input are to be processed. */
+    public static final BooleanOption XINCLUDE = new BooleanOption("xinclude", false);
     /** XSD validation. */
     public static final StringOption XSD_VALIDATION = new StringOption("xsd-validation",
         MainOptions.SKIP);
@@ -25,8 +35,6 @@ public final class FnParseXml extends FnParseXmlFragment {
     public static final BooleanOption INTPARSE = new BooleanOption("intparse", false);
     /** Custom option (see {@link MainOptions#DTD}). */
     public static final BooleanOption DTD = new BooleanOption("dtd", true);
-    /** Custom option (see {@link MainOptions#XINCLUDE}). */
-    public static final BooleanOption XINCLUDE = new BooleanOption("xinclude", false);
     /** Custom option (see {@link MainOptions#CATALOG}). */
     public static final StringOption CATALOG = new StringOption("catalog", "");
   }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnParseXmlFragment.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnParseXmlFragment.java
@@ -74,6 +74,7 @@ public class FnParseXmlFragment extends StandardFunc {
     Map.of(ParseXmlFragmentOptions.STRIP_SPACE, MainOptions.STRIPWS,
         ParseXmlFragmentOptions.STRIPNS, MainOptions.STRIPNS,
         ParseXmlOptions.INTPARSE, MainOptions.INTPARSE,
+        ParseXmlOptions.ALLOW_EXTERNAL_ENTITIES, MainOptions.ALLOWEXTERNALENTITIES,
         ParseXmlOptions.DTD, MainOptions.DTD,
         ParseXmlOptions.DTD_VALIDATION, MainOptions.DTDVALIDATION,
         ParseXmlOptions.XINCLUDE, MainOptions.XINCLUDE).forEach((opt, mopt) -> {
@@ -83,8 +84,15 @@ public class FnParseXmlFragment extends StandardFunc {
         ParseXmlOptions.CATALOG, MainOptions.CATALOG).forEach((opt, mopt) -> {
       if(options.contains(opt)) mopts.set(mopt, options.get(opt));
     });
-    if(mopts.get(MainOptions.DTD) || mopts.get(MainOptions.XINCLUDE) ||
-        !mopts.get(MainOptions.CATALOG).isEmpty()) checkPerm(qc, Perm.CREATE);
+    if(options.contains(ParseXmlOptions.ENTITY_EXPANSION_LIMIT)) {
+      mopts.set(MainOptions.ENTITYEXPANSIONLIMIT,
+          options.get(ParseXmlOptions.ENTITY_EXPANSION_LIMIT));
+    }
+    if(mopts.get(MainOptions.DTD) || mopts.get(MainOptions.XINCLUDE)
+        || mopts.get(MainOptions.ALLOWEXTERNALENTITIES)
+        || !mopts.get(MainOptions.CATALOG).isEmpty()) {
+      checkPerm(qc, Perm.CREATE);
+    }
 
     final boolean dtdVal = mopts.get(MainOptions.DTDVALIDATION);
     final String xsdVal = mopts.get(MainOptions.XSDVALIDATION);
@@ -95,8 +103,8 @@ public class FnParseXmlFragment extends StandardFunc {
       if(dtdVal) throw NODTDVALIDATION.get(info);
       if(!skip) throw NOXSDVALIDATION_X.get(info, xsdVal);
     } else if(!skip) {
-      if(dtdVal) throw NOXSDANDDTD_X.get(info, xsdVal);
       if(!strict) throw INVALIDXSDOPT_X.get(info, xsdVal);
+      if(dtdVal) throw NOXSDANDDTD_X.get(info, xsdVal);
     }
 
     try {

--- a/basex-core/src/main/java/org/basex/util/options/Options.java
+++ b/basex-core/src/main/java/org/basex/util/options/Options.java
@@ -933,4 +933,9 @@ public class Options implements Iterable<Option<?>> {
     if(!left) add.run();
     return map;
   }
+
+  @Override
+  public boolean equals(final Object obj) {
+    return obj != null && getClass() == obj.getClass() && values.equals(((Options) obj).values);
+  }
 }

--- a/basex-core/src/test/java/org/basex/core/CatalogTest.java
+++ b/basex-core/src/test/java/org/basex/core/CatalogTest.java
@@ -1,5 +1,6 @@
 package org.basex.core;
 
+import static org.basex.query.QueryError.*;
 import static org.basex.query.func.Function.*;
 
 import org.basex.*;
@@ -103,8 +104,10 @@ public final class CatalogTest extends SandboxTest {
   @Test public void doc() {
     final Function func = DOC;
 
-    set(MainOptions.DTD, true);
     set(MainOptions.CATALOG, CATALOG);
-    query(func.args("http://doc.xml"), "<doc>X</doc>");
+    query(func.args("http://doc.xml", " {'dtd': true()}"), "<doc>X</doc>");
+    query(func.args("http://doc.xml", " {'dtd': false()}"), "<doc/>");
+    query(func.args("http://doc.xml", " {'allow-external-entities': true()}"), "<doc>X</doc>");
+    error(func.args("http://doc.xml", " {'allow-external-entities': false()}"), IOERR_X);
   }
 }

--- a/basex-tests/src/main/java/org/basex/tests/bxapi/XQuery.java
+++ b/basex-tests/src/main/java/org/basex/tests/bxapi/XQuery.java
@@ -133,7 +133,7 @@ public final class XQuery implements Iterable<XdmItem>, Closeable {
    */
   public XdmValue document(final String name) {
     try {
-      return XdmItem.get(qp.qc.resources.doc(new QueryInput(name, qp.sc), qp.qc.user, null));
+      return XdmItem.get(qp.qc.resources.doc(new QueryInput(name, qp.sc), null, qp.qc.user, null));
     } catch(final QueryException ex) {
       throw new XQueryException(ex);
     }

--- a/basex-tests/src/main/java/org/basex/tests/w3c/W3CTS.java
+++ b/basex-tests/src/main/java/org/basex/tests/w3c/W3CTS.java
@@ -537,7 +537,7 @@ public abstract class W3CTS extends Main {
         }
       }
 
-      final Value value = qp.qc.resources.doc(new QueryInput(src, qp.sc), qp.qc.user, null);
+      final Value value = qp.qc.resources.doc(new QueryInput(src, qp.sc), null, qp.qc.user, null);
       qp.variable(string(vars.itemAt(n).string(null)), value);
     }
     return tb.finish();


### PR DESCRIPTION
These changes implement the new options for `fn:doc`, `fn:doc-available`. When fetching non-database documents, the functions no longer make use of the main options, rather the new `DocOptions` class provides the available options and default values. But providing explicit options is only supported for non-database documents, while it is rejected, when the the path turns out to identify a database document. Explicit options are also rejected, when the functions are used to create database documents by using `FORCECREATE`.

Option `allow-external-entities` is related, but different to existing option `dtd`. A value of `false()` for `dtd` asks for ignoring external entities, while `false()` for `allow-external-entities` will cause failure for any reference of an external entity.

`MetaData` has been extended with a new member `docOpts`. It is populated for non-database documents only, and it helps creating the same node, when identical documents are loaded more than once with equal options.

This also adds the new options of `fn:parse-xml`.

In contrast to `fn:parse-xml`, `fn:doc` and `fn:doc-available` have not been equipped with option `catalog`. The reason for this was the structure of the code in `Docs`, where `queryInput` is evaluated early, before the options have been looked at. But in order to honor `catalog`, the options would have needed to be processed before evaluating `queryInput`. Rather `catalog` is now taken from `context.options`. Actually I was not sure whether this the preferable alternative, or whether `catalog` should be part of the function's options as it was done for `fn:parse-xml`. This should be done consistently in the same way in either case -  please let me know which way to go.

One problem that was detected while working on these changes: documents loaded by `fn:doc` and `fn:collection` will create different nodes, even when identical. This is because of the comparison `IO.get(original).eq(qi.io)` in `QueryResources.data`, it fails because `fn:collection` and `fn:doc` cause different content here. A QT4 test for this, `collection-009`, does not detect the problem, because in the QT4 test environment, the collection documents are pre-loaded before the actual query execution.

The changes pass all QT4 tests with prefixes `fn-doc-` and `parse-xml`.