### PR TITLE
Support streaming in the JSON parser

### DIFF
--- a/basex-core/src/main/java/org/basex/gui/view/editor/EditorView.java
+++ b/basex-core/src/main/java/org/basex/gui/view/editor/EditorView.java
@@ -867,7 +867,7 @@ public final class EditorView extends View {
     if(opened == null || ii == null) return;
 
     // mark error, jump to error position
-    final int ep = pos(opened.last, ii.line(), ii.column());
+    final int ep = pos(opened.last, (int) ii.line(), (int) ii.column());
     opened.error(ep);
 
     if(jump) {

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonConverter.java
@@ -92,7 +92,7 @@ public abstract class JsonConverter {
   public final Value convert(final IO input) throws QueryException, IOException {
     final String encoding = jopts.get(JsonParserOptions.ENCODING);
     try(NewlineInput ni = new NewlineInput(input)) {
-      return convert(ni.encoding(encoding).cache().toString(), input.url(), null);
+      return convert(ni.encoding(encoding), input.url(), null);
     }
   }
 
@@ -104,11 +104,15 @@ public abstract class JsonConverter {
    * @return result
    * @throws QueryException query exception
    */
-  public final Value convert(final String input, final String uri,
+  public final Value convert(final TextInput input, final String uri,
       final QueryContext qc) throws QueryException {
     qctx = qc;
     init(uri);
-    new JsonParser(input, jopts, this).parse();
+    try {
+      new JsonParser(input, jopts, this).parse();
+    } catch(IOException ex) {
+      throw new QueryException(ex);
+    }
     return finish();
   }
 

--- a/basex-core/src/main/java/org/basex/query/QueryContext.java
+++ b/basex-core/src/main/java/org/basex/query/QueryContext.java
@@ -19,6 +19,7 @@ import org.basex.core.jobs.*;
 import org.basex.core.locks.*;
 import org.basex.core.users.*;
 import org.basex.data.*;
+import org.basex.io.in.*;
 import org.basex.io.parse.json.*;
 import org.basex.io.serial.*;
 import org.basex.query.ann.*;
@@ -203,7 +204,7 @@ public final class QueryContext extends Job implements Closeable {
       qs.parseMain();
       return qs.complete(qs.mark);
     } catch(final QueryException ex) {
-      return qs.complete(ex.column() - 1);
+      return qs.complete((int) ex.column() - 1);
     }
   }
 
@@ -715,7 +716,13 @@ public final class QueryContext extends Job implements Closeable {
     if(type.equalsIgnoreCase(MainParser.JSON.name())) {
       final JsonParserOptions jp = new JsonParserOptions();
       jp.set(JsonOptions.FORMAT, JsonFormat.W3);
-      return JsonConverter.get(jp).convert(object.toString(), "", this);
+      final TextInput ti;
+      try {
+        ti = new TextInput(Token.token(object.toString()));
+      } catch(final IOException ex) {
+        throw new QueryException(ex);
+      }
+      return JsonConverter.get(jp).convert(ti, "", this);
     }
 
     // parse target type

--- a/basex-core/src/main/java/org/basex/query/QueryException.java
+++ b/basex-core/src/main/java/org/basex/query/QueryException.java
@@ -123,7 +123,7 @@ public class QueryException extends Exception {
    * Returns the column number of the error.
    * @return column number, or {@code 0} if unknown
    */
-  public final int column() {
+  public final long column() {
     return info == null ? 0 : info.column();
   }
 
@@ -139,7 +139,7 @@ public class QueryException extends Exception {
    * Returns the line number of the error.
    * @return line number, or {@code 0} if unknown
    */
-  public final int line() {
+  public final long line() {
     return info == null ? 0 : info.line();
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/fn/ParseJson.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/ParseJson.java
@@ -13,7 +13,6 @@ import org.basex.query.expr.*;
 import org.basex.query.value.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.seq.*;
-import org.basex.util.*;
 import org.basex.util.options.*;
 
 /**
@@ -71,10 +70,9 @@ public abstract class ParseJson extends ParseFn {
    * @param ti text input
    * @return resulting item
    * @throws QueryException query exception
-   * @throws IOException I/O exception
    */
   private Value parse(final QueryContext qc, final JsonFormat format, final TextInput ti)
-      throws QueryException, IOException {
+      throws QueryException {
 
     final JsonParserOptions options = toOptions(arg(1), new JsonParserOptions(), qc);
     if(format != null) options.set(JsonOptions.FORMAT, format);
@@ -104,6 +102,6 @@ public abstract class ParseJson extends ParseFn {
       throw INVALIDOPTION_X.get(info, Options.unknown(JsonParserOptions.NULL));
     }
     converter.nullValue(nll);
-    return converter.convert(Token.string(ti.content()), "", qc);
+    return converter.convert(ti, "", qc);
   }
 }

--- a/basex-core/src/main/java/org/basex/util/InputInfo.java
+++ b/basex-core/src/main/java/org/basex/util/InputInfo.java
@@ -25,9 +25,9 @@ public final class InputInfo {
   /** Input string as codepoints (can be {@code null}). */
   private int[] input;
   /** Line number ({@code 0} if not initialized). */
-  private int line;
+  private long line;
   /** Column number or (if not initialized) string position. */
-  private int column;
+  private long column;
 
   /**
    * Constructor.
@@ -55,7 +55,7 @@ public final class InputInfo {
    * @param line line
    * @param col column
    */
-  public InputInfo(final String path, final int line, final int col) {
+  public InputInfo(final String path, final long line, final long col) {
     this.path = path;
     this.line = line;
     this.column = col;
@@ -73,7 +73,7 @@ public final class InputInfo {
    * Returns the line position.
    * @return line position
    */
-  public int line() {
+  public long line() {
     init();
     return line;
   }
@@ -82,7 +82,7 @@ public final class InputInfo {
    * Returns the column position.
    * @return column position
    */
-  public int column() {
+  public long column() {
     init();
     return column;
   }
@@ -102,7 +102,7 @@ public final class InputInfo {
     // positions have already been calculated
     if(line != 0) return;
 
-    final int cl = Math.min(column, input.length);
+    final int cl = Math.min((int) column, input.length);
     int l = 1, c = 1;
     for(int i = 0; i < cl; i++) {
       final int cp = input[i];
@@ -139,7 +139,8 @@ public final class InputInfo {
 
   @Override
   public int hashCode() {
-    return (path != null ? path.hashCode() : Arrays.hashCode(input)) + column() + (line() << 16);
+    return (path != null ? path.hashCode() : Arrays.hashCode(input))
+        + ((int) column() ^ (int) line());
   }
 
   @Override

--- a/basex-core/src/test/java/org/basex/io/parse/json/JsonParserTest.java
+++ b/basex-core/src/test/java/org/basex/io/parse/json/JsonParserTest.java
@@ -58,12 +58,12 @@ public final class JsonParserTest {
     parse("\"\\u000a\"", "\"\\n\"", false);
     parse("\"\\u000A\"", "\"\\n\"", false);
     parse("\"\n\"", "\"\\n\"", true);
-    parse("\"\uD834\"", "\"\uFFFD\"", false);
+    parse("\"\\uD834\"", "\"\uFFFD\"", false);
     parse("\"\uFFFF\"", "\"\uFFFD\"", false);
     parse("\"\\b\\f\\t\\r\\n\"", "\"\uFFFD\uFFFD\\t\\r\\n\"", false);
     parse("\"\\u0000\\u001F\"", "\"\uFFFD\uFFFD\"", false);
-    parse("\"\uD853\uFFFF\"", "\"\uFFFD\uFFFD\"", false);
-    parse("\"\uD853a\"", "\"\uFFFDa\"", false);
+    parse("\"\\uD853\\uFFFF\"", "\"\uFFFD\uFFFD\"", false);
+    parse("\"\\uD853a\"", "\"\uFFFDa\"", false);
 
     escape("\"\\u0008\\u000c\\u0009\\u000d\\u000a\"", "\"\\\\b\\\\f\\\\t\\\\r\\\\n\"");
     escape("\"\\b\\f\\t\\r\\n\"", "\"\\\\b\\\\f\\\\t\\\\r\\\\n\"");

--- a/basex-core/src/test/java/org/basex/io/parse/json/JsonStringConverter.java
+++ b/basex-core/src/test/java/org/basex/io/parse/json/JsonStringConverter.java
@@ -1,6 +1,10 @@
 package org.basex.io.parse.json;
 
+import java.io.*;
+
 import org.basex.build.json.*;
+import org.basex.io.*;
+import org.basex.io.in.*;
 import org.basex.query.*;
 import org.basex.query.value.item.*;
 import org.basex.util.*;
@@ -35,15 +39,16 @@ final class JsonStringConverter extends JsonConverter {
    * @param escape escape flag
    * @return resulting string
    * @throws QueryException query exception
+   * @throws IOException I/O exception
    */
   public static String toString(final String json, final boolean liberal, final boolean escape)
-      throws QueryException {
+      throws QueryException, IOException {
 
     final JsonParserOptions jopts = new JsonParserOptions();
     jopts.set(JsonParserOptions.LIBERAL, liberal);
     jopts.set(JsonParserOptions.ESCAPE, escape);
     final JsonStringConverter jsc = new JsonStringConverter(jopts, new TokenBuilder());
-    return (String) jsc.convert(json, "", null).toJava();
+    return (String) jsc.convert(new TextInput(new IOContent(json)), "", null).toJava();
   }
 
   @Override

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -2351,6 +2351,11 @@ public final class FnModuleTest extends SandboxTest {
   @Test public void parseJson() {
     final Function func = PARSE_JSON;
     query(func.args("\"x\\u0000\""), "x\uFFFD");
+    query(func.args("\"a\\bb\\uD801\\uDC02c\\uD803d\\uDC04e\\uD805\\uD806\"",
+        " {'fallback': fn($s) {'[' || $s || ']'}}"),
+        "a[\\b]b\uD801\uDC02c[\\uD803]d[\\uDC04]e[\\uD805][\\uD806]");
+    query("try {" + func.args("nvll") + "} catch * {$err:description}",
+        "(1:1): Unexpected JSON value: 'nvll'.");
   }
 
   /** Test method. */


### PR DESCRIPTION
These changes make the JSON parser accept a `TextInput` in order to support streaming:

  - `JsonParser` no longer derives from `InputParser`, but now has its own `consume` methods.
  - the most recent 16 input code points are  buffered, for being able to make them available to error messages and to the `fallback` function.
  - members `line` and `column` of `InputInfo` have been changed from `int` to `long`, in order to avoid overflows showing up in error messages.

This does not yet cover providing any progress info.