### PR TITLE
Fix class loader closing

### DIFF
--- a/basex-core/src/main/java/org/basex/query/util/pkg/ModuleLoader.java
+++ b/basex-core/src/main/java/org/basex/query/util/pkg/ModuleLoader.java
@@ -49,17 +49,19 @@ public final class ModuleLoader {
    * implementing {@link QueryResource}.
    */
   public void close() {
-    if(loader != LOADER) {
-      try {
-        ((URLClassLoader) loader).close();
-      } catch(final IOException ex) {
-        Util.stack(ex);
-      }
-    }
     for(final Object jm : javaModules) {
       for(final Class<?> c : jm.getClass().getInterfaces()) {
         if(c == QueryResource.class) Reflect.invoke(CLOSE, jm);
       }
+    }
+    try {
+      while(loader != LOADER) {
+        final ClassLoader parent = loader.getParent();
+        ((URLClassLoader) loader).close();
+        loader = parent;
+      }
+    } catch(final IOException ex) {
+      Util.stack(ex);
     }
   }
 


### PR DESCRIPTION
This change fixes 2 problems in `ModuleLoader.close`:

- only the topmost class loader is closed, but one classloader per module may have been instantiated,
- the `close` method of Java classes implementing `QueryResource` is currently called after class loader closing, though it might still require the class loader to work.