### PR TITLE
Use JDK's default SAXParserFactory

### DIFF
--- a/basex-core/src/main/java/org/basex/io/parse/xml/XmlParser.java
+++ b/basex-core/src/main/java/org/basex/io/parse/xml/XmlParser.java
@@ -69,7 +69,7 @@ public final class XmlParser {
     final boolean xsdValidation = CommonOptions.STRICT.equals(
         options.get(MainOptions.XSDVALIDATION));
     final boolean xsiLocation = options.get(MainOptions.XSILOCATION);
-    final SAXParserFactory f = SAXParserFactory.newInstance();
+    final SAXParserFactory f = SAXParserFactory.newDefaultInstance();
     if(extEntities) {
       // setting these options to false will ignore external entities, rather than rejecting them
       f.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", dtd);
@@ -87,8 +87,7 @@ public final class XmlParser {
       f.setSchema(sf.newSchema());
     }
     final XMLReader xr = f.newSAXParser().getXMLReader();
-    // temporary fix; ensures that other XML parsers do not reject the property
-    if(entExpansion != null && entExpansion != 64000) {
+    if(entExpansion != null) {
       xr.setProperty("http://www.oracle.com/xml/jaxp/properties/entityExpansionLimit",
         entExpansion);
     }


### PR DESCRIPTION
This change 

 - enforces the JDK's built-in XML-Parser by using `SAXParserFactory.newDefaultInstance`
 - removes the temporary fix of not propagating the entity expansion limit in case it is being set to the JDK's default

Note: the spec of `entity-expansion-limit` says:

> if the value is zero, then entity expansion should if possible be disabled entirely, leading to a dynamic error if the input contains any entity references. A negative value should be interpreted as placing no limits on entity expansion.

This could be handled as speficied at this point by mapping 0 to -1 and negative values to 0, as was done somewhere in my original PR for the feature. @ChristianGruen, I guess you deliberately removed this, did you?
