### PR TITLE
Prevent `CscW3Serializer` from resetting headers (fixes #2428)

### DIFF
--- a/basex-core/src/main/java/org/basex/io/serial/csv/CsvSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/csv/CsvSerializer.java
@@ -91,6 +91,16 @@ public abstract class CsvSerializer extends StandardSerializer {
    * @throws IOException I/O exception
    */
   final void record(final TokenList entries) throws IOException {
+    record(entries, true);
+  }
+
+  /**
+   * Prints a record with the specified entries.
+   * @param entries record entries to be printed
+   * @param reset whether to reset the entries after serialization
+   * @throws IOException I/O exception
+   */
+  final void record(final TokenList entries, final boolean reset) throws IOException {
     int f = 0;
     if(maxCol < 0) {
       for(final byte[] val : entries) field(f++, val);
@@ -107,7 +117,7 @@ public abstract class CsvSerializer extends StandardSerializer {
       }
     }
     out.print(rowDelimiter);
-    entries.reset();
+    if(reset) entries.reset();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/io/serial/csv/CsvW3XmlSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/csv/CsvW3XmlSerializer.java
@@ -70,7 +70,7 @@ public final class CsvW3XmlSerializer extends CsvSerializer {
   protected void finishClose() throws IOException {
     if(level != 2 || !elem.eq(CsvW3XmlConverter.Q_FN_ROW)) return;
     if(header) {
-      record(headers);
+      record(headers, false);
       header = false;
     }
     record(data);
@@ -79,7 +79,7 @@ public final class CsvW3XmlSerializer extends CsvSerializer {
   @Override
   protected void attribute(final byte[] name, final byte[] value, final boolean standalone)
       throws IOException {
-    if(headers == null || !name.equals(CsvW3XmlConverter.Q_COLUMN.local())) return;
+    if(headers == null || !eq(name, CsvW3XmlConverter.Q_COLUMN.local())) return;
     if(data.size() < headers.size() && eq(value, headers.get(data.size()))) return;
     throw CSV_SERIALIZE_X_X.getIO("Unexpected column", value);
   }

--- a/basex-core/src/test/java/org/basex/query/func/CsvModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/CsvModuleTest.java
@@ -217,6 +217,18 @@ public final class CsvModuleTest extends SandboxTest {
     serial(map, "'format': 'xquery', 'header': ('C', 'D')", "X\nY\n");
   }
 
+  /** Test method. */
+  @Test public void gh2428() {
+    final Function func = _CSV_SERIALIZE;
+    final String xml = " <csv xmlns='http://www.w3.org/2005/xpath-functions'><columns><column>x"
+        + "</column></columns><rows><row><field column='x'>y</field></row><row><field column='$1'>z"
+        + "</field></row></rows></csv>";
+//    query(func.args(xml.replace("$1", "x"), " { 'header': true(), 'format': 'w3-xml' }"),
+//        "x\ny\nz\n");
+    error(func.args(xml.replace("$1", "w"), " { 'header': true(), 'format': 'w3-xml' }"),
+        CSV_SERIALIZE_X_X);
+  }
+
   /**
    * Runs the specified query.
    * @param input query input

--- a/basex-core/src/test/java/org/basex/query/func/CsvModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/CsvModuleTest.java
@@ -223,8 +223,8 @@ public final class CsvModuleTest extends SandboxTest {
     final String xml = " <csv xmlns='http://www.w3.org/2005/xpath-functions'><columns><column>x"
         + "</column></columns><rows><row><field column='x'>y</field></row><row><field column='$1'>z"
         + "</field></row></rows></csv>";
-//    query(func.args(xml.replace("$1", "x"), " { 'header': true(), 'format': 'w3-xml' }"),
-//        "x\ny\nz\n");
+    query(func.args(xml.replace("$1", "x"), " { 'header': true(), 'format': 'w3-xml' }"),
+        "x\ny\nz\n");
     error(func.args(xml.replace("$1", "w"), " { 'header': true(), 'format': 'w3-xml' }"),
         CSV_SERIALIZE_X_X);
   }


### PR DESCRIPTION
`CscW3Serializer` called `record(headers)`, which resets `headers`, but `headers` was needed later on to verify the incoming column names. A bug in the name comparison logic (#2428) however was hiding this.

This change prevents `headers` to be reset by using a new signature of the `record` method, which provides control over resetting.