### PR TITLE
Add support for Let[Sequence|Array|Map]Binding

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -1097,6 +1097,8 @@ public enum QueryError {
   /** Error code. */
   NOSUBDUR_X(XPTY, 4, "Subtype of xs:duration expected: %."),
   /** Error code. */
+  NOSUB_X_X(XPTY, 4, "Subtype of % expected: %."),
+  /** Error code. */
   STRQNM_X_X(XPTY, 4, "String or QName expected, % found: %."),
   /** Error code. */
   STRNCN_X_X(XPTY, 4, "String or NCName expected, % found: %."),


### PR DESCRIPTION
This change adds support for the new 
- `LetSequenceBinding`
- `LetArrayBinding`
- `LetMapBinding`

The new constructs are rewritten to bindings for the source (using the last of the variable names) and the individual variables referring to it.

This fixes all of the new test cases with names having the `let-` prefix.