### PR TITLE
Adapt to changed comparison operators

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -1993,9 +1993,9 @@ public class QueryParser extends InputParser {
   private Expr pipeline() throws QueryException {
     final Expr expr = arrow();
     if(expr != null) {
-      if(wsConsumeWs("->") || wsConsumeWs("-\uFF1E")) {
+      if(wsConsumeWs("->")) {
         final ExprList el = new ExprList(expr);
-        do add(el, arrow()); while(wsConsumeWs("->") || wsConsumeWs("-\uFF1E"));
+        do add(el, arrow()); while(wsConsumeWs("->"));
         return new Pipeline(info(), el.finish());
       }
     }
@@ -2011,8 +2011,8 @@ public class QueryParser extends InputParser {
     Expr expr = unary();
     if(expr != null) {
       while(true) {
-        final boolean mapping = wsConsume("=!>") || wsConsume("=!\uFF1E");
-        if(!mapping && !consume("=>") && !consume("=\uFF1E")) break;
+        final boolean mapping = wsConsume("=!>");
+        if(!mapping && !consume("=>")) break;
 
         QNm name = null;
         Expr ex;

--- a/basex-core/src/main/java/org/basex/query/expr/CmpN.java
+++ b/basex-core/src/main/java/org/basex/query/expr/CmpN.java
@@ -30,16 +30,24 @@ public final class CmpN extends Cmp {
       }
     },
 
-    /** Node comparison: before. */
-    ET("<<", "\uFF1C\uFF1C") {
+    /** Node comparison: different. */
+    NE("is-not") {
+      @Override
+      public boolean eval(final ANode node1, final ANode node2) {
+        return !node1.is(node2);
+      }
+    },
+
+    /** Node comparison: precedes. */
+    LT("<<", "precedes") {
       @Override
       public boolean eval(final ANode node1, final ANode node2) {
         return node1.compare(node2) < 0;
       }
     },
 
-    /** Node comparison: after. */
-    GT(">>", "\uFF1E\uFF1E") {
+    /** Node comparison: follows. */
+    GT(">>", "follows") {
       @Override
       public boolean eval(final ANode node1, final ANode node2) {
         return node1.compare(node2) > 0;

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnOp.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnOp.java
@@ -61,9 +61,10 @@ public final class FnOp extends StandardFunc {
       case "gt" -> new CmpV(info, arg1, arg2, OpV.GT);
       case "ge" -> new CmpV(info, arg1, arg2, OpV.GE);
       case "ne" -> new CmpV(info, arg1, arg2, OpV.NE);
-      case "<<" -> new CmpN(info, arg1, arg2, OpN.ET);
-      case ">>" -> new CmpN(info, arg1, arg2, OpN.GT);
+      case "<<", "precedes" -> new CmpN(info, arg1, arg2, OpN.LT);
+      case ">>", "follows" -> new CmpN(info, arg1, arg2, OpN.GT);
       case "is" -> new CmpN(info, arg1, arg2, OpN.EQ);
+      case "is-not" -> new CmpN(info, arg1, arg2, OpN.NE);
       case "||" -> new Concat(info, arg1, arg2);
       case "|", "union" -> new Union(info, arg1, arg2);
       case "except" -> new Except(info, arg1, arg2);


### PR DESCRIPTION
This change

 - adds the new `is-not`, `precedes` and `follows` operators
 - removes support of the operators using full-width less-than and greater-than signs.