### PR TITLE
Fix `DynFuncCall` argument type check and `StructFilter` context setting

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/AFilter.java
+++ b/basex-core/src/main/java/org/basex/query/expr/AFilter.java
@@ -70,7 +70,8 @@ public abstract class AFilter extends Preds {
     if(changed) root = inlined;
 
     // do not inline context reference in predicates
-    changed |= ic.var != null && ic.cc.ok(root, true, () -> ic.inline(exprs));
+    final Expr ctx = this instanceof StructFilter ? null : root;
+    changed |= ic.var != null && ic.cc.ok(ctx, true, () -> ic.inline(exprs));
 
     return changed ? optimize(ic.cc) : null;
   }

--- a/basex-core/src/main/java/org/basex/query/func/DynFuncCall.java
+++ b/basex-core/src/main/java/org/basex/query/func/DynFuncCall.java
@@ -16,7 +16,6 @@ import org.basex.query.util.*;
 import org.basex.query.util.list.*;
 import org.basex.query.value.*;
 import org.basex.query.value.item.*;
-import org.basex.query.value.map.*;
 import org.basex.query.value.type.*;
 import org.basex.query.var.*;
 import org.basex.util.*;
@@ -92,7 +91,8 @@ public final class DynFuncCall extends FuncCall {
         final int arity = ft.argTypes.length;
         if(nargs != arity) throw arityError(func, nargs, arity, false, info);
         for(int a = 0; a < arity; ++a) {
-          final SeqType st = func instanceof XQMap ? Types.ANY_ATOMIC_TYPE_O : ft.argTypes[a];
+          final SeqType st = func.seqType().type instanceof MapType
+              ? Types.ANY_ATOMIC_TYPE_O : ft.argTypes[a];
           exprs[a] = new TypeCheck(info, exprs[a], st).compile(cc);
         }
       }

--- a/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/FuncItemTest.java
@@ -421,4 +421,12 @@ public final class FuncItemTest extends SandboxTest {
       };
       local:self(identity#1)""", INVCONVERT_X_X_X);
   }
+
+  /** Map lookup causing double to integer comparison; StructFilter context setting. */
+  @Test public void gh2546() {
+    query("let $m := { 1: 0 } return $m({ \"x\": 1e0 }?x)", "0");
+    query("let $m := { 1: 0 } return $m(1e0)", "0");
+    query("let $filter := fn($k, $v) { $k = $v }\n"
+        + "return { 0: 0 }?[$filter(?key, ?value)]", "{0:0}");
+  }
 }


### PR DESCRIPTION
#2546 was caused by the change made for #2530. While the change is doing the right thing, its check for the function being a map is insufficient. It checked for `instanceof XQMap`, but should have checked `.seqType().type instanceof MapType`, in order to also cover variables, as in the first offending query.

The other query (from #2547) calls for an additional fix. Its empty result is caused by `MapCompilation` analysing `keyMismatch` for a map type of `map(xs:integer, xs:integer)` and a key type of  `xs:string`. However the relevant map type in this case would have been `record(key as xs:anyAtomicType, value as item()*)`. The map type originates from the context setting established in `AFilter.inline`, and I have set it to `null` for the `StructFilter` case. Maybe there is a better solution for this one?