### PR TITLE
Fix `escape-uri-attributes` for XHTML serializer

### DIFF
--- a/basex-core/src/main/java/org/basex/io/serial/SerializerOptions.java
+++ b/basex-core/src/main/java/org/basex/io/serial/SerializerOptions.java
@@ -48,7 +48,7 @@ public final class SerializerOptions extends Options {
       new EnumOption<>("escape-solidus", YesNo.YES);
   /** Serialization parameter: yes/no. */
   public static final EnumOption<YesNo> ESCAPE_URI_ATTRIBUTES =
-      new EnumOption<>("escape-uri-attributes", YesNo.NO);
+      new EnumOption<>("escape-uri-attributes", YesNo.YES);
   /** Serialization parameter: yes/no. */
   public static final EnumOption<YesNo> INCLUDE_CONTENT_TYPE =
       new EnumOption<>("include-content-type", YesNo.YES);

--- a/basex-core/src/main/java/org/basex/io/serial/XHTMLSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/XHTMLSerializer.java
@@ -31,7 +31,7 @@ final class XHTMLSerializer extends MarkupSerializer {
       throws IOException {
 
     // escape URI attributes
-    final byte[] nm = concat(lc(elem.local()), cpToken(':'), lc(name));
+    final byte[] nm = concat(lc(elem.local()), ATT, lc(name));
     final byte[] val = escape && HTMLSerializer.URIS.contains(nm) ?
       encodeUri(value, UriEncoder.ESCAPE) : value;
     super.attribute(name, val, standalone);

--- a/basex-core/src/test/java/org/basex/query/SerializerTest.java
+++ b/basex-core/src/test/java/org/basex/query/SerializerTest.java
@@ -78,6 +78,18 @@ public final class SerializerTest extends SandboxTest {
         + "         style=\"width: 42px\"></div>\n"
         + "  </body>\n"
         + "</html>");
+    // URI escaping enabled: href and name will be percent-encoded
+    query(option
+        + "<html xmlns='http://www.w3.org/1999/xhtml'><body><a href='\u8f49\u7fa9.html'"
+        + " name='\u8f49\u7fa9'>Link</a></body></html>",
+        "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><a href=\"%E8%BD%89%E7%BE%A9.html\""
+        + " name=\"%E8%BD%89%E7%BE%A9\">Link</a></body></html>");
+    // URI escaping disabled: raw Unicode is preserved
+    query(option + ESCAPE_URI_ATTRIBUTES.arg("no")
+        + "<html xmlns='http://www.w3.org/1999/xhtml'><body><a href='\u672a\u8f49\u7fa9.html'"
+        + " name='\u672a\u8f49\u7fa9'>Link</a></body></html>",
+        "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><a href=\"\u672a\u8f49\u7fa9.html\""
+        + " name=\"\u672a\u8f49\u7fa9\">Link</a></body></html>");
   }
 
   /** method=xhtml, meta element. */


### PR DESCRIPTION
The XHTML serializer currently does not honor serialization parameter `escape-uri-attributes` because of a bug in constructing the element-attribute pair for checking the set of URI attributes.

Also, the spec (even in [XQuery 3.1](https://www.w3.org/TR/xquery-31/#id-xq-static-context-components)) says that the default value of `escape-uri-attributes` should be `yes`.