### PR TITLE
Update ICU4J from 77.1 to 78.1

### DIFF
--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -1313,7 +1313,7 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args(" 12345.67", "#.##0,00", "de"), "12.345,67");
     query(func.args(" 12345.67", "#.##0,00", " { 'decimal-separator': ',', "
         + "'grouping-separator': '.' }"), "12.345,67");
-    query(func.args(" 12345.67", "#\u2019##0.00", "de-CH"), "12\u2019345.67");
+    query(func.args(" 12345.67", "#'##0.00", "de-CH"), "12'345.67");
     query(func.args(" 12345.67", "#.##0,00", " { "
         + "'decimal-separator': ',', 'grouping-separator': '.' }"), "12.345,67");
     query(func.args(" 12345.67", "#.##0,00", " { 'format-name': 'de' }"), "12.345,67");

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
       <dependency>
         <groupId>com.ibm.icu</groupId>
         <artifactId>icu4j</artifactId>
-        <version>77.1</version>
+        <version>78.1</version>
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
#2524 is a dependabot attempt to update ICU4J from 77.1 to 78.1, but this results in a test failure. The reason is that ICU 78.1 includes updates to Unicode 17 and CLDR 48 (see the [unicode blog](https://blog.unicode.org/2025/10/icu-78-released.html)). In CLDR 48, the group separator char for Swiss German was changed from `’` (`0x2019`, right single quotation mark) to `'` (`0x27`, fullwidth apostrophe). The change can be seen on the [Swiss German Delta page](https://www.unicode.org/cldr/charts/48/delta/gsw.html) comparing CLDR 47 and 48. 

This change caused `FnModuleTest.formatNumber` to fail, because it relied on the previously used character.

This PR updates ICU4J to version 78.1 and adapts the test accordingly, rendering #2524 obsolete.

There is a related test failure in the QT4 test case `graphemes-1177`; I will create a PR for `qt4tests` to address that separately.