### PR TITLE
Add classloader cache for Java modules

### DIFF
--- a/basex-core/src/main/java/org/basex/query/util/pkg/ClassLoaderCache.java
+++ b/basex-core/src/main/java/org/basex/query/util/pkg/ClassLoaderCache.java
@@ -1,0 +1,150 @@
+package org.basex.query.util.pkg;
+
+import java.io.*;
+import java.net.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+
+import org.basex.util.*;
+
+/**
+ * Class loader cache.
+ */
+final class ClassLoaderCache {
+  /** Default class loader. */
+  private static final ClassLoader LOADER = ClassLoaderCache.class.getClassLoader();
+  /** Class loaders by key. */
+  private static final ConcurrentHashMap<List<String>, Loader> CACHE = new ConcurrentHashMap<>();
+
+  /** Private constructor. */
+  private ClassLoaderCache() {
+  }
+
+  /**
+   * Acquire cache entry for a module. If the module is not cached, or if any of the files have
+   * changed, a new loader is created. Otherwise, the existing loader is returned and its reference
+   * count is incremented.
+   * @param fileUrls URLs
+   * @return cache entry
+   * @throws IOException I/O exception
+   */
+  public static Loader acquire(final List<String> fileUrls) throws IOException {
+    final List<String> keys = normalize(fileUrls);
+    final int n = keys.size();
+    final URL[] urls = new URL[n];
+    final long[] lastModified = new long[n];
+
+    try {
+      int i = 0;
+      for(final String key : keys) {
+        final URL url = new URL(key);
+        if(!"file".equals(url.getProtocol())) throw Util.notExpected();
+        lastModified[i] = Files.getLastModifiedTime(Paths.get(url.toURI())).toMillis();
+        urls[i++] = url;
+      }
+    } catch(final URISyntaxException | MalformedURLException ex) {
+      throw Util.notExpected(ex);
+    }
+    return CACHE.compute(keys, (k, v) -> {
+      if(v != null) {
+        if(Arrays.equals(v.lastModified, lastModified)) {
+          v.refs.incrementAndGet();
+          return v;
+        }
+        v.invalidate();
+      }
+      return new Loader(new URLClassLoader(urls, LOADER), lastModified);
+    });
+  }
+
+  /**
+   * Invalidate cache entry for the given URLs, if any.
+   * @param fileUrls URLs
+   */
+  public static void invalidate(final List<String> fileUrls) {
+    final Loader loader = CACHE.remove(normalize(fileUrls));
+    if(loader != null) loader.invalidate();
+  }
+
+  /**
+   * Normalizes a list of strings by sorting them.
+   * @param strings list of strings
+   * @return normalized list
+   */
+  private static List<String> normalize(final List<String> strings) {
+    final List<String> normalized = new ArrayList<>(strings);
+    normalized.sort(String::compareTo);
+    return normalized;
+  }
+
+  /** Cache entry. */
+  public static final class Loader {
+    /** The class loader. */
+    private final URLClassLoader loader;
+    /** The time stamps collected for the URLs at loader creation time. */
+    private final long[] lastModified;
+    /** Number of references to this instance. */
+    private final AtomicInteger refs = new AtomicInteger(1);
+    /** Whether we had to replace this instance due to file changes. */
+    private volatile boolean stale;
+    /** Cached classes. */
+    private final Map<String, Class<?>> classes = new ConcurrentHashMap<>();
+
+    /**
+     * Constructor.
+     * @param loader class loader
+     * @param lastModified the time stamps collected for the URLs at loader creation time
+     */
+    private Loader(final URLClassLoader loader, final long[] lastModified) {
+      this.loader = loader;
+      this.lastModified = lastModified;
+    }
+
+    /**
+     * Caches and returns a reference to the specified class.
+     * @param name fully qualified class name
+     * @return reference, or {@code null} if the class is not found
+     */
+    public Class<?> find(final String name) {
+      final Class<?> cached = classes.get(name);
+      if(cached != null) return cached;
+      try {
+        final Class<?> c = Class.forName(name, true, loader);
+        classes.putIfAbsent(name, c);
+        return c;
+      } catch(final ClassNotFoundException ex) {
+        Util.debug(ex);
+        return null;
+      }
+    }
+
+    /**
+     * Release this Loader after use, but keep it cached.
+     */
+    public void release() {
+      if(refs.decrementAndGet() == 0 && stale) close();
+    }
+
+    /**
+     * Invalidate this Loader.
+     */
+    private void invalidate() {
+      stale = true;
+      if(refs.get() == 0) close();
+    }
+
+    /**
+     * Close the class loader, ignoring any exceptions.
+     */
+    private void close() {
+      try {
+        loader.close();
+      } catch(final IOException ex) {
+        Util.stack(ex);
+      }
+      classes.clear();
+    }
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/util/pkg/Pkg.java
+++ b/basex-core/src/main/java/org/basex/query/util/pkg/Pkg.java
@@ -139,4 +139,15 @@ public final class Pkg {
   public static String version(final String pkg) {
     return pkg.substring(pkg.lastIndexOf('-') + 1);
   }
+
+  /**
+   * Choose module directory (support for both 2010 and 2012 specs).
+   * @param pkgPath package path
+   * @return module directory
+   */
+  public IOFile modDir(final IOFile pkgPath) {
+    IOFile modDir = new IOFile(pkgPath, PkgText.CONTENT);
+    if(!modDir.exists()) modDir = new IOFile(pkgPath, abbrev());
+    return modDir;
+  }
 }

--- a/basex-core/src/test/java/org/basex/query/expr/PackageAPITest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/PackageAPITest.java
@@ -280,7 +280,8 @@ public final class PackageAPITest extends SandboxTest {
     }
 
     // delete package
-    assertTrue(new IOFile(REPO, dir).delete(), "Repo directory could not be deleted.");
+    assertTrue(new IOFile(REPO, dir).exists());
+    execute(new RepoDelete("jarPkg", null));
     assertFalse(new IOFile(REPO, dir).exists());
   }
 


### PR DESCRIPTION
Currently, for installed modules with Java dependencies, new `URLClassLoader`s are instantiated for each query that is importing the modules, and the classoaders are closed when the query terminates.

For modules with complex Java components, the resulting repeated class-loading effort causes a substantial runtime overhead. Some tests running under that model took up to 16 minutes, whereas the same tests completed in around 10 seconds when the Java dependencies were permanently added to the classpath.

At the same time, installable modules provide useful isolation of artifacts and, in particular, the ability to remove or replace a module with a few simple commands. Preserving this isolation while avoiding the excessive runtime overhead of repeated class loading is highly desirable.

This PR introduces classloader caching to the `ModuleLoader`. When a query imports a module that has Java dependency file URLs, the corresponding classloader is retrieved from a cache, or created and added to the cache if it does not yet exist. A cached classloader is no longer closed at query termination, but only upon an explicit invalidation request, which is issued when executing a `repo delete` command.

This change largely eliminates excessive class loading and thus drastically improves performance.

The following differences to the previous behavior should be noted:

  - classloaders are for a single module only, and independent from those of other modules. Previously multiple module imports could create multiple classloaders that were dependent on each other. So in theory, those would have been able to resolve inter-module Java-level dependencies. However, it seems questionable whether such dependencies actually exist in practice and whether they should exist.

  - classloaders are kept alive across queries and are only closed when a module is explicitly invalidated (e.g. via repo delete). As a consequence, Java classes and resources remain loaded for the lifetime of the JVM unless the module is removed.
  
  - on Windows, module jar files cannot be removed when they are held open by a classloader, so obviously with the new approach, there are less opportunities to remove them while there are running JVMs. However Java code has been observed that does not qualify for hot-removable jars anyway, because it keeps jars open even though their classloader has been closed (using `getResourceAsStream` for a jar resource might be one possible reason). Modules can still be removed, but it might be necessary to shut down all JVMs where the module was imported.