### PR TITLE
Use relabeling rather than just casting for deep lookup array keys

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/ALookup.java
+++ b/basex-core/src/main/java/org/basex/query/expr/ALookup.java
@@ -57,8 +57,15 @@ public abstract class ALookup extends Arr {
           value = ((FuncItem) value).toMethod(struct);
         }
       } else {
-        final Item index = !deep ? key :
-          key.type.isNumber() ? (Item) SeqType.INTEGER_O.cast(key, false, qc, info) : null;
+        final Item index;
+        if (!deep) {
+          index = key;
+        } else if(!key.type.isNumber()) {
+          index = null;
+        } else {
+          final Item cast = (Item) SeqType.INTEGER_O.cast(key, false, qc, info);
+          index = key.equal(cast, null, info) ? cast : null;
+        }
         if(index != null) value = ((XQArray) struct).getOrNull(index, qc, info);
       }
       if(value != null) vb.add(value);

--- a/basex-core/src/test/java/org/basex/query/expr/LookupTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/LookupTest.java
@@ -76,4 +76,10 @@ public final class LookupTest extends SandboxTest {
   @Test public void error() {
     error("1?a", LOOKUP_X);
   }
+
+  /** Test. */
+  @Test public void deep() {
+    query("[ 'a' ]??(1.0)", "a");
+    query("[ 'a' ]??(1.1)", "");
+  }
 }


### PR DESCRIPTION
The current implementation incorrectly returns a result for

```xquery
[ 'a' ]??(1.1)
```