### PR TITLE
Add support for canonical serialization

### DIFF
--- a/basex-core/pom.xml
+++ b/basex-core/pom.xml
@@ -64,6 +64,11 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>io.github.erdtman</groupId>
+      <artifactId>java-json-canonicalization</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/basex-core/src/main/java/org/basex/io/serial/MarkupSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/MarkupSerializer.java
@@ -274,7 +274,14 @@ abstract class MarkupSerializer extends StandardSerializer {
 
   @Override
   protected void finishEmpty() throws IOException {
-    out.print(ELEM_SC);
+    if(canonical) {
+      out.print(ELEM_C);
+      out.print(ELEM_OS);
+      out.print(elem.string());
+      out.print(ELEM_C);
+    } else {
+      out.print(ELEM_SC);
+    }
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/io/serial/OutputSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/OutputSerializer.java
@@ -42,6 +42,7 @@ public abstract class OutputSerializer extends Serializer {
 
     this.sopts = sopts;
     indent = sopts.yes(INDENT);
+    canonical = sopts.yes(CANONICAL);
 
     // project-specific options
     indents = sopts.get(INDENTS);

--- a/basex-core/src/main/java/org/basex/io/serial/SerializerOptions.java
+++ b/basex-core/src/main/java/org/basex/io/serial/SerializerOptions.java
@@ -100,6 +100,9 @@ public final class SerializerOptions extends Options {
   /** Serialization parameter: yes/no. */
   public static final EnumOption<YesNo> JSON_LINES =
       new EnumOption<>("json-lines", YesNo.NO);
+  /** Serialization parameter: yes/no. */
+  public static final EnumOption<YesNo> CANONICAL =
+      new EnumOption<>("canonical", YesNo.NO);
 
   /** Specific serialization parameter. */
   public static final OptionsOption<CsvOptions> CSV =

--- a/basex-core/src/main/java/org/basex/io/serial/json/JsonSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/json/JsonSerializer.java
@@ -5,6 +5,7 @@ import static org.basex.util.Token.*;
 import static org.basex.util.Token.normalize;
 
 import java.io.*;
+import java.util.*;
 
 import org.basex.build.json.*;
 import org.basex.io.out.PrintOutput.*;
@@ -16,8 +17,10 @@ import org.basex.query.value.array.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.map.*;
 import org.basex.query.value.type.*;
+import org.basex.util.*;
 import org.basex.util.hash.*;
 import org.basex.util.options.Options.*;
+import org.erdtman.jcs.*;
 
 /**
  * Abstract JSON serializer class.
@@ -66,7 +69,7 @@ public abstract class JsonSerializer extends StandardSerializer {
     super(os, sopts);
     jopts = sopts.get(SerializerOptions.JSON);
     escape = jopts.get(JsonSerialOptions.ESCAPE);
-    escapeSolidus = escape && jopts.get(JsonSerialOptions.ESCAPE_SOLIDUS) &&
+    escapeSolidus = escape && !canonical && jopts.get(JsonSerialOptions.ESCAPE_SOLIDUS) &&
         sopts.get(SerializerOptions.ESCAPE_SOLIDUS) == YesNo.YES;
     nodups = sopts.get(SerializerOptions.ALLOW_DUPLICATE_NAMES) == YesNo.NO;
     lines = sopts.get(SerializerOptions.JSON_LINES) == YesNo.YES;
@@ -108,7 +111,7 @@ public abstract class JsonSerializer extends StandardSerializer {
 
         boolean s = false;
         final TokenSet set = nodups ? new TokenSet() : null;
-        for(final Item key : map.keys()) {
+        for(final Item key : keys(map)) {
           final byte[] name = key.string(null);
           if(nodups) {
             if(set.contains(name)) throw SERDUPL_X.getIO(name);
@@ -150,14 +153,41 @@ public abstract class JsonSerializer extends StandardSerializer {
     sep = true;
   }
 
+  /**
+   * Returns the keys of the given map, in canonical order, if required. Per RFC8785, "property name
+   * strings to be sorted are formatted as arrays of UTF-16 [UNICODE] code units. The sorting is
+   * based on pure value comparisons, where code units are treated as unsigned integers, independent
+   * of locale settings". This is achieved here by sorting the keys as strings.
+   * @param map map
+   * @return keys
+   * @throws QueryException query exception
+   */
+  private Iterable<Item> keys(final XQMap map) throws QueryException {
+    final Iterable<Item> ks = map.keys();
+    if(!canonical) return ks;
+    record Key(String string, Item item) { }
+    final ArrayList<Key> list = new ArrayList<>();
+    for(final Item k : ks) list.add(new Key(Token.string(k.string(null)), k));
+    list.sort(Comparator.comparing(Key::string));
+    return () -> new Iterator<>() {
+      private final Iterator<Key> it = list.iterator();
+      @Override public boolean hasNext() { return it.hasNext(); }
+      @Override public Item next() { return it.next().item(); }
+    };
+  }
+
   @Override
   protected void atomic(final Item item) throws IOException {
     try {
       final Type type = item.type;
-      if(type.oneOf(AtomType.DOUBLE, AtomType.FLOAT)) {
+      if(type.oneOf(AtomType.DOUBLE, AtomType.FLOAT) || canonical && type.isNumber()) {
         final double d = item.dbl(null);
         if(!Double.isFinite(d)) throw SERNUMBER_X.getIO(d);
-        out.print(Dbl.string(d));
+        if(canonical) {
+          out.print(NumberToJSON.serializeNumber(d));
+        } else {
+          out.print(Dbl.string(d));
+        }
       } else if(type == AtomType.BOOLEAN || type.isNumber()) {
         out.print(item.string(null));
       } else {

--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -854,6 +854,10 @@ public enum QueryError {
   SERJSON(SERE, 23, "Only one item can be serialized with JSON."),
   /** Error code. */
   SERJSONSEQ(SERE, 23, "Value has more than one item."),
+  /** Error code. */
+  SERRELURI(SERE, 24, "Canonical XML serialization failed: found relative namespace URI: '%'"),
+  /** Error code. */
+  SERWELLFORM_X(SERE, 24, "Canonical XML serialization failed: not wellformed: '%'"),
 
   /** Error code. */
   NOCTX_X(XPDY, 2, "%: Context value is undefined."),

--- a/basex-core/src/main/java/org/basex/util/Token.java
+++ b/basex-core/src/main/java/org/basex/util/Token.java
@@ -750,6 +750,21 @@ public final class Token {
   }
 
   /**
+   * Compares a substring of two tokens lexicographically.
+   * @param token first token
+   * @param tFrom the index (inclusive) of the first element in the first token to be compared
+   * @param tTo the index (exclusive) of the last element in the first token to be compared
+   * @param compare token to be compared
+   * @param cFrom the index (inclusive) of the first element in the second token to be compared
+   * @param cTo the index (exclusive) of the last element in the second token to be compared
+   * @return result of comparison (-1, 0, 1)
+   */
+  public static int compare(final byte[] token, final int tFrom, final int tTo,
+      final byte[] compare, final int cFrom, final int cTo)  {
+    return Integer.signum(Arrays.compareUnsigned(token, tFrom, tTo, compare, cFrom, cTo));
+  }
+
+  /**
    * Compares two tokens lexicographically.
    * @param token first token
    * @param compare token to be compared

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,12 @@
         <scope>provided</scope>
         <optional>true</optional>
       </dependency>
+      <dependency>
+        <groupId>io.github.erdtman</groupId>
+        <artifactId>java-json-canonicalization</artifactId>
+        <version>1.1</version>
+        <scope>runtime</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This PR adds support for canonical serialization of XML, XHTML, and JSON.

For XML/XHTML, canonicalization includes deterministic ordering of namespace declarations and attributes, validation of namespace URIs, and whitespace normalization on document level.

For JSON, object member names are serialized in canonical order as defined by [RFC 8785](https://www.ietf.org/rfc/rfc8785.txt) (JSON Canonicalization Scheme, JCS), and numbers are serialized in canonical form. The latter is accomplished by adding a dependency on [`io.github.erdtman:java-json-canonicalization`](https://github.com/erdtman/java-json-canonicalization), which was written by a co-author of RFC 8785. This adds a 28 KB JAR to the BaseX distribution.

This fixes all of the serialization QT4 tests that use option `canonical`.