### PR TITLE
Resolve unscoped variable with `localVars`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -1393,11 +1393,11 @@ public class QueryParser extends InputParser {
     final SeqType asType = Objects.requireNonNullElse(optAsType(), SeqType.ITEM_ZM);
     final SeqType st = asType.intersect(binding.type);
     if(st == null) throw error(NOSUB_X_X, binding.type, asType);
-    final Var seq = new Var(var.getLast().name, st, qc, ii);
+    final Var struct = new Var(var.getLast().name, st, qc, ii);
 
     wsCheck(":=");
-    clauses.add(new Let(seq, check(single(), NOVARDECL)));
-    final VarRef seqRef = new VarRef(ii, seq);
+    clauses.add(new Let(localVars.add(struct), check(single(), NOVARDECL)));
+    final VarRef seqRef = new VarRef(ii, struct);
     int i = 0;
     for(final Var v : var) {
       final Expr expr = switch (binding.endCp) {

--- a/basex-core/src/test/java/org/basex/query/expr/GFLWORTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/GFLWORTest.java
@@ -463,6 +463,12 @@ public final class GFLWORTest extends SandboxTest {
         + "only end when $p = 2 return <w>{ $w }</w>", "<w>2</w>");
   }
 
+  /** Destructuring let. */
+  @Test public void gh2452() {
+    query("let $($a, $b) := (1 to 6) ! string()\nfor $i in 1 to 3\nreturn ($a, $b, $i)",
+        "1\n2\n1\n1\n2\n2\n1\n2\n3");
+  }
+
   /** Merge where clauses. */
   @Test public void mergeWhere() {
     check("for $i at $p in (1 to 4) where $i <= 3 return $p",


### PR DESCRIPTION
In method `letStructBinding`, a variable is created to hold the structure, which is never added to a `VarScope`. This causes its `slot` member to stick to the initial `-1` value and causes the AIOOBE reported in https://github.com/BaseXdb/basex/issues/2452.