### PR TITLE
Add support for built-in named record types

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/Convert.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Convert.java
@@ -45,7 +45,7 @@ abstract class Convert extends Single {
    * Returns a stricter cast type.
    * @return sequence type
    */
-  final SeqType castType() {
+  public final SeqType castType() {
     final SeqType est = expr.seqType();
     Type type = seqType.type;
     Occ occ = seqType.occ;

--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -91,7 +91,7 @@ public enum Function implements AFunction {
       params(ANY_ATOMIC_TYPE_O, ANY_ATOMIC_TYPE_O), BOOLEAN_O),
   /** XQuery function. */
   ATOMIC_TYPE_ANNOTATION(FnAtomicTypeAnnotation::new, "atomic-type-annotation(value)",
-      params(ANY_ATOMIC_TYPE_O), MAP_O),
+      params(ANY_ATOMIC_TYPE_O), SCHEMA_TYPE_RECORD_O),
   /** XQuery function. */
   AVAILABLE_ENVIRONMENT_VARIABLES(FnAvailableEnvironmentVariables::new,
       "available-environment-variables()",
@@ -157,7 +157,7 @@ public enum Function implements AFunction {
       params(ITEM_ZM), INTEGER_O),
   /** XQuery function. */
   CSV_DOC(FnCsvDoc::new, "csv-doc(source[,options])",
-      params(STRING_ZO, MAP_ZO), MAP_O, flag(NDT), FN_URI, Perm.CREATE),
+      params(STRING_ZO, MAP_ZO), PARSED_CSV_STRUCTURE_RECORD_O, flag(NDT), FN_URI, Perm.CREATE),
   /** XQuery function. */
   CSV_TO_ARRAYS(FnCsvToArrays::new, "csv-to-arrays(value[,options])",
       params(STRING_ZO, MAP_ZO), STRING_O.arrayType().seqType(Occ.ZERO_OR_MORE)),
@@ -337,7 +337,7 @@ public enum Function implements AFunction {
       params(NODE_ZM), BOOLEAN_O),
   /** XQuery function. */
   HASH(FnHash::new, "hash(value[,algorithm,options])",
-      params(ANY_ATOMIC_TYPE_ZO, STRING_ZO, MAP_ZO), HEX_BINARY_O),
+      params(STRING_OR_BINARY_ZO, STRING_ZO, MAP_ZO), HEX_BINARY_O),
   /** XQuery function. */
   HEAD(FnHead::new, "head(input)",
       params(ITEM_ZM), ITEM_ZO),
@@ -414,7 +414,7 @@ public enum Function implements AFunction {
       params(), INTEGER_O, flag(POS, CTX)),
   /** XQuery function. */
   LOAD_XQUERY_MODULE(FnLoadXQueryModule::new, "load-xquery-module(module-uri[,options])",
-      params(STRING_O, MAP_ZO), MAP_O, flag(NDT, HOF), FN_URI, Perm.ADMIN),
+      params(STRING_O, MAP_ZO), LOAD_XQUERY_MODULE_RECORD_O, flag(NDT, HOF), FN_URI, Perm.ADMIN),
   /** XQuery function. */
   LOCAL_NAME(FnLocalName::new, "local-name([node])",
       params(NODE_ZO), STRING_O),
@@ -478,7 +478,7 @@ public enum Function implements AFunction {
       params(NODE_ZO), QNAME_ZO),
   /** XQuery function. */
   NODE_TYPE_ANNOTATION(FnNodeTypeAnnotation::new, "node-type-annotation(node)",
-      params(NODE_O), MAP_O),
+      params(NODE_O), SCHEMA_TYPE_RECORD_O),
   /** XQuery function. */
   NORMALIZE_SPACE(FnNormalizeSpace::new, "normalize-space([value])",
       params(STRING_ZO), STRING_O),
@@ -502,31 +502,31 @@ public enum Function implements AFunction {
       params(NODE_ZM), NODE_ZM),
   /** XQuery function. */
   PARSE_CSV(FnParseCsv::new, "parse-csv(value[,options])",
-      params(STRING_ZO, MAP_ZO), MAP_O),
+      params(STRING_OR_BINARY_ZO, MAP_ZO), PARSED_CSV_STRUCTURE_RECORD_O),
   /** XQuery function. */
   PARSE_IETF_DATE(FnParseIetfDate::new, "parse-ietf-date(value)",
       params(STRING_ZO), DATE_TIME_ZO),
   /** XQuery function. */
