### PR TITLE
Remove shortcut from function coercion

### DIFF
--- a/basex-core/src/main/java/org/basex/query/value/item/FItem.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/FItem.java
@@ -82,7 +82,7 @@ public abstract class FItem extends Item implements XQFunction {
     if(nargs < arity) throw arityError(this, arity, nargs, false, info);
 
     // optimize: continue with coercion if current type is only an instance of new type
-    if(type instanceof FuncType && (cc != null ? type.eq(ft) : type.instanceOf(ft))) return this;
+    if(type.eq(ft)) return this;
 
     // create new compilation context and variable scope
     final VarScope vs = new VarScope();

--- a/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java
@@ -204,6 +204,8 @@ public final class FuncItemTest extends SandboxTest {
     error("let $x as fn(xs:integer) as xs:integer := [1, 2] return $x?*", LOOKUP_X);
     error("let $x as fn(*) := { 1:'A', 'x':'B' } return $x?*", LOOKUP_X);
     error("let $x as fn(*) := [1, 2] return $x?*", LOOKUP_X);
+    error("declare variable $f as fn(xs:integer) as xs:string := string#1; $f('x')",
+        INVCONVERT_X_X_X);
 
     query("let $f as fn() as xs:anyAtomicType := fn() { <a/> } " +
       "return $f() ! (. = ('1', '2'))", "false");


### PR DESCRIPTION
Function coercion for static variable values currently fails to detect incorrect parameter types. For example, the following should fail, but it doesn't:

```xquery
declare variable $f as fn(xs:integer) as xs:string := string#1;
$f('x')
```

The coercion is actually done, but `FItem.coerceTo` has a shortcut for `cc == null` that is already satisfied with an `instanceOf` test:

```java
    if(type instanceof FuncType && (cc != null ? type.eq(ft) : type.instanceOf(ft))) return this;
```

The shortcut however misses coercion of the arguments, so I am removing it here.

This fixes QT4 test `VarDecl066`.