### PR TITLE
Update to markup-blitz 1.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
       <dependency>
         <groupId>de.bottlecaps</groupId>
         <artifactId>markup-blitz</artifactId>
-        <version>1.8</version>
+        <version>1.9</version>
         <scope>runtime</scope>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
[1.9](https://github.com/GuntherRademacher/markup-blitz/releases/tag/1.9) is a bugfix release.