### PR TITLE
Revert maven-jar-plugin to 3.4.2 in order to avoid Eclipse m2e problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.4.2</version>
           <inherited>true</inherited>
           <configuration>
             <archive>


### PR DESCRIPTION
3.5.0 was causing these errors in Eclipse:

```txt
Cannot access Key[type=org.apache.maven.project.MavenProject, annotation=[none]] outside of a scoping block	pom.xml	/basex	line 1	Maven Configuration Problem
Cannot access Key[type=org.apache.maven.project.MavenProject, annotation=[none]] outside of a scoping block	pom.xml	/basex-api	line 1	Maven Configuration Problem
Cannot access Key[type=org.apache.maven.project.MavenProject, annotation=[none]] outside of a scoping block	pom.xml	/basex-tests	line 1	Maven Configuration Problem
```