### PR TITLE
Add HTML option fail-on-error, remove html-version

### DIFF
--- a/basex-core/src/main/java/org/basex/build/html/HtmlOptions.java
+++ b/basex-core/src/main/java/org/basex/build/html/HtmlOptions.java
@@ -47,8 +47,8 @@ public final class HtmlOptions extends Options {
   public static final EnumOption<HtmlParser.Method> METHOD = new EnumOption<>("method",
       HtmlParser.Method.class);
 
-  /** fn:parse-html option: html-version. */
-  public static final StringOption HTML_VERSION = new StringOption("html-version");
+  /** fn:parse-html option: fail-on-error. */
+  public static final BooleanOption FAIL_ON_ERROR = new BooleanOption("fail-on-error", false);
   /** fn:parse-html option: include-template-content. */
   public static final BooleanOption INCLUDE_TEMPLATE_CONTENT =
       new BooleanOption("include-template-content");

--- a/basex-core/src/main/java/org/basex/build/html/HtmlParser.java
+++ b/basex-core/src/main/java/org/basex/build/html/HtmlParser.java
@@ -177,7 +177,26 @@ public final class HtmlParser extends XMLParser {
       @Override
       XMLReader reader(final HtmlOptions hopts, final StringWriter sw) throws SAXException {
         final nu.validator.htmlparser.sax.HtmlParser reader =
-            new nu.validator.htmlparser.sax.HtmlParser(XmlViolationPolicy.ALTER_INFOSET);
+            new nu.validator.htmlparser.sax.HtmlParser();
+        if(hopts.get(FAIL_ON_ERROR)) {
+          reader.setErrorHandler(new ErrorHandler() {
+            @Override
+            public void warning(final SAXParseException e) throws SAXException {
+            }
+
+            @Override
+            public void error(final SAXParseException e) throws SAXException {
+              throw e;
+            }
+
+            @Override
+            public void fatalError(final SAXParseException e) throws SAXException {
+              throw e;
+            }
+          });
+        } else {
+          reader.setXmlPolicy(XmlViolationPolicy.ALTER_INFOSET);
+        }
         final ContentHandler writer = new XmlSerializer(sw);
         reader.setContentHandler(writer);
         reader.setProperty("http://xml.org/sax/properties/lexical-handler", writer);


### PR DESCRIPTION
The current state of the spec has HTML option `fail-on-error`, and it does not have `html-version` anymore.