### PR TITLE
Disallow a question mark to follow the `<` operator, honoring the longest token rule

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -1748,7 +1748,11 @@ public class QueryParser extends InputParser {
         }
       }
       for(final OpG c : OpG.values()) {
-        if(wsConsumeWs(c.name)) return new CmpG(info(), expr, check(ftContains(), CMPEXPR), c);
+        if(wsConsume(c.name)) {
+          if(c == OpG.LT && current('?')) throw error(CMPEXPR); // longest token rule asks for "<?"
+          skipWs();
+          return new CmpG(info(), expr, check(ftContains(), CMPEXPR), c);
+        }
       }
     }
     return expr;


### PR DESCRIPTION
Test case `Constr-pi-content-9` has this expression, which is invalid by the longest token rule:

```xquery
map{'a':<z>4</z>, 'b':<z>6</z>} ! (?a <?b and ?a treat as node()?>>?a)
```

This change consequently disallows a question mark to follow the `<` operator. Issuing error `CMPEXPR` treats the question mark the same as other invalid character sequences to follow, e.g. `!--`, `![CDATA[`.