### PR TITLE
Drop position from fold callbacks

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -279,11 +279,11 @@ public enum Function implements AFunction {
       params(NUMERIC_ZO), NUMERIC_ZO),
   /** XQuery function. */
   FOLD_LEFT(FnFoldLeft::new, "fold-left(input,init,action)",
-      params(ITEM_ZM, ITEM_ZM, FuncType.get(ITEM_ZM, ITEM_ZM, ITEM_O, INTEGER_O).seqType()),
+      params(ITEM_ZM, ITEM_ZM, FuncType.get(ITEM_ZM, ITEM_ZM, ITEM_O).seqType()),
       ITEM_ZM, flag(HOF)),
   /** XQuery function. */
   FOLD_RIGHT(FnFoldRight::new, "fold-right(input,init,action)",
-      params(ITEM_ZM, ITEM_ZM, FuncType.get(ITEM_ZM, ITEM_O, ITEM_ZM, INTEGER_O).seqType()),
+      params(ITEM_ZM, ITEM_ZM, FuncType.get(ITEM_ZM, ITEM_O, ITEM_ZM).seqType()),
       ITEM_ZM, flag(HOF)),
   /** XQuery function. */
   FOOT(FnFoot::new, "foot(input)",
@@ -837,11 +837,11 @@ public enum Function implements AFunction {
       params(ITEM_ZM), ITEM_ZM, ARRAY_URI),
   /** XQuery function. */
   _ARRAY_FOLD_LEFT(ArrayFoldLeft::new, "fold-left(array,init,action)",
-      params(ARRAY_O, ITEM_ZM, FuncType.get(ITEM_ZM, ITEM_ZM, ITEM_O, INTEGER_O).seqType()),
+      params(ARRAY_O, ITEM_ZM, FuncType.get(ITEM_ZM, ITEM_ZM, ITEM_O).seqType()),
       ITEM_ZM, flag(HOF), ARRAY_URI),
   /** XQuery function. */
   _ARRAY_FOLD_RIGHT(ArrayFoldRight::new, "fold-right(array,init,action)",
-      params(ARRAY_O, ITEM_ZM, FuncType.get(ITEM_ZM, ITEM_O, ITEM_ZM, INTEGER_O).seqType()),
+      params(ARRAY_O, ITEM_ZM, FuncType.get(ITEM_ZM, ITEM_O, ITEM_ZM).seqType()),
       ITEM_ZM, flag(HOF), ARRAY_URI),
   /** XQuery function. */
   _ARRAY_FOOT(ArrayFoot::new, "foot(array)",

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayFoldLeft.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayFoldLeft.java
@@ -20,7 +20,7 @@ public class ArrayFoldLeft extends FnFoldLeft {
     final XQArray array = toArray(arg(0), qc);
     final FItem action = action(qc);
 
-    final HofArgs args = new HofArgs(3, action).set(0, arg(1).value(qc));
+    final HofArgs args = new HofArgs(2).set(0, arg(1).value(qc));
     for(final Value value : array.iterable()) {
       args.set(1, value).inc();
       if(skip(qc, args)) break;

--- a/basex-core/src/main/java/org/basex/query/func/array/ArrayFoldRight.java
+++ b/basex-core/src/main/java/org/basex/query/func/array/ArrayFoldRight.java
@@ -21,7 +21,7 @@ public final class ArrayFoldRight extends ArrayFoldLeft {
     final XQArray array = toArray(arg(0), qc);
     final FItem action = action(qc);
 
-    final HofArgs args = new HofArgs(3, action).set(1, arg(1).value(qc));
+    final HofArgs args = new HofArgs(2).set(1, arg(1).value(qc));
     final long p = array.structSize();
     for(final ListIterator<Value> iter = array.iterator(p); iter.hasPrevious();) {
       args.set(1, invoke(action, args.set(0, iter.previous()).inc(), qc));

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnFoldLeft.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnFoldLeft.java
@@ -25,7 +25,7 @@ public class FnFoldLeft extends StandardFunc {
     final Iter input = arg(0).iter(qc);
     final FItem action = action(qc);
 
-    final HofArgs args = new HofArgs(3, action).set(0, arg(1).value(qc));
+    final HofArgs args = new HofArgs(2).set(0, arg(1).value(qc));
     for(Item item; (item = input.next()) != null;) {
       args.set(1, item).inc();
       if(skip(qc, args)) break;
@@ -52,7 +52,7 @@ public class FnFoldLeft extends StandardFunc {
    * @throws QueryException query exception
    */
   public final FItem action(final QueryContext qc) throws QueryException {
-    return iff != null ? iff[1] : toFunction(arg(2), 3, qc);
+    return iff != null ? iff[1] : toFunction(arg(2), 2, qc);
   }
 
   @Override
@@ -69,24 +69,21 @@ public class FnFoldLeft extends StandardFunc {
    * @throws QueryException query exception
    */
   final Expr unroll(final CompileContext cc, final boolean left) throws QueryException {
-    final Expr input = arg(0), init = arg(1), action = arg(2);
-    final int arity = arity(action);
-    if(arity == 2) {
-      final ExprList unroll = cc.unroll(input, true);
-      if(unroll != null) {
-        final Expr func = coerceFunc(2, cc, arity);
-        Expr expr = init;
-        if(left) {
-          for(final Expr ex : unroll) {
-            expr = new DynFuncCall(info, func, expr, ex).optimize(cc);
-          }
-        } else {
-          for(int es = unroll.size() - 1; es >= 0; es--) {
-            expr = new DynFuncCall(info, func, unroll.get(es), expr).optimize(cc);
-          }
+    final Expr input = arg(0), init = arg(1);
+    final ExprList unroll = cc.unroll(input, true);
+    if(unroll != null) {
+      final Expr func = coerceFunc(2, cc);
+      Expr expr = init;
+      if(left) {
+        for(final Expr ex : unroll) {
+          expr = new DynFuncCall(info, func, expr, ex).optimize(cc);
         }
-        return expr;
+      } else {
+        for(int es = unroll.size() - 1; es >= 0; es--) {
+          expr = new DynFuncCall(info, func, unroll.get(es), expr).optimize(cc);
+        }
       }
+      return expr;
     }
     return this;
   }
@@ -120,7 +117,7 @@ public class FnFoldLeft extends StandardFunc {
         SeqType.ITEM_O : ist.with(Occ.EXACTLY_ONE);
       SeqType st = zst, ost;
       do {
-        final SeqType[] types = { left ? st : i1t, left ? i1t : st, SeqType.INTEGER_O };
+        final SeqType[] types = { left ? st : i1t, left ? i1t : st };
         arg(2, arg -> refineFunc(action, cc, types));
         ost = st;
         st = st.union(arg(2).funcType().declType);

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnFoldRight.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnFoldRight.java
@@ -22,7 +22,7 @@ public final class FnFoldRight extends FnFoldLeft {
     final Iter input = arg(0).iter(qc);
     final FItem action = action(qc);
 
-    final HofArgs args = new HofArgs(3, action).set(1, arg(1).value(qc));
+    final HofArgs args = new HofArgs(2).set(1, arg(1).value(qc));
     long p = input.size();
     if(p != -1) {
       for(; p > 0; p--) {

--- a/basex-core/src/test/java/org/basex/query/func/ArrayModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/ArrayModuleTest.java
@@ -114,16 +114,12 @@ public final class ArrayModuleTest extends SandboxTest {
   @Test public void foldLeft() {
     final Function func = _ARRAY_FOLD_LEFT;
     query(func.args(" [ 1, 2 ]", 0, " function($a, $b) { $a + $b }"), 3);
-    query(func.args(" array { 1 to 6 }", "ok", " fn($r, $i, $p) { $r[$i = $p] }"), "ok");
-    query(func.args(" array { 2 to 7 }", "-", " fn($r, $i, $p) { $r[$i = $p] }"), "");
   }
 
   /** Test method. */
   @Test public void foldRight() {
     final Function func = _ARRAY_FOLD_RIGHT;
     query(func.args(" [ 1, 2 ]", " ()", " function($a, $b) { $b, $a }"), "2\n1");
-    query(func.args(" array { 1 to 6 }", "ok", " fn($i, $r, $p) { $r[$i = 7 - $p] }"), "ok");
-    query(func.args(" array { 2 to 7 }", "-", " fn($i, $r, $p) { $r[$i = $p] }"), "");
   }
 
   /** Test method. */

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -1079,9 +1079,6 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args(2, 1, " function($a, $b) { $b }"), 2);
     query("sort(" + func.args(" <a/>", "a", " compare#2") + ")", 1);
 
-    query(func.args(" 1 to 6", "ok", " fn($r, $i, $p) { $r[$i = $p] }"), "ok");
-    query(func.args(" 2 to 7", "-", " fn($r, $i, $p) { $r[$i = $p] }"), "");
-
     check(func.args(" ()", " ()", " function($a, $b) { $b }"), "", empty());
 
     check(func.args(" 1 to 10", " xs:byte(1)", " function($n, $_) {" +
@@ -1123,9 +1120,6 @@ public final class FnModuleTest extends SandboxTest {
   /** Test method. */
   @Test public void foldRight() {
     final Function func = FOLD_RIGHT;
-    query(func.args(" 1 to 6", "ok", " fn($i, $r, $p) { $r[$i = 7 - $p] }"), "ok");
-    query(func.args(" 1 to 6", "-", " fn($i, $r, $p) { $r[$i = $p] }"), "");
-
     check(func.args(" ()", " ()", " function($a, $b) { $a }"), "", empty());
 
     // should not be unrolled


### PR DESCRIPTION
This changes removes the position parameters form fold functions, as per qt4cg/qtspecs#1867.