### PR TITLE
WIP: Add missing type check to method calls

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -2580,7 +2580,8 @@ public class QueryParser extends InputParser {
     final VarRef arg = new VarRef(info, fr.var);
     final FuncBuilder fb = argumentList(false, arg);
     if(fb.placeholders != 0) throw error(INVPLACEHOLDER_X, key);
-    final Lookup func = new Lookup(info, arg, key);
+    final Lookup val = new Lookup(info, arg, key);
+    final TypeCheck func = new TypeCheck(info, val, Types.FUNCTION_O);
     final Expr call = Functions.dynamic(func, fb);
     final GFLWOR gflwor = new GFLWOR(info, fr, call);
     localVars.closeScope(s);

--- a/basex-core/src/test/java/org/basex/query/expr/XQuery4Test.java
+++ b/basex-core/src/test/java/org/basex/query/expr/XQuery4Test.java
@@ -65,13 +65,14 @@ public final class XQuery4Test extends SandboxTest {
     query("declare record local:rect(height, width, area := fn { ?height × ?width }); "
         + "let $r := local:rect(3, 4) return local:rect(5, 6, $r?area)=?>area()", 30);
     query("{ 'self': fn { . } }=?>self() => map:keys()", "self");
-    query("let $f := fn {trace(., \"context\")?i}\n"
+    query("let $f := fn {?i}\n"
         + "let $g := ({ 'i': 7, 'f': $f }, { 'i': 11, 'g': $f })\n"
         + "let $h := $g?('f', 'g')\n"
         + "return $h[1]($g[1]) * $h[2]($g[2])", 77);
 
     error("(" + rect + "=> map:get('area'))()", INVARITY_X_X);
     error(rect + "('area')()", INVARITY_X_X);
+    error("{} =?> x()", INVCONVERT_X_X_X);
   }
 
   /** Otherwise expression. */


### PR DESCRIPTION
The spec, in [4.14.4 Method Calls](https://qt4cg.org/specifications/xquery-40/xquery-40.html#id-methods), requires a map that goes into a method call to have an entry with the given key that is a single function item. Implementation-wise this used to be checked implicitly by the involved dynamic function call, because until recently that required a single function item as well. However with that changed to allowing a sequence of zero or more function items, an extra type check becomes necessary for method calls, which is added here.

This fixes QT4 test cases `method-902` and `method-904`.