### PR TITLE
Add missing `compile` call to `Transform`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/up/expr/Transform.java
+++ b/basex-core/src/main/java/org/basex/query/up/expr/Transform.java
@@ -43,7 +43,7 @@ public final class Transform extends Copy {
   @Override
   public Expr compile(final CompileContext cc) throws QueryException {
     // type of let variable must not match expression type (name of node may change)
-    for(final Let copy : copies) copy.exprType.assign(copy.expr);
+    for(final Let copy : copies) copy.exprType.assign(copy.expr.compile(cc));
     return super.compile(cc);
   }
 

--- a/basex-core/src/test/java/org/basex/query/expr/GFLWORTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/GFLWORTest.java
@@ -469,6 +469,17 @@ public final class GFLWORTest extends SandboxTest {
         "1\n2\n1\n1\n2\n2\n1\n2\n3");
   }
 
+  /** Java call in copy/modify/return. */
+  @Test public void gh2455() {
+    query("declare namespace ll = \"java:java.util.LinkedList\";\n"
+        + "declare variable $linkedList := ll:new();\n"
+        + "\n"
+        + "copy $test := <A>{ll:size($linkedList)}</A>\n"
+        + "modify ()\n"
+        + "return $test",
+        "<A>0</A>");
+  }
+
   /** Merge where clauses. */
   @Test public void mergeWhere() {
     check("for $i at $p in (1 to 4) where $i <= 3 return $p",


### PR DESCRIPTION
As reported by [Andreas Hengsbach on basex-talk](https://www.mail-archive.com/basex-talk@mailman.uni-konstanz.de/msg16265.html), a `NullPointerException` may occur when there is a Java call inside of a copy/modify/return expression, e.g.

```xquery
declare namespace ll = "java:java.util.LinkedList";
declare variable $linkedList := ll:new();

copy $test := <A>{ll:size($linkedList)}</A>
modify ()
return $test
```

The failure occurs with recent release versions, but was not present in BaseX 10.4.

In fact the problem first occurred after commit a8f0f9afd1ae0ad5519e48edd66fe5ea78360a7e for #2237, which reorganized function registration and resolution. After that change, it is essential that `compile` is called for a `StaticFuncCall` to be able to mutate to a `DynJavaFunc` (which happens [here](https://github.com/BaseXdb/basex/blob/6903e4cb442b6041cd68efdf093dded806cd2920/basex-core/src/main/java/org/basex/query/func/StaticFuncCall.java#L71)). However the copy/modify/return expression translates to an instance of `Transform`, which up to now fails to call `compile` for its `copies`.

The change in this PR adds the missing call.