### PR TITLE
Allow line endings of either LF or CR-LF in test for `fn:unparsed-binary`

### DIFF
--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -3472,7 +3472,7 @@ public final class FnModuleTest extends SandboxTest {
   /** Test method. */
   @Test public void unparsedBinary() {
     final Function func = UNPARSED_BINARY;
-    query(func.args(DOC) + " => bin:length()", 395);
+    query(func.args(DOC) + " => bin:length() = (395, 413)", true);
     error(func.args(DOC + ".xyz"), RESNF_X);
     error(func.args(DOC + "#xyz"), FRAGID_X);
   }


### PR DESCRIPTION
The new test for `fn:unparsed-binary` checks the exact size of a text file. The project however does not have a `.gitattributes` prescribing specific line endings, so these may be LF or CR-LF, depending on the environment. This change allows both variants.