### PR TITLE
Allow a sequence of function items in dynamic function calls

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/DynFuncCall.java
+++ b/basex-core/src/main/java/org/basex/query/func/DynFuncCall.java
@@ -72,7 +72,14 @@ public final class DynFuncCall extends FuncCall {
     if(ft != null) {
       if(ft.argTypes != null) {
         final int arity = ft.argTypes.length;
-        if(nargs != arity) throw arityError(func, nargs, arity, false, info);
+        if(nargs != arity) {
+          Expr funcItem = func;
+          if(func instanceof VarRef ref) {
+            final Expr expr = ref.var.expr();
+            if(expr instanceof FuncItem) funcItem = expr;
+          }
+          throw arityError(funcItem, nargs, arity, false, info);
+        }
       }
       if(!sc().mixUpdates && !updating && ft.anns.contains(Annotation.UPDATING)) {
         throw FUNCUP_X.get(info, func);

--- a/basex-core/src/main/java/org/basex/query/var/Var.java
+++ b/basex-core/src/main/java/org/basex/query/var/Var.java
@@ -94,6 +94,14 @@ public final class Var extends ExprInfo {
   }
 
   /**
+   * Returns the input expression.
+   * @return input expression (can be {@code null} if not yet set)
+   */
+  public Expr expr() {
+    return ex;
+  }
+
+  /**
    * Returns the result size.
    * @return result size
    */

--- a/basex-core/src/test/java/org/basex/query/expr/HigherOrderTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/HigherOrderTest.java
@@ -107,7 +107,8 @@ public final class HigherOrderTest extends SandboxTest {
 
   /**  Test for invalid function expressions. */
   @Test public void invalidFunTest() {
-    error("()()", INVFUNCITEM_X_X);
+    query("()()", "");
+
     error("1()", INVFUNCITEM_X_X);
     error("1.0()", INVFUNCITEM_X_X);
     error("1e0()", INVFUNCITEM_X_X);

--- a/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java
+++ b/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java
@@ -125,8 +125,8 @@ public final class SimpleTest extends QueryTest {
       { "Seq 3", integers(1, 2), "((( 1, 2 )  )    )" },
       { "Seq 4", integers(1, 2, 3), "(1, (( 2,3 )  )    )" },
       { "Seq 5", integers(1, 2, 3, 4), "(1, (( 2,3 )  ),4   )" },
-      { "Seq 6", "()()" },
-      { "Seq 7", "() ()" },
+      { "Seq 6", emptySequence(), "()()" },
+      { "Seq 7", emptySequence(), "() ()" },
 
       { "IntersectExcept 1", emptySequence(), "<a/> intersect <b/>" },
       { "IntersectExcept 2", emptySequence(), "<a/> intersect <b/> except <c/>" },


### PR DESCRIPTION
These changes add support for [PR 1975](https://github.com/qt4cg/qtspecs/pull/1975), i.e. allowing dynamic function calls to operate on a sequence of function items, fixing the corresponding QT4-Tests. Unfortunately there are  3 errors in BaseX-Tests, because tail-call optimization for dynamic function calls does not work any longer:
 - [RewritingsTest.gh2314](https://github.com/BaseXdb/basex/blob/d88855a4f2113315859204b96016b9fa46d23d5e/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java#L3364-L3367)
 - [TCOTest.dynFuncCall](https://github.com/BaseXdb/basex/blob/d88855a4f2113315859204b96016b9fa46d23d5e/basex-core/src/test/java/org/basex/query/ast/TCOTest.java#L108-L123)
 - [FuncItemTest.funcItemInlining](https://github.com/BaseXdb/basex/blob/d88855a4f2113315859204b96016b9fa46d23d5e/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java#L159-L179)

The approach taken here is to generate in iteration from within the parser. Effectively,
```xquery
(upper-case#1, lower-case#1)('aBcD')
```
 is translated to
```xquery
for $fn in (upper-case#1, lower-case#1) return $fn('aBcD')
```
but there also is special treatment without an interation for the case where the static type indicates exactly one function item.

An alternative approach might be enhancing the `DynFuncCall` operator to support a sequence of function items, but that has not been investigated yet.