### PR TITLE
Remove option `catalog` from `fn:parse-xml`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/FnParseXml.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnParseXml.java
@@ -31,8 +31,6 @@ public final class FnParseXml extends FnParseXmlFragment {
     public static final BooleanOption INTPARSE = CommonOptions.INTPARSE;
     /** Custom option (see {@link MainOptions#DTD}). */
     public static final BooleanOption DTD = CommonOptions.DTD;
-    /** Custom option (see {@link MainOptions#CATALOG}). */
-    public static final StringOption CATALOG = CommonOptions.CATALOG;
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnParseXmlFragment.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnParseXmlFragment.java
@@ -74,6 +74,7 @@ public class FnParseXmlFragment extends Docs {
       Strings.UTF8);
 
     final MainOptions mopts = new MainOptions(options);
+    mopts.set(MainOptions.CATALOG, qc.context.options.get(MainOptions.CATALOG));
     try {
       final boolean ip = fragment || mopts.get(MainOptions.INTPARSE);
       return new DBNode(ip ? new XMLParser(io, mopts, fragment) : Parser.xmlParser(io, mopts));

--- a/basex-core/src/test/java/org/basex/core/CatalogTest.java
+++ b/basex-core/src/test/java/org/basex/core/CatalogTest.java
@@ -110,4 +110,19 @@ public final class CatalogTest extends SandboxTest {
     query(func.args("http://doc.xml", " {'allow-external-entities': true()}"), "<doc>X</doc>");
     error(func.args("http://doc.xml", " {'allow-external-entities': false()}"), IOERR_X);
   }
+
+  /** Test method.*/
+  @Test public void parseXml() {
+    final Function func = PARSE_XML;
+
+    set(MainOptions.CATALOG, CATALOG);
+    query(func.args("<!DOCTYPE xml SYSTEM 'http://dtd.dtd'><doc>&amp;x;</doc>", " {'dtd': true()}"),
+        "<doc>X</doc>");
+    query(func.args("<!DOCTYPE xml SYSTEM 'http://dtd.dtd'><doc>&amp;x;</doc>", " {'dtd': 'no'}"),
+        "<doc/>");
+    query(func.args("<!DOCTYPE xml SYSTEM 'http://dtd.dtd'><doc>&amp;x;</doc>",
+        " {'allow-external-entities': true()}"), "<doc>X</doc>");
+    error(func.args("<!DOCTYPE xml SYSTEM 'http://dtd.dtd'><doc>&amp;x;</doc>",
+        " {'allow-external-entities': 'no'}"), SAXERR_X);
+  }
 }

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -2405,6 +2405,7 @@ public final class FnModuleTest extends SandboxTest {
     error(func.args("<a xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' "
         + "xsi:noNamespaceSchemaLocation='src/test/resources/validate.xsd'/>",
         " {'xsd-validation': 'strict'}"), XSDVALIDATIONERR_X);
+    error(func.args("<a/>", " {'catalog': 'catalog.xml'}"), INVALIDOPTION_X);
   }
 
   /** Test method. */


### PR DESCRIPTION
As discussed - rather than individually allowing option `catalog`, `fn:parse-xml` now honors context option `CATALOG`. The documentation has already been adapted.