### PR TITLE
Allow `QNameLiteral` as `AnnotationValue`, whitespace in `QNameLiteral` and `MarkedNCName`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -454,7 +454,12 @@ public class QueryParser extends InputParser {
               wsCheck(")");
               expr = Bln.get(truee);
             } else {
-              expr = quote(current()) ? Str.get(stringLiteral()) : numericLiteral(0, true);
+              if(quote(current())) expr = Str.get(stringLiteral());
+              else if(!consume('#')) expr = numericLiteral(0, true);
+              else {
+                skipWs();
+                expr = eQName(null, QNAME_X);
+              }
               if(!(expr instanceof Item)) {
                 if(Function.ERROR.is(expr)) expr.item(qc, ii);
                 throw error(ANNVALUE_X, currentAsString());
@@ -2615,8 +2620,10 @@ public class QueryParser extends InputParser {
    * @throws QueryException query exception
    */
   private Expr literal() throws QueryException {
-    return quote(current()) ? Str.get(stringLiteral())
-                            : consume('#') ? eQName(null, QNAME_X) : numericLiteral(0, false);
+    if(quote(current())) return Str.get(stringLiteral());
+    if(!consume('#')) return numericLiteral(0, false);
+    skipWs();
+    return eQName(null, QNAME_X);
   }
 
   /**
@@ -3277,6 +3284,7 @@ public class QueryParser extends InputParser {
     }
     // parse literal name
     consume("#");
+    skipWs();
     if(qname) return eQName(SKIPCHECK, null);
 
     // parse name enclosed in quotes

--- a/basex-core/src/test/java/org/basex/query/expr/AnnotationsTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/AnnotationsTest.java
@@ -26,6 +26,8 @@ public final class AnnotationsTest extends SandboxTest {
     query("declare %private variable $x := 1; $x", 1);
     query("declare namespace a='a';declare %a:a variable $x := 1; $x", 1);
     query("declare namespace a='a';declare %a:a(1) %a:b(2) variable $x:=1; $x", 1);
+    query("declare namespace a='a';declare %a:a(#x) %a:b(#Q{y}z) variable $x:=1; $x", 1);
+    query("declare namespace a='a';declare %a:a(# x) %a:b(# Q{y}z) variable $x:=1; $x", 1);
   }
 
   /** Parsing errors and conflicts. */


### PR DESCRIPTION
This adapts to recent grammar changes with respect to  `AnnotationValue`, `QNameLiteral`, and `MarkedNCName`.

It would have been possible to reuse `literal()` in `annotations(boolean)`, but I have preferred to keep it separate, as in the specification grammar.

This fixes 6 QT4-tests that are using whitespace in `QNameLiteral`s and `MarkedNCName`s:

- `K2-ComputeConAttr-64`
- `K2-ComputeConElem-19`
- `nscons-046`
- `K2-ComputeConPI-15`
- `Literals-40-925`
- `Literals-40-926`