### PR TITLE
Add coercion from `xs:anyURI` to enumeration types

### DIFF
--- a/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
@@ -340,7 +340,8 @@ public final class SeqType {
       type == STRING && at == ANY_URI ||
       type == ANY_URI && at.instanceOf(STRING) ||
       type == HEX_BINARY && at == BASE64_BINARY ||
-      type == BASE64_BINARY && at == HEX_BINARY
+      type == BASE64_BINARY && at == HEX_BINARY ||
+      type instanceof EnumType && at == ANY_URI
     ) {
       // item will be cast
     } else if(!type.union(at).oneOf(ANY_ATOMIC_TYPE, NUMERIC)) {

--- a/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java
+++ b/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java
@@ -95,6 +95,7 @@ public final class SimpleTest extends QueryTest {
       { "ExtVar 1", integers(1), "declare variable $a external; 1" },
       { "ExtVar 2", "declare variable $a external; $a" },
       { "ExtVar 3", strings("a"), "declare variable $x as enum('a', 'b') := 'a'; $x" },
+      { "ExtVar 4", strings("a"), "declare variable $x as enum('a', 'b') := xs:anyURI('a'); $x" },
 
       { "If  1", booleans(true), "if(true()) then true() else false()" },
       { "If  2", booleans(false), "if(false()) then true() else false()" },


### PR DESCRIPTION
The coercion rules have changed to allow coercion from `xs:anyURI` to enumeration types. This change adapts `SeqType.coerceAtom` to support that.

This fixes QT4 test cases `DynamicFunctionCall-136` and `DynamicFunctionCall-R-136`.