### PR TITLE
Minor fixes of `FnLoadXQueryModule`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/FnLoadXQueryModule.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnLoadXQueryModule.java
@@ -87,7 +87,8 @@ public final class FnLoadXQueryModule extends StandardFunc {
     }
 
     if(opt.contains(XQUERY_VERSION)) {
-      final String version = opt.get(XQUERY_VERSION).toString();
+      String version = opt.get(XQUERY_VERSION).toString();
+      if(!version.contains(".")) version += ".0";
       if(!isSupported(version)) throw MODULE_XQUERY_VERSION_X.get(info, version);
     }
 
@@ -160,14 +161,7 @@ public final class FnLoadXQueryModule extends StandardFunc {
     final MapBuilder variables = new MapBuilder();
     for(final StaticVar var : mqc.vars) {
       if(!var.anns.contains(Annotation.PRIVATE) && Token.eq(var.name.uri(), modUri)) {
-        try {
-          variables.put(var.name, var.value(mqc));
-        } catch(final QueryException ex) {
-          throw ex;
-        } catch(final Exception ex) {
-          Util.debug(ex);
-          throw VAREMPTY_X.get(info, var.name());
-        }
+        variables.put(var.name, var.value(mqc));
       }
     }
 

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -1830,6 +1830,8 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args("x", " { 'content': 'module namespace x=\"x\";\ndeclare context item as "
         + "xs:decimal external; declare variable $x:x := .;', 'context-item': 1 }") + "?variables"
         + "?#Q{x}x", 1);
+    query(func.args("x", " { 'content': 'module namespace x=\"x\";\ndeclare variable $x:x := 1;', "
+        + "'xquery-version': 4.0 }") + "?variables?#Q{x}x", 1);
 
     error(func.args(""), MODULE_URI_EMPTY);
     error(func.args("x"), MODULE_NOT_FOUND_X);


### PR DESCRIPTION
This changes two minor issues in `FnLoadXQueryModule`:

 - the try-catch for reporting uninitialized variables is now superfluous, since the message is already generated during execution of `Variables.compileAll` (which was introduced in ca6d268cb8) 
 - the input for the `xquery-version` check is a decimal, but the check is performed on a string representation expecting a period and a minor version. This caused `4.0` to fail, because it was stringified to `4`. The change here explicitly adds `.0` in case the string does not contain a `.`.