### PR TITLE
Add support for functions in no namespace

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryContext.java
+++ b/basex-core/src/main/java/org/basex/query/QueryContext.java
@@ -354,6 +354,8 @@ public final class QueryContext extends Job implements Closeable {
       } else {
         // required for XQueryParse
         functions.compileAll(cc);
+        // required for fn:load-xquery-module
+        vars.compileAll(cc);
       }
     } catch(final StackOverflowError ex) {
       Util.debug(ex);

--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -1256,8 +1256,6 @@ public enum QueryError {
   /** Error code. */
   WRONGMODULE_X_X_X(XQST, 59, "Imported module '%' has unexpected namespace: '%' vs '%'."),
   /** Error code. */
-  FUNNONS_X(XQST, 60, "Namespace needed for function '%'."),
-  /** Error code. */
   DUPLORD(XQST, 65, "Duplicate 'ordering' declaration."),
   /** Error code. */
   DUPLNS(XQST, 66, "Duplicate 'default namespace' declaration."),

--- a/basex-core/src/main/java/org/basex/query/StaticContext.java
+++ b/basex-core/src/main/java/org/basex/query/StaticContext.java
@@ -1,6 +1,5 @@
 package org.basex.query;
 
-import static org.basex.query.QueryText.*;
 import static org.basex.util.Token.*;
 
 import javax.xml.catalog.*;
@@ -15,6 +14,7 @@ import org.basex.query.util.format.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.type.*;
 import org.basex.util.*;
+import org.basex.util.Util;
 import org.basex.util.hash.*;
 import org.xml.sax.*;
 
@@ -39,7 +39,7 @@ public final class StaticContext {
   /** Default element/type namespace. */
   public byte[] elemNS;
   /** Default function namespace. */
-  public byte[] funcNS = FN_URI;
+  public byte[] funcNS;
   /** Name of module (not assigned for main module). */
   public QNm module;
 

--- a/basex-core/src/main/java/org/basex/query/func/FuncRef.java
+++ b/basex-core/src/main/java/org/basex/query/func/FuncRef.java
@@ -1,0 +1,140 @@
+package org.basex.query.func;
+
+import java.util.function.*;
+
+import org.basex.query.*;
+import org.basex.query.expr.*;
+import org.basex.query.iter.*;
+import org.basex.query.util.*;
+import org.basex.query.util.parse.*;
+import org.basex.query.value.*;
+import org.basex.query.value.item.*;
+import org.basex.query.value.type.*;
+import org.basex.query.var.*;
+import org.basex.util.*;
+import org.basex.util.hash.*;
+
+/**
+ * A reference to an unresolved function call or named function item, to be resolved after parsing,
+ * when all user-defined function declarations have been processed.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public class FuncRef extends Arr {
+  /** Function to resolve this reference. */
+  private final ThrowingFunction<QueryContext, Expr, QueryException> resolve;
+  /** Function to convert to string. */
+  private final Consumer<QueryString> toString;
+  /** Function call or function item after resolution. */
+  private Expr expr;
+
+  /**
+   * Constructor for static function calls.
+   * @param name function name
+   * @param fb function builder
+   * @param hasImport indicates whether a module import for the function name's URI was present
+   */
+  public FuncRef(final QNm name, final FuncBuilder fb, final boolean hasImport) {
+    this(fb.info,
+        qc -> Functions.get(name, fb, qc, hasImport),
+        qs -> qs.token(name.prefixId()).params(fb.args()));
+  }
+
+  /**
+   * Constructor for named function references.
+   * @param name function name
+   * @param arity function arity
+   * @param info input info (can be {@code null})
+   * @param hasImport indicates whether a module import for the function name's URI was present
+   */
+  public FuncRef(final QNm name, final int arity, final InputInfo info, final boolean hasImport) {
+    this(info,
+        qc -> Functions.item(name, arity, false, info, qc, hasImport),
+        qs -> qs.token(name.prefixId()).token('#').token(arity));
+  }
+
+  /**
+   * Constructor.
+   * @param info input info (can be {@code null})
+   * @param resolve function to resolve the reference
+   * @param toString function to convert to string
+   */
+  private FuncRef(final InputInfo info,
+      final ThrowingFunction<QueryContext, Expr, QueryException> resolve,
+      final Consumer<QueryString> toString) {
+    super(info, SeqType.ITEM_ZM);
+    this.resolve = resolve;
+    this.toString = toString;
+  }
+
+  /**
+   * Functional interface for functions that may throw an exception.
+   * @param <T> parameter type
+   * @param <R> result type
+   * @param <E> exception type
+   */
+  @FunctionalInterface
+  public interface ThrowingFunction<T, R, E extends Exception> {
+    /**
+     * Applies this function to the given argument.
+     * @param t argument
+     * @return result
+     * @throws E exception
+     */
+    R apply(T t) throws E;
+  }
+
+  /**
+   * Resolves the function reference.
+   * @param qc query context
+   * @throws QueryException query exception
+   */
+  public void resolve(final QueryContext qc) throws QueryException {
+    expr = resolve.apply(qc);
+  }
+
+  /**
+   * Returns the resolved expression.
+   * @return expression
+   */
+  private Expr expr() {
+    if(expr == null) throw Util.notExpected();
+    return expr;
+  }
+
+  @Override
+  public boolean has(final Flag... flags) {
+    return expr().has(flags);
+  }
+
+  @Override
+  public boolean vacuous() {
+    return expr().vacuous();
+  }
+
+  @Override
+  public Iter iter(final QueryContext qc) throws QueryException {
+    return expr().iter(qc);
+  }
+
+  @Override
+  public Expr compile(final CompileContext cc) throws QueryException {
+    return expr().compile(cc);
+  }
+
+  @Override
+  public Value value(final QueryContext qc) throws QueryException {
+    throw Util.notExpected();
+  }
+
+  @Override
+  public Expr copy(final CompileContext cc, final IntObjectMap<Var> vm) {
+    throw Util.notExpected();
+  }
+
+  @Override
+  public void toString(final QueryString qs) {
+    toString.accept(qs);
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/func/StaticFuncs.java
+++ b/basex-core/src/main/java/org/basex/query/func/StaticFuncs.java
@@ -48,7 +48,6 @@ public final class StaticFuncs extends ExprInfo {
       throws QueryException {
 
     final byte[] uri = name.uri();
-    if(uri.length == 0) throw FUNNONS_X.get(info, name.string());
     if(NSGlobal.reserved(uri) || Functions.builtIn(name) != null)
       throw FNRESERVED_X.get(info, name.string());
 

--- a/basex-core/src/main/java/org/basex/query/func/inspect/InspectStaticContext.java
+++ b/basex-core/src/main/java/org/basex/query/func/inspect/InspectStaticContext.java
@@ -54,7 +54,7 @@ public final class InspectStaticContext extends StandardFunc {
       case ELEMENT_NAMESPACE ->
         sctx.elemNS == null ? Empty.VALUE : Uri.get(sctx.elemNS);
       case FUNCTION_NAMESPACE ->
-        sctx.funcNS == null ? Empty.VALUE : Uri.get(sctx.funcNS);
+        sctx.funcNS == null ? Str.get(QueryText.FN_URI) : Uri.get(sctx.funcNS);
       case COLLATION ->
         Uri.get(sctx.collation == null ? COLLATION_URI : sctx.collation.uri());
       case ORDERING ->

--- a/basex-core/src/main/java/org/basex/query/var/Variables.java
+++ b/basex-core/src/main/java/org/basex/query/var/Variables.java
@@ -72,6 +72,17 @@ public final class Variables extends ExprInfo implements Iterable<StaticVar> {
   }
 
   /**
+   * Compiles all static variables.
+   * @param cc compilation context
+   * @throws QueryException query exception
+   */
+  public void compileAll(final CompileContext cc) throws QueryException {
+    for(final StaticVar var : this) {
+      var.compile(cc);
+    }
+  }
+
+  /**
    * Returns a new reference to the (possibly not yet declared) variable with the given name.
    * @param name variable name
    * @param info input info (can be {@code null})

--- a/basex-core/src/test/java/org/basex/query/func/QueryModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/QueryModuleTest.java
@@ -54,7 +54,7 @@ public final class QueryModuleTest extends QueryModule {
   @Requires(Permission.NONE)
   @ContextDependent
   public Str functionNS() {
-    return Str.get(staticContext.funcNS);
+    return Str.get(staticContext.funcNS == null ? QueryText.FN_URI : staticContext.funcNS);
   }
 
   /**


### PR DESCRIPTION
These changes adapt to the new rules allowing functions in no namespace.

These rules require that unprefixed function names cannot be resolved before all user-defined functions have been declared. This is accomplished by new class `FuncRef`, acting as a placeholder for a static function call or named function item, delaying the construction of the implementation until its `resolve` method is called.