-  PARSE_HTML(FnParseHtml::new, "parse-html(html[,options])",
-      params(ANY_ATOMIC_TYPE_ZO, MAP_ZO), DOCUMENT_NODE_ZO),
+  PARSE_HTML(FnParseHtml::new, "parse-html(value[,options])",
+      params(STRING_OR_BINARY_ZO, MAP_ZO), DOCUMENT_NODE_ZO),
   /** XQuery function. */
   PARSE_INTEGER(FnParseInteger::new, "parse-integer(value[,radix])",
       params(STRING_ZO, INTEGER_ZO), INTEGER_ZO),
   /** XQuery function. */
   PARSE_JSON(FnParseJson::new, "parse-json(value[,options])",
-      params(STRING_ZO, MAP_ZO), ITEM_ZO, flag(CNS, HOF)),
+      params(STRING_OR_BINARY_ZO, MAP_ZO), ITEM_ZO, flag(CNS, HOF)),
   /** XQuery function. */
   PARSE_QNAME(FnParseQName::new, "parse-QName(value)",
       params(STRING_ZO), QNAME_ZO),
   /** XQuery function. */
   PARSE_URI(FnParseUri::new, "parse-uri(value[,options])",
-      params(STRING_ZO, MAP_ZO), MAP_O),
+      params(STRING_ZO, MAP_ZO), URI_STRUCTURE_RECORD_O),
   /** XQuery function. */
   PARSE_XML(FnParseXml::new, "parse-xml(value[,options])",
-      params(ANY_ATOMIC_TYPE_ZO, MAP_ZO), DOCUMENT_NODE_ZO, flag(CNS)),
+      params(STRING_OR_BINARY_ZO, MAP_ZO), DOCUMENT_NODE_ZO, flag(CNS)),
   /** XQuery function. */
   PARSE_XML_FRAGMENT(FnParseXmlFragment::new, "parse-xml-fragment(value[,options])",
-      params(ANY_ATOMIC_TYPE_ZO, MAP_ZO), DOCUMENT_NODE_ZO, flag(CNS)),
+      params(STRING_OR_BINARY_ZO, MAP_ZO), DOCUMENT_NODE_ZO, flag(CNS)),
   /** XQuery function. */
   PARTIAL_APPLY(FnPartialApply::new, "partial-apply(function,arguments)",
       params(FUNCTION_O, MAP_O), FUNCTION_O, flag(HOF)),
@@ -551,7 +551,7 @@ public enum Function implements AFunction {
       params(STRING_ZO, STRING_O), QNAME_O),
   /** XQuery function. */
   RANDOM_NUMBER_GENERATOR(FnRandomNumberGenerator::new, "random-number-generator([seed])",
-      params(ANY_ATOMIC_TYPE_ZO), MAP_O, flag(HOF, NDT)),
+      params(ANY_ATOMIC_TYPE_ZO), RANDOM_NUMBER_GENERATOR_RECORD_O, flag(HOF, NDT)),
   /** XQuery function. */
   REMOVE(FnRemove::new, "remove(input,positions)",
       params(ITEM_ZM, INTEGER_ZM), ITEM_ZM),
@@ -589,7 +589,7 @@ public enum Function implements AFunction {
       ARRAY_ZM, flag(HOF)),
   /** XQuery function. */
   SCHEMA_TYPE(FnSchemaType::new, "schema-type(name)",
-      params(QNAME_O), MAP_ZO),
+      params(QNAME_O), SCHEMA_TYPE_RECORD_ZO),
   /** XQuery function. */
   SECONDS(FnSeconds::new, "seconds(value)",
       params(DECIMAL_ZO), DAY_TIME_DURATION_ZO),
@@ -801,10 +801,10 @@ public enum Function implements AFunction {
       params(MAP_ZM, MAP_ZO), MAP_O, flag(HOF), MAP_URI),
   /** XQuery function. */
   _MAP_PAIR(MapPair::new, "pair(key,value)",
-      params(ANY_ATOMIC_TYPE_O, ITEM_ZM), PAIR_O, MAP_URI),
+      params(ANY_ATOMIC_TYPE_O, ITEM_ZM), KEY_VALUE_PAIR_O, MAP_URI),
   /** XQuery function. */
   _MAP_PAIRS(MapPairs::new, "pairs(map)",
-      params(MAP_O), PAIR_ZM, MAP_URI),
+      params(MAP_O), KEY_VALUE_PAIR_ZM, MAP_URI),
   /** XQuery function. */
   _MAP_PUT(MapPut::new, "put(map,key,value)",
       params(MAP_O, ANY_ATOMIC_TYPE_O, ITEM_ZM), MAP_O, MAP_URI),
