### PR TITLE
Prevent type of `RecordType` from being refined to `MapType`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/value/map/XQMap.java
+++ b/basex-core/src/main/java/org/basex/query/value/map/XQMap.java
@@ -373,7 +373,7 @@ public abstract class XQMap extends XQStruct {
   }
 
   @Override
-  public final boolean refineType() throws QueryException {
+  public boolean refineType() throws QueryException {
     Type refined = null;
     for(final Item key : keys()) {
       final Value value = get(key);

--- a/basex-core/src/main/java/org/basex/query/value/map/XQRecordMap.java
+++ b/basex-core/src/main/java/org/basex/query/value/map/XQRecordMap.java
@@ -28,6 +28,11 @@ public final class XQRecordMap extends XQHashMap {
   }
 
   @Override
+  public boolean refineType() throws QueryException {
+    return true;
+  }
+
+  @Override
   public long structSize() {
     return values.length;
   }


### PR DESCRIPTION
As reported by [Andreas Hengsbach on basex-talk](https://www.mail-archive.com/basex-talk@mailman.uni-konstanz.de/msg16267.html), a `ClassCastException` may occur when `inspect:argument` is called with a map argument, e.g.

```xquery
map {
'username' : "aaa",
'password' : "bbb",
'grant_type' : 'password'
} => inspect:type()
```

The failure occurs in the GUI, or on command line with option `-V`.

This is caused by an `XQRecordType` that has a `MapType` rather than the required `RecordType` as its `type`. The type is modified when `refineType` is called.

The change in this PR adds a dummy implementation of `refineType` to `XQRecordType`, such that the implementation in the base class is no longer used for `XQRecordType`.