### PR TITLE
Fix `ArrowTarget` function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Compiling BaseX
 
 The code base of BaseX can be accessed on [GitHub]: https://github.com/BaseXdb/basex
 
-JDK 11 and JUnit are currently required to compile the complete sources of the
+JDK 17 and JUnit are currently required to compile the complete sources of the
 main project. Our default IDE is Eclipse.
 
 You can launch the following classes, which are all placed in the basex-core

--- a/basex-core/src/main/java/org/basex/query/func/FuncRef.java
+++ b/basex-core/src/main/java/org/basex/query/func/FuncRef.java
@@ -2,8 +2,6 @@ package org.basex.query.func;
 
 import org.basex.query.*;
 import org.basex.query.expr.*;
-import org.basex.query.util.parse.*;
-import org.basex.query.value.item.*;
 import org.basex.query.value.type.*;
 import org.basex.query.var.*;
 import org.basex.util.*;
@@ -18,46 +16,23 @@ import org.basex.util.hash.*;
  */
 public final class FuncRef extends Single {
   /** Function to resolve this reference. */
-  private final QueryFunction<QueryContext, Expr> resolve;
-
-  /**
-   * Constructor for static function calls.
-   * @param name function name
-   * @param fb function builder
-   * @param hasImport indicates whether a module import for the function name's URI was present
-   */
-  public FuncRef(final QNm name, final FuncBuilder fb, final boolean hasImport) {
-    this(fb.info, qc -> Functions.get(name, fb, qc, hasImport));
-  }
-
-  /**
-   * Constructor for named function references.
-   * @param name function name
-   * @param arity function arity
-   * @param info input info (can be {@code null})
-   * @param hasImport indicates whether a module import for the function name's URI was present
-   */
-  public FuncRef(final QNm name, final int arity, final InputInfo info, final boolean hasImport) {
-    this(info, qc -> Functions.item(name, arity, false, info, qc, hasImport));
-  }
+  private final QuerySupplier<Expr> resolve;
 
   /**
    * Constructor.
-   * @param info input info (can be {@code null})
    * @param resolve function to resolve the reference
    */
-  private FuncRef(final InputInfo info, final QueryFunction<QueryContext, Expr> resolve) {
-    super(info, null, Types.ITEM_ZM);
+  public FuncRef(final QuerySupplier<Expr> resolve) {
+    super(null, null, Types.ITEM_ZM);
     this.resolve = resolve;
   }
 
   /**
    * Resolves the function reference.
-   * @param qc query context
    * @throws QueryException query exception
    */
-  public void resolve(final QueryContext qc) throws QueryException {
-    expr = resolve.apply(qc);
+  public void resolve() throws QueryException {
+    expr = resolve.get();
   }
 
   @Override

--- a/basex-core/src/test/java/org/basex/query/expr/XQuery4Test.java
+++ b/basex-core/src/test/java/org/basex/query/expr/XQuery4Test.java
@@ -222,6 +222,7 @@ public final class XQuery4Test extends SandboxTest {
     query("1 => [ 8 ]()", 8);
     query("8 => fn { . }()", 8);
     query("8 => fn($n) { $n }()", 8);
+    query("declare variable $v := 42 => f(); declare function f($x) {$x}; $v", 42);
   }
 
   /** Mapping arrow operator. */


### PR DESCRIPTION
This query currently returns `[XPST0017] Unknown function: fn:f`:

```xquery
declare variable $v := 42 => f();
declare function f($x) {$x};
$v
```

This happens because the changes made for #2513 were incomplete: the `ArrowTarget` function call was overlooked.

This PR adds a `FunctionReference` to this function call, which is only resolved once the entire module has been parsed. It also simplifies the `FunctionReference` class by keeping only a generic constructor and moving the specific logic to the calling sites.

As an unrelated change, the JDK version in README.md is updated to 17.