### PR TITLE
set HttpOnly, Secure, and Path attributes for cookies

### DIFF
--- a/basex-api/src/main/java/org/basex/http/webdav/WebDAVResponse.java
+++ b/basex-api/src/main/java/org/basex/http/webdav/WebDAVResponse.java
@@ -126,6 +126,10 @@ final class WebDAVResponse extends AbstractResponse {
   @Override
   public Cookie setCookie(final String name, final String value) {
     final jakarta.servlet.http.Cookie c = new jakarta.servlet.http.Cookie(name, value);
+    c.setHttpOnly(true);
+    c.setSecure(true);
+    c.setPath("/");
+    
     response.addCookie(c);
     return new WebDAVCookie(c);
   }


### PR DESCRIPTION
This PR addresses potential security vulnerability of cookies set in WebDAVResponse.java by explicitly setting:

- `HttpOnly = true`: prevents client-side scripts from accessing cookies
- `Secure = true`: ensures cookies are only sent over HTTPS
- `Path = "/"`: restricts cookies to the application root path

Appreciate time taken to review this, thanks!

References
https://cwe.mitre.org/data/definitions/1004.html
