### PR TITLE
Fix comparison of `xs:unsignedLong` to `xs:decimal`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/value/item/Uln.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/Uln.java
@@ -89,15 +89,16 @@ public final class Uln extends ANum {
   public boolean equal(final Item item, final Collation coll, final InputInfo ii)
       throws QueryException {
     return item.type == AtomType.UNSIGNED_LONG ? value.equals(((Uln) item).value) :
-      item.type == AtomType.DOUBLE || item.type == AtomType.FLOAT ? item.equal(this, coll, ii) :
-      value.compareTo(BigInteger.valueOf(item.itr(ii))) == 0;
+      item.type == AtomType.DOUBLE || item.type == AtomType.FLOAT || item.type == AtomType.DECIMAL ?
+        item.equal(this, coll, ii) :
+        value.compareTo(BigInteger.valueOf(item.itr(ii))) == 0;
   }
 
   @Override
   public int compare(final Item item, final Collation coll, final boolean transitive,
       final InputInfo ii) throws QueryException {
     return item.type == AtomType.UNSIGNED_LONG ? value.compareTo(((Uln) item).value) :
-      item.type == AtomType.DOUBLE || item.type == AtomType.FLOAT ?
+      item.type == AtomType.DOUBLE || item.type == AtomType.FLOAT || item.type == AtomType.DECIMAL ?
         -item.compare(this, coll, transitive, ii) :
         value.compareTo(BigInteger.valueOf(item.itr(ii)));
   }

--- a/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java
+++ b/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java
@@ -35,6 +35,13 @@ public final class SimpleTest extends QueryTest {
       { "Double 7", booleans(true), "xs:double('-INF') < 0" },
       { "Double 8", "xs:double('-inf')" },
 
+      { "UnsignedLong 1", booleans(false), "xs:unsignedLong('3') eq 3.1"},
+      { "UnsignedLong 2", booleans(false), "3.1 eq xs:unsignedLong('3')"},
+      { "UnsignedLong 3", booleans(true), "xs:unsignedLong(3) lt 3.1"},
+      { "UnsignedLong 4", booleans(true), "3.1 gt xs:unsignedLong(3)"},
+      { "UnsignedLong 5", integers(1), "compare(3.1, xs:unsignedLong('3'))"},
+      { "UnsignedLong 6", integers(-1), "compare(xs:unsignedLong('3'), 3.1)"},
+
       { "Annotation 1", integers(1), "declare %local:x(.1) variable $a := 1; $a" },
       { "Annotation 2", integers(1), "declare %local:x(1.) variable $a := 1; $a" },
       { "Annotation 3", "declare %local:x(.) variable $a := 1; $a" },


### PR DESCRIPTION
These queries currently return a wrong result:

```xquery
xs:unsignedLong('3') eq 3.1,              (: true, but should be false :)
xs:unsignedLong(3) lt 3.1,                (: false, but should be true :)
compare(xs:unsignedLong('3'), 3.1)        (: 0, but should be -1       :)
```

This is caused by both `Uln.equal` and `Uln.compare` neglecting the fractional part when the right-hand-side operand is a `Dec`. This is fixed here.