### PR TITLE
Update to Markup Blitz 1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
       <dependency>
         <groupId>de.bottlecaps</groupId>
         <artifactId>markup-blitz</artifactId>
-        <version>1.9</version>
+        <version>1.10</version>
         <scope>runtime</scope>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
Markup Blitz 1.10 uses Unicode 17.0, so this aligns well with the recent update to ICU4J 78.1.