@@ -1543,7 +1543,7 @@ public enum Function implements AFunction {
       params(STRING_O, MAP_ZO), ITEM_ZO, flag(NDT), HTML_URI, Perm.CREATE),
   /** XQuery function. */
   _HTML_PARSE(HtmlParse::new, "parse(value[,options])",
-      params(ANY_ATOMIC_TYPE_ZO, MAP_ZO), DOCUMENT_NODE_ZO, HTML_URI),
+      params(STRING_OR_BINARY_ZO, MAP_ZO), DOCUMENT_NODE_ZO, HTML_URI),
   /** XQuery function. */
   _HTML_PARSER(HtmlParser::new, "parser()",
       params(), STRING_O, HTML_URI),

--- a/basex-core/src/main/java/org/basex/query/func/Functions.java
+++ b/basex-core/src/main/java/org/basex/query/func/Functions.java
@@ -154,8 +154,8 @@ public final class Functions {
     // constructor function
     if(eq(name.uri(), XS_URI)) {
       if(arity > 0) fb.add(CAST_PARAM[0], SeqType.ANY_ATOMIC_TYPE_ZO, qc);
-      final Expr expr = constructorCall(name, fb);
-      final FuncType ft = FuncType.get(fb.anns, null, fb.params);
+      final Cast expr = constructorCall(name, fb);
+      final FuncType ft = FuncType.get(fb.anns, expr.castType(), fb.params);
       return item(expr, fb, ft, name, false, arity == 0);
     }
 
@@ -226,7 +226,7 @@ public final class Functions {
    * @param name function name
    * @return function definition if found, {@code null} otherwise
    */
-  static FuncDefinition builtIn(final QNm name) {
+  public static FuncDefinition builtIn(final QNm name) {
     return BUILT_IN.get(name);
   }
 
@@ -308,7 +308,9 @@ public final class Functions {
   private static StaticFuncCall staticCall(final QNm name, final FuncBuilder fb,
       final QueryContext qc, final boolean hasImport) throws QueryException {
 
-    if(NSGlobal.reserved(name.uri())) throw qc.functions.similarError(name, fb.info);
+    if(NSGlobal.reserved(name.uri()) && !SeqType.BUILT_IN_NAMED_RECORD_TYPES.contains(name)) {
+      throw qc.functions.similarError(name, fb.info);
+    }
 
     final StaticFuncCall call = new StaticFuncCall(name, fb.args(), fb.keywords, fb.info,
         hasImport);

--- a/basex-core/src/main/java/org/basex/query/func/StaticFuncs.java
+++ b/basex-core/src/main/java/org/basex/query/func/StaticFuncs.java
@@ -8,7 +8,6 @@ import org.basex.core.*;
 import org.basex.query.*;
 import org.basex.query.expr.*;
 import org.basex.query.func.java.*;
-import org.basex.query.util.*;
 import org.basex.query.util.list.*;
 import org.basex.query.util.parse.*;
 import org.basex.query.value.item.*;
@@ -46,11 +45,6 @@ public final class StaticFuncs extends ExprInfo {
   public StaticFunc declare(final QNm name, final Params params, final Expr expr,
       final AnnList anns, final String doc, final VarScope vs, final InputInfo info)
       throws QueryException {
-
-    final byte[] uri = name.uri();
-    if(uri.length == 0) throw FUNNONS_X.get(info, name.string());
-    if(NSGlobal.reserved(uri) || Functions.builtIn(name) != null)
-      throw FNRESERVED_X.get(info, name.string());
 
     final StaticFunc sf = new StaticFunc(name, params, expr, anns, vs, info, doc);
     if(!cache(name.prefixId()).register(sf)) throw DUPLFUNC_X.get(sf.info, name.string());

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnLoadXQueryModule.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnLoadXQueryModule.java
@@ -162,8 +162,8 @@ public final class FnLoadXQueryModule extends StandardFunc {
     }
 
     final MapBuilder result = new MapBuilder();
-    result.put("functions", functions.map());
     result.put("variables", variables.map());
+    result.put("functions", functions.map());
     return result.map();
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnParseUri.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnParseUri.java
@@ -171,6 +171,7 @@ public class FnParseUri extends StandardFunc {
     final MapBuilder mb = new MapBuilder();
     add(mb, URI, value);
     add(mb, SCHEME, scheme);
+    if(absolute) add(mb, ABSOLUTE, Bln.TRUE);
     add(mb, HIERARCHICAL, hierarchical);
     add(mb, AUTHORITY, authority);
     add(mb, USERINFO, userinfo);
@@ -182,7 +183,6 @@ public class FnParseUri extends StandardFunc {
     add(mb, PATH_SEGMENTS, StrSeq.get(segments));
     add(mb, QUERY_PARAMETERS, queries);
     add(mb, FILEPATH, filepath);
-    if(absolute) add(mb, ABSOLUTE, Bln.TRUE);
     return mb.map();
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnRandomNumberGenerator.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnRandomNumberGenerator.java
@@ -41,7 +41,7 @@ public final class FnRandomNumberGenerator extends StandardFunc {
     return new MapBuilder().
       // derived from Java's random class
       put(NUMBER, Dbl.get(((i1 >>> 22 << 27) + (i2 >>> 21)) / (double) (1L << 53))).
-      put(NEXT, nextFunc(i2)).
+      put(NEXT, SeqType.RANDOM_NUMBER_GENERATOR_RECORD_NEXT.cast(nextFunc(i2),  qc, ii)).
       put(PERMUTE, permuteFunc(i1, qc)).map();
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/inspect/InspectFunctions.java
+++ b/basex-core/src/main/java/org/basex/query/func/inspect/InspectFunctions.java
@@ -25,7 +25,9 @@ public final class InspectFunctions extends StandardFunc {
     // returns all functions from the query context
     if(!defined(0)) {
       final ValueBuilder vb = new ValueBuilder(qc);
-      for(final StaticFunc sf : qc.functions.funcs()) addItems(vb, sf, qc);
+      for(final StaticFunc sf : qc.functions.funcs()) {
+        if(!NSGlobal.reserved(sf.name.uri())) addItems(vb, sf, qc);
+      }
       return vb.value(this);
     }
 

--- a/basex-core/src/main/java/org/basex/query/func/inspect/PlainDoc.java
+++ b/basex-core/src/main/java/org/basex/query/func/inspect/PlainDoc.java
@@ -6,6 +6,7 @@ import org.basex.io.*;
 import org.basex.query.*;
 import org.basex.query.func.*;
 import org.basex.query.scope.*;
+import org.basex.query.util.*;
 import org.basex.query.util.list.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.node.*;
@@ -40,7 +41,7 @@ final class PlainDoc extends Inspect {
     final FBuilder root = element("context");
     for(final StaticVar sv : qc.vars) root.add(variable(sv));
     for(final StaticFunc sf : qc.functions.funcs()) {
-      root.add(function(sf.name, sf, sf.funcType(), sf.anns));
+      if(!NSGlobal.reserved(sf.name.uri())) root.add(function(sf.name, sf, sf.funcType(), sf.anns));
     }
     return root.finish();
   }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapMerge.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapMerge.java
@@ -148,7 +148,7 @@ public class MapMerge extends StandardFunc {
     final String string = duplicates.isEmpty() ? dflt.toString() : toString(duplicates, qc);
     final Duplicates value = Enums.get(Duplicates.class, string);
     if(value == null) throw QueryError.typeError(duplicates,
-        new EnumType(Duplicates.values()), info);
+        EnumType.get(Duplicates.values()), info);
 
     return switch(value) {
       case REJECT -> new Reject();

--- a/basex-core/src/main/java/org/basex/query/func/map/MapOfPairs.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapOfPairs.java
@@ -24,7 +24,7 @@ public final class MapOfPairs extends MapMerge {
 
     final MapBuilder builder = new MapBuilder(input.size());
     for(Item item; (item = qc.next(input)) != null;) {
-      final XQMap pair = toRecord(item, SeqType.PAIR, qc);
+      final XQMap pair = toRecord(item, SeqType.KEY_VALUE_PAIR, qc);
       final Item key = toAtomItem(pair.get(Str.KEY), qc);
       final Value old = builder.get(key);
       final Value val = merger.merge(key, old, pair.get(Str.VALUE));

--- a/basex-core/src/main/java/org/basex/query/util/SharedData.java
+++ b/basex-core/src/main/java/org/basex/query/util/SharedData.java
@@ -28,7 +28,7 @@ public final class SharedData {
    */
   public SharedData() {
     record(SeqType.RECORD);
-    record(SeqType.PAIR);
+    record(SeqType.KEY_VALUE_PAIR);
     record(SeqType.MEMBER);
   }
 

--- a/basex-core/src/main/java/org/basex/query/value/type/ChoiceItemType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/ChoiceItemType.java
@@ -39,6 +39,15 @@ public final class ChoiceItemType implements Type {
     union = tp;
   }
 
+  /**
+   * Creates a choice item type.
+   * @param types alternative item types
+   * @return choice item type
+   */
+  public static ChoiceItemType get(final SeqType... types) {
+    return new ChoiceItemType(Arrays.asList(types));
+  }
+
   @Override
   public Value cast(final Item item, final QueryContext qc, final InputInfo info)
       throws QueryException {

--- a/basex-core/src/main/java/org/basex/query/value/type/EnumType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/EnumType.java
@@ -34,11 +34,15 @@ public final class EnumType implements Type {
 
   /**
    * Constructor.
+   * @param <T> type of enumeration values
    * @param values enumeration values (at least one)
+   * @return enum type
    */
-  public EnumType(final Enum<?>[] values) {
-    this.values = new TokenSet(values.length);
-    for(final Enum<?> v : values) this.values.add(v.toString());
+  @SafeVarargs
+  public static <T> EnumType get(final T... values) {
+    final TokenSet val = new TokenSet(values.length);
+    for(final T v : values) val.add(v.toString());
+    return new EnumType(val);
   }
 
   @Override

--- a/basex-core/src/test/java/org/basex/query/expr/RecordTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/RecordTest.java
@@ -139,6 +139,29 @@ public final class RecordTest extends SandboxTest {
         + "let $box := geom:rectangle(3, 2)\n"
         + "return $box?area($box)",
         6);
+    // constructor via function item
+    query("declare record local:r(x); local:r#1(42)", "{\"x\":42}");
+    // constructor via function lookup
+    query("declare record local:r(x); function-lookup(#local:r, 1)(42)", "{\"x\":42}");
+    // built-in record type constructor
+    query("fn:key-value-pair('x', 42)", "{\"key\":\"x\",\"value\":42}");
+    // built-in record type constructor via function item
+    query("fn:key-value-pair#2('x', 42)", "{\"key\":\"x\",\"value\":42}");
+    // built-in record type constructor via function lookup
+    query("function-lookup(#fn:key-value-pair, 2)('x', 42)", "{\"key\":\"x\",\"value\":42}");
+
+    // function declaration and record constructor with the same signature
+    error("declare function local:f($x) {local:r($x)};\n"
+        + "declare function local:r($x) {43};\n"
+        + "declare record local:r(x);\n"
+        + "local:f(42)"
+        , DUPLFUNC_X);
+    // record constructor and function declaration with the same signature
+    error("declare function local:f($x) {local:r($x)};\n"
+        + "declare record local:r(x);\n"
+        + "declare function local:r($x) {43};\n"
+        + "local:f(42)"
+        , DUPLFUNC_X);
   }
 
   /** Static typing. */


### PR DESCRIPTION
These changes add support for [built-in named record types](https://qt4cg.org/specifications/xpath-functions-40/Overview.html#id-built-in-named-record-types). These types are now defined in `SeqType`. Function signatures have been adapted to use them, and the order of generated map elements has been aligned with the type definition.

Constructor functions for built-in record types are handled in the same way as user-defined record type constructors, i.e. they are generated dynamically from the record definition. While this makes sure that they match the record definition, it is a little unfortunate, because they are created for each and every query. This currently must be done in order to make them available for `fn:function-lookup`. I would expect these functions to be rarely used, if ever, so it would be desirable to save the effort for creating them dynamically over and over again. I am thus thinking of replacing the dynamic generation with fixed Java implementations, or possibly finding a way to generate them only once.

This fixes a total of 39 QT4 tests. Two specific tests, `built-in-record-type-303` and `built-in-record-type-304` do not succeed yet, because of a problem with function item types: in [`Closure.optimize(CompileContext)`](https://github.com/BaseXdb/basex/blob/ad5301568536465450e9db061a2b3b5d18d2a947/basex-core/src/main/java/org/basex/query/func/Closure.java#L196-L198), the result type is inferred from the function body:

```java
    final SeqType st = expr.seqType();
    final SeqType dt = declType == null || st.instanceOf(declType) ? st : declType;
    exprType.assign(FuncType.get(anns, dt, params));
```

This makes the following `instance of` succeed, but it is expected to fail:

```xquery
fn() as xs:anyAtomicType? {'banana'} instance of function() as xs:string
```

It could be fixed replacing the above three lines with just

```java
    exprType.assign(FuncType.get(anns, declType, params));
```

But while this change is fine with respect to QT4 tests, it causes a number of BaseX tests to fail, and some hang because the code is optimized differently. So this needs further investigation as well.