### PR TITLE
Fix `DualIterMap` context value handling

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/DualIterMap.java
+++ b/basex-core/src/main/java/org/basex/query/expr/DualIterMap.java
@@ -71,6 +71,7 @@ public final class DualIterMap extends SimpleMap {
         qf.value = item1;
         final Iter iter2 = exprs[1].iter(qc);
         for(Item item2; (item2 = qc.next(iter2)) != null;) vb.add(item2);
+        qf.value = qv;
       }
       return vb.value(this);
     } finally {

--- a/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
@@ -3398,4 +3398,19 @@ public final class RewritingsTest extends SandboxTest {
     query("let $a := 'x' let $b := if($a) then (<a/>, <b/>) else error() return $b/name()",
         "a\nb");
   }
+
+  /** DualIterMap context value setting. */
+  @Test public void gh2569() {
+    check("let $node := <X><A/><B/><C/></X>\n"
+        + "let $pos := $node/A ! position()\n"
+        + "let $nodes := for $c at $i in $node/* where $i gt $pos return $c\n"
+        + "let $flat := $nodes ! (if (*) then * else .)\n"
+        + "return element Y {$flat except $flat[1]}",
+        "<Y><C/></Y>", exists(DualIterMap.class));
+    check("let $node := <X><A/><B/><C/></X>\n"
+        + "return $node/A ! position()\n"
+        + "  -> (for $c at $i in $node/* where $i gt . return $c) ! (* otherwise .)\n"
+        + "  -> element Y {. except head(.)}",
+        "<Y><C/></Y>", exists(DualIterMap.class));
+  }
 }


### PR DESCRIPTION
After upgrading an application to 12.1, a comparison error occurred due to a different optimization uncovering a bug in `DualIterMap.value`. The context value is taken from the first iteration and applied to the second, but it is not restored before continuing the first iteration.

This change fixes that behavior and adds two tests with minimal queries reproducing the issue.