### PR TITLE
Add support for extended `KeySpecifier` syntax

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -873,8 +873,6 @@ public enum QueryError {
   /** Error code. */
   NUMBER_X(XPST, 3, "Incomplete number: '%'."),
   /** Error code. */
-  NUMBERITR_X_X(XPST, 3, "Integer expected, % found: '%'."),
-  /** Error code. */
   QUERYEND_X(XPST, 3, "Unexpected end of query: '%'."),
   /** Error code. */
   MODEXPR(XPST, 3, "No expression allowed in a library module."),

--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -2617,12 +2617,15 @@ public class QueryParser extends InputParser {
     final int cp = current();
     if(cp == '(') return parenthesized();
     if(cp == '$') return varRef();
-    if(quote(cp)) return Str.get(stringLiteral());
-    final Expr num = numericLiteral(Long.MAX_VALUE, false);
-    if(num != null) {
-      if(Function.ERROR.is(num) || num instanceof Itr) return num;
-      throw error(NUMBERITR_X_X, num.seqType(), num);
+    if(cp == '.') {
+      if(next() == '.') return null;
+      if(!digit(next())) {
+        consume();
+        return new ContextValue(info());
+      }
     }
+    final Expr lit = literal();
+    if(lit != null) return lit;
     return Str.get(ncName(KEYSPEC_X));
   }
 


### PR DESCRIPTION
This change implements the [recently modified](https://github.com/qt4cg/qtspecs/commit/e26b54c337ea4b1eea7d194a4555ca5218729589) `KeySpecifier` syntax.