### PR TITLE
`RecordType` updates

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/constr/CMap.java
+++ b/basex-core/src/main/java/org/basex/query/expr/constr/CMap.java
@@ -127,8 +127,7 @@ public final class CMap extends Arr {
     } else if(expr instanceof CRecord) {
       // { 'a': <a/> }
       final RecordType rt = (RecordType) expr.seqType().type;
-      final boolean extensible = rt.isExtensible();
-      if(extensible || rt.hasOptional()) return false;
+      if(rt.hasOptional()) return false;
       final TokenObjectMap<RecordField> fields = rt.fields();
       final int fs = fields.size();
       for(int f = 1; f <= fs; f++) list.add(Str.get(fields.key(f))).add(expr.arg(f - 1));

--- a/basex-core/src/main/java/org/basex/query/expr/constr/CRecord.java
+++ b/basex-core/src/main/java/org/basex/query/expr/constr/CRecord.java
@@ -38,8 +38,7 @@ public final class CRecord extends Arr {
   @Override
   public XQMap item(final QueryContext qc, final InputInfo ii) throws QueryException {
     final RecordType rt = (RecordType) seqType().type;
-    final boolean extensible = rt.isExtensible();
-    if(extensible || rt.hasOptional()) {
+    if(rt.hasOptional()) {
       final MapBuilder mb = new MapBuilder(exprs.length);
       final TokenObjectMap<RecordField> fields = rt.fields();
       final int fs = fields.size();
@@ -51,11 +50,6 @@ public final class CRecord extends Arr {
           if(rf.isOptional() && rf.expr() == null) add = false;
         }
         if(add) mb.put(fields.key(f), value);
-      }
-      if(extensible) {
-        toMap(arg(fs), qc).forEach((k, v) -> {
-          if(!mb.contains(k)) mb.put(k, v);
-        });
       }
       return mb.map();
     }
@@ -70,7 +64,7 @@ public final class CRecord extends Arr {
   @Override
   public long structSize() {
     final RecordType rt = (RecordType) seqType().type;
-    return rt.isExtensible() || rt.hasOptional() ? -1 : exprs.length;
+    return rt.hasOptional() ? -1 : exprs.length;
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/func/Records.java
+++ b/basex-core/src/main/java/org/basex/query/func/Records.java
@@ -16,36 +16,36 @@ import org.basex.util.hash.*;
  */
 public enum Records {
   /** Record definition. */
-  DIVIDED_DECIMALS("divided-decimals", false,
+  DIVIDED_DECIMALS("divided-decimals",
     field("quotient", Types.DECIMAL_O),
     field("remainder", Types.DECIMAL_O)
   ),
   /** Record definition. */
-  INFER_ENCODING("infer-encoding", false,
+  INFER_ENCODING("infer-encoding",
     field("encoding", Types.STRING_O, false),
     field("offset", Types.INTEGER_O, false)
   ),
   /** Record definition. */
-  LOAD_XQUERY_MODULE("load-xquery-module", false,
+  LOAD_XQUERY_MODULE("load-xquery-module",
     field("variables", MapType.get(BasicType.QNAME, Types.ITEM_ZO).seqType()),
     field("functions", MapType.get(BasicType.QNAME,
       MapType.get(BasicType.INTEGER, Types.FUNCTION_O).seqType()).seqType())),
   /** Record definition. */
-  MEMBER("member", false,
+  MEMBER("member",
     field("value", Types.ITEM_ZM)),
   /** Record definition. */
-  PARSED_CSV_STRUCTURE("parsed-csv-structure", false,
+  PARSED_CSV_STRUCTURE("parsed-csv-structure",
     field("columns", Types.STRING_ZM),
     field("column-index", MapType.get(BasicType.STRING, Types.INTEGER_O).seqType(Occ.ZERO_OR_ONE)),
     field("rows", ArrayType.get(Types.STRING_O).seqType(Occ.ZERO_OR_MORE)),
     field("get", FuncType.get(Types.STRING_O, Types.POSITIVE_INTEGER_O,
       ChoiceItemType.get(Types.POSITIVE_INTEGER_O, Types.STRING_O).seqType()).seqType())),
   /** Record definition. */
-  RANDOM_NUMBER_GENERATOR("random-number-generator", true),
+  RANDOM_NUMBER_GENERATOR("random-number-generator"),
   /** Record definition. */
-  SCHEMA_TYPE("schema-type", true),
+  SCHEMA_TYPE("schema-type"),
   /** Record definition. */
-  URI_STRUCTURE("uri-structure", true,
+  URI_STRUCTURE("uri-structure",
     field("uri", Types.STRING_ZO, true),
     field("scheme", Types.STRING_ZO, true),
     field("absolute", Types.BOOLEAN_ZO, true),
@@ -111,16 +111,15 @@ public enum Records {
   /**
    * Constructor.
    * @param name name of record
-   * @param extensible extensible flag
    * @param fields field declarations
    */
-  Records(final String name, final boolean extensible, final NamedRecordField... fields) {
+  Records(final String name, final NamedRecordField... fields) {
     final TokenObjectMap<RecordField> map = new TokenObjectMap<>(fields.length);
     for(final NamedRecordField field : fields) {
       map.put(field.name, field.field);
     }
     final QNm qnm = new QNm(name + "-record", QueryText.FN_URI);
-    type = new RecordType(map, extensible, qnm, AnnList.EMPTY);
+    type = new RecordType(map, qnm, AnnList.EMPTY);
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/func/map/MapContains.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapContains.java
@@ -37,7 +37,7 @@ public final class MapContains extends MapFn {
       if(mti.field != null) {
         if(!mti.field.isOptional()) return Bln.TRUE;
       } else if(mti.validKey) {
-        if(!mti.record.isExtensible()) return Bln.FALSE;
+        return Bln.FALSE;
       }
       if(mti.mapType != null) {
         // map:contains({ 1: 1 }, 'string') → false()

--- a/basex-core/src/main/java/org/basex/query/func/map/MapFn.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapFn.java
@@ -23,6 +23,6 @@ abstract class MapFn extends StandardFunc {
   @Override
   public long structSize() {
     return seqType().type instanceof final RecordType rt &&
-        !rt.isExtensible() && !rt.hasOptional() ? rt.fields().size() : -1;
+        !rt.hasOptional() ? rt.fields().size() : -1;
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapGet.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapGet.java
@@ -42,7 +42,7 @@ public final class MapGet extends MapFn {
       st = mti.field.seqType();
     } else if(mti.validKey) {
       // map:get({ 'a': 1 }, 'b') → ()
-      if(!mti.record.isExtensible()) notFound = true;
+      notFound = true;
     }
 
     if(mti.mapType != null) {

--- a/basex-core/src/main/java/org/basex/query/func/map/MapPut.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapPut.java
@@ -46,10 +46,7 @@ public final class MapPut extends MapFn {
         tp = mti.record.copy(null, mti.key, vt.union(ft), cc);
       }
     } else if(mti.validKey) {
-      if(mti.record.isExtensible()) {
-        // structure does not change: propagate record type
-        tp = mti.record;
-      } else if(mti.key != null && mti.record.fields().size() < RecordType.MAX_GENERATED_SIZE) {
+      if(mti.key != null && mti.record.fields().size() < RecordType.MAX_GENERATED_SIZE) {
         // otherwise, derive new record type
         tp = mti.record.copy(null, mti.key, value.seqType(), cc);
       }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapRemove.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapRemove.java
@@ -41,14 +41,12 @@ public final class MapRemove extends MapFn {
         // otherwise, derive new record type
         final RecordType rt = mti.record.copy(mti.key, null, null, cc);
         // return empty map if it will contain no entries
-        if(rt != null && rt.fields().isEmpty() && !rt.isExtensible()) return XQMap.empty();
+        if(rt != null && rt.fields().isEmpty()) return XQMap.empty();
         tp = rt;
       }
     } else if(mti.validKey) {
       // return input map if nothing changes: map:remove({ 'a': 1 }, 'b') → { 'a': 1 }
-      if(!mti.record.isExtensible()) return map;
-      // structure does not change: propagate record type
-      tp = mti.record;
+      return map;
     }
 
     if(tp == null && mti.mapType != null) {

--- a/basex-core/src/main/java/org/basex/query/value/map/XQMap.java
+++ b/basex-core/src/main/java/org/basex/query/value/map/XQMap.java
@@ -205,7 +205,7 @@ public abstract class XQMap extends XQStruct {
               !Token.eq(fields.key(f), key.string(null)) ||
               st != Types.ITEM_ZM && !st.instance(getOrNull(key))) return false;
           }
-          return keys.next() == null || rt.isExtensible();
+          return keys.next() == null;
         }
 
         for(int f = 1; f <= fs; f++) {
@@ -213,11 +213,9 @@ public abstract class XQMap extends XQStruct {
           final Value value = getOrNull(Str.get(fields.key(f)));
           if(value != null ? !rf.seqType().instance(value) : !rf.isOptional()) return false;
         }
-        if(!rt.isExtensible()) {
-          for(final Item key : keys()) {
-            if(!key.type.instanceOf(BasicType.STRING) || !fields.contains(key.string(null)))
-              return false;
-          }
+        for(final Item key : keys()) {
+          if(!key.type.instanceOf(BasicType.STRING) || !fields.contains(key.string(null)))
+            return false;
         }
         return true;
       }
@@ -331,16 +329,6 @@ public abstract class XQMap extends XQStruct {
       } else if(!rf.isOptional()) {
         throw typeError(this, rt, ii);
       }
-    }
-    // add remaining values
-    if(mb.size() < ms) {
-      if(!rt.isExtensible()) throw typeError(this, rt, ii);
-      forEach((key, value) -> {
-        if(!mb.contains(key)) {
-          qc.checkStop();
-          mb.put(key, value);
-        }
-      });
     }
 
     // assign record type to speed up future type checks

--- a/basex-core/src/main/java/org/basex/query/value/type/MapType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/MapType.java
@@ -122,7 +122,7 @@ public class MapType extends FType {
 
   @Override
   public boolean instanceOf(final Type type) {
-    if(this == type || type.oneOf(RECORD, MAP, FUNCTION, BasicType.ITEM)) return true;
+    if(this == type || type.oneOf(MAP, FUNCTION, BasicType.ITEM)) return true;
     if(type instanceof RecordType) return false;
     if(type instanceof final MapType mt) {
       return this != MAP && valueType.instanceOf(mt.valueType) && keyType.instanceOf(mt.keyType);

--- a/basex-core/src/main/java/org/basex/query/value/type/RecordType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/RecordType.java
@@ -26,8 +26,6 @@ public final class RecordType extends MapType {
   /** Maximum size for generated record definitions. */
   public static final int MAX_GENERATED_SIZE = 32;
 
-  /** Extensible flag. */
-  private boolean extensible;
   /** Record fields. */
   private TokenObjectMap<RecordField> fields;
   /** Record type name (can be {@code null}). */
@@ -38,34 +36,21 @@ public final class RecordType extends MapType {
   private InputInfo info;
 
   /**
-   * Constructor for non-extensible record type.
+   * Constructor.
    * @param fields field declarations
    */
   public RecordType(final TokenObjectMap<RecordField> fields) {
-    this(fields, false);
+    this(fields, null, AnnList.EMPTY);
   }
 
   /**
    * Constructor.
    * @param fields field declarations
-   * @param extensible extensible flag
-   */
-  public RecordType(final TokenObjectMap<RecordField> fields, final boolean extensible) {
-    this(fields, extensible, null, AnnList.EMPTY);
-  }
-
-  /**
-   * Constructor.
-   * @param fields field declarations
-   * @param extensible extensible flag
    * @param name record type name (can be {@code null})
    * @param anns annotations
    */
-  public RecordType(final TokenObjectMap<RecordField> fields, final boolean extensible,
-      final QNm name, final AnnList anns) {
-    super(extensible ? BasicType.ANY_ATOMIC_TYPE : BasicType.STRING,
-        extensible ? Types.ITEM_ZM : unionType(fields));
-    this.extensible = extensible;
+  public RecordType(final TokenObjectMap<RecordField> fields, final QNm name, final AnnList anns) {
+    super(BasicType.STRING, unionType(fields));
     this.fields = fields;
     this.name = name;
     this.anns = anns;
@@ -81,7 +66,6 @@ public final class RecordType extends MapType {
     super(BasicType.ANY_ATOMIC_TYPE, Types.ITEM_ZM, false);
     this.name = name;
     this.info = info;
-    extensible = true;
     fields = new TokenObjectMap<>(0);
     anns = AnnList.EMPTY;
   }
@@ -120,14 +104,6 @@ public final class RecordType extends MapType {
    */
   public TokenObjectMap<RecordField> fields() {
     return fields;
-  }
-
-  /**
-   * Indicates if this record type is extensible.
-   * @return result of check
-   */
-  public boolean isExtensible() {
-    return extensible;
   }
 
   /**
@@ -193,7 +169,7 @@ public final class RecordType extends MapType {
   private boolean eq(final Type type, final Set<Pair> pairs, final boolean strict) {
     if(this == type) return true;
     if(!(type instanceof final RecordType rt)) return false;
-    if(extensible != rt.extensible || fields.size() != rt.fields.size()) return false;
+    if(fields.size() != rt.fields.size()) return false;
 
     final Predicate<byte[]> compareFields = key -> {
       final RecordField rf1 = fields.get(key), rf2 = rt.fields.get(key);
@@ -235,7 +211,7 @@ public final class RecordType extends MapType {
    * @return result of check
    */
   private boolean instanceOf(final Type type, final Set<Pair> pairs) {
-    if(this == type || type.oneOf(Types.RECORD, Types.MAP, Types.FUNCTION, BasicType.ITEM)) {
+    if(this == type || type.oneOf(Types.MAP, Types.FUNCTION, BasicType.ITEM)) {
       return true;
     }
     if(type instanceof final ChoiceItemType cit) {
@@ -245,11 +221,8 @@ public final class RecordType extends MapType {
       return false;
     }
     if(type instanceof final RecordType rt) {
-      if(!rt.extensible) {
-        if(extensible) return false;
-        for(final byte[] key : fields) {
-          if(!rt.fields.contains(key)) return false;
-        }
+      for(final byte[] key : fields) {
+        if(!rt.fields.contains(key)) return false;
       }
       for(final byte[] key : rt.fields) {
         final RecordField rtf = rt.fields.get(key);
@@ -272,7 +245,7 @@ public final class RecordType extends MapType {
               }
             }
           }
-        } else if(!rtf.optional || extensible && rtf.seqType() != Types.ITEM_ZM) {
+        } else if(!rtf.optional) {
           return false;
         }
       }
@@ -325,7 +298,7 @@ public final class RecordType extends MapType {
           if(ft instanceof final RecordType rt1 && rtft instanceof final RecordType rt2 &&
               !fst.zero() && !rtfst.zero()) {
             final Pair pair = new Pair(rt1, rt2);
-            if(pairs.contains(pair)) return Types.RECORD;
+            if(pairs.contains(pair)) return Types.MAP;
             union = SeqType.get(rt1.union(rt2, pair.addTo(pairs)), fst.occ.union(rtfst.occ));
           } else {
             union = fst.union(rtfst);
@@ -342,7 +315,7 @@ public final class RecordType extends MapType {
           map.put(key, new RecordField(rt.fields.get(key).seqType, true));
         }
       }
-      return new RecordType(map, extensible || rt.extensible);
+      return new RecordType(map);
     }
     return type instanceof final MapType mt ? mt.union(keyType(), valueType()) :
            type instanceof ArrayType ? Types.FUNCTION :
@@ -381,19 +354,16 @@ public final class RecordType extends MapType {
           map.put(key, new RecordField(is, f.optional && rtf.optional));
         } else {
           // field missing in type
-          if(!rt.extensible) return null;
-          map.put(key, new RecordField(f.seqType, f.optional));
+          return null;
         }
       }
       for(final byte[] key : rt.fields) {
         if(!fields.contains(key)) {
           // field missing in this RecordType
-          if(!extensible) return null;
-          final RecordField rtf = rt.fields.get(key);
-          map.put(key, new RecordField(rtf.seqType, rtf.optional));
+          return null;
         }
       }
-      return new RecordType(map, extensible && rt.extensible);
+      return new RecordType(map);
     }
     if(type instanceof final MapType mt) {
       if(mt.keyType().intersect(BasicType.STRING) == null) return null;
@@ -404,7 +374,7 @@ public final class RecordType extends MapType {
         if(is == null) return null;
         map.put(key, new RecordField(is, f.optional));
       }
-      return new RecordType(map, extensible);
+      return new RecordType(map);
     }
     return null;
   }
@@ -447,7 +417,7 @@ public final class RecordType extends MapType {
     if(put != null) map.put(put, new RecordField(seqType));
 
     return map.size() > MAX_GENERATED_SIZE ? null :
-      cc.qc.shared.record(new RecordType(map, extensible));
+      cc.qc.shared.record(new RecordType(map));
   }
 
   @Override
@@ -456,16 +426,13 @@ public final class RecordType extends MapType {
 
     final QueryString qs = new QueryString().token(RECORD).token('(');
     final TokenBuilder tb = new TokenBuilder();
-    if(this == Types.RECORD) {
-      tb.add('*');
-    } else {
+    if(this != Types.RECORD) {
       for(final byte[] key : fields) {
         if(!tb.isEmpty()) tb.add(", ");
         if(!tb.moreInfo()) break;
         tb.add(XMLToken.isNCName(key) ? key : QueryString.toQuoted(key));
         if(fields.get(key).optional) tb.add('?');
       }
-      if(extensible) tb.add(", *");
     }
     return qs.token(tb.finish()).token(')').toString();
   }
@@ -482,7 +449,6 @@ public final class RecordType extends MapType {
     for(final QNm name : recordTypeRefs) {
       final RecordType ref = recordTypeRefs.get(name);
       final RecordType dec = ref.getDeclaration(declaredRecordTypes);
-      ref.extensible = dec.extensible;
       ref.fields = dec.fields;
       ref.info = null;
       ref.finalizeTypes(dec.keyType(), dec.valueType());

--- a/basex-core/src/main/java/org/basex/query/value/type/Types.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/Types.java
@@ -236,9 +236,9 @@ public final class Types {
   public static final EnumType SCHEMA_TYPE_RECORD_VARIETY =
       EnumType.get("atomic", "list", "union", "empty", "simple", "element-only", "mixed");
 
-  /** The general record type. */
-  public static final RecordType RECORD = new RecordType(new TokenObjectMap<>(0), true);
-  /** Single record. */
+  /** The empty record type. */
+  public static final RecordType RECORD = new RecordType(new TokenObjectMap<>(0));
+  /** Single empty record. */
   public static final SeqType RECORD_O = RECORD.seqType();
 
   /** Indexed item types. */

--- a/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
+++ b/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
@@ -322,7 +322,7 @@ public final class SeqTypeTest {
     RecordType.resolveRefs(recordTypeRefs, declaredRecordTypes);
 
     assertTrue(RECORD_O.instanceOf(FUNCTION_O));
-    assertTrue(MAP_O.instanceOf(RECORD_O));
+    assertFalse(MAP_O.instanceOf(RECORD_O));
     assertTrue(RECORD_O.instanceOf(MAP_O));
     assertTrue(r1.instanceOf(r2));
     assertTrue(r2.instanceOf(r1));
@@ -498,25 +498,26 @@ public final class SeqTypeTest {
     final TokenObjectMap<RecordField> fld1 = new TokenObjectMap<>(),
         fld2 = new TokenObjectMap<>(),
         fld3 = new TokenObjectMap<>(),
-        fld4 = new TokenObjectMap<>(),
         fld5 = new TokenObjectMap<>(),
         fld6 = new TokenObjectMap<>(),
         fld7 = new TokenObjectMap<>(),
         fld8 = new TokenObjectMap<>(),
         fld9 = new TokenObjectMap<>(),
-        fld10 = new TokenObjectMap<>();
+        fld10 = new TokenObjectMap<>(),
+        fld11 = new TokenObjectMap<>();
     fld1.put(Token.token("a"), new RecordField(INTEGER_O));
     fld2.put(Token.token("a"), new RecordField(STRING_O));
     fld3.put(Token.token("a"), new RecordField(ANY_ATOMIC_TYPE_O));
-    fld4.put(Token.token("a"), new RecordField(INTEGER_O));
     fld5.put(Token.token("a"), new RecordField(INTEGER_O, true));
     fld6.put(Token.token("b"), new RecordField(INTEGER_O, true));
     fld7.put(Token.token("a"), new RecordField(INTEGER_O, true));
     fld7.put(Token.token("b"), new RecordField(INTEGER_O, true));
-    fld10.put(Token.token("next"), new RecordField(RECORD_O, true));
+    fld10.put(Token.token("next"), new RecordField(MAP_O, true));
     fld10.put(Token.token("x"), new RecordField(ITEM_ZM));
     fld10.put(Token.token("y"), new RecordField(ITEM_ZM, true));
     fld10.put(Token.token("z"), new RecordField(ITEM_ZM, true));
+    fld11.put(Token.token("a"), new RecordField(STRING_O, true));
+    fld11.put(Token.token("b"), new RecordField(INTEGER_O, true));
     final QNm r8Name = new QNm(Token.token("r8")),
       r9Name = new QNm(Token.token("r9"));
     final InputInfo ii = new InputInfo(getClass().getName(), 1, 1);
@@ -527,20 +528,20 @@ public final class SeqTypeTest {
       r2 = SeqType.get(new RecordType(fld2), EXACTLY_ONE),
       // record(a as xs:anyAtomicType)
       r3 = SeqType.get(new RecordType(fld3), EXACTLY_ONE),
-      // record(a as xs:integer, *)
-      r4 = SeqType.get(new RecordType(fld4, true), EXACTLY_ONE),
-      // record(a as xs:integer?, *)
-      r5 = SeqType.get(new RecordType(fld5, true), EXACTLY_ONE),
-      // record(b as xs:integer?, *)
-      r6 = SeqType.get(new RecordType(fld6, true), EXACTLY_ONE),
-      // record(b as xs:integer?, *)
-      r7 = SeqType.get(new RecordType(fld7, true), EXACTLY_ONE),
+      // record(a as xs:integer?)
+      r5 = SeqType.get(new RecordType(fld5), EXACTLY_ONE),
+      // record(b as xs:integer?)
+      r6 = SeqType.get(new RecordType(fld6), EXACTLY_ONE),
+      // record(a as xs:integer?, b as xs:integer?)
+      r7 = SeqType.get(new RecordType(fld7), EXACTLY_ONE),
       // r8 record(next? as r8, x, y)
       r8 = SeqType.get(new RecordType(r8Name, ii), EXACTLY_ONE),
-      // r9 record(next? as r8, x, z)
+      // r9 record(next? as r9, x, z)
       r9 = SeqType.get(new RecordType(r9Name, ii), EXACTLY_ONE),
-      // r10 record(next? as record(*), x, y, z)
-      r10 = SeqType.get(new RecordType(fld10), EXACTLY_ONE);
+      // record(next? as map(*), x, y?, z?)
+      r10 = SeqType.get(new RecordType(fld10), EXACTLY_ONE),
+      // record(a? as xs:string, b? as xs:integer)
+      r11 = SeqType.get(new RecordType(fld11), EXACTLY_ONE);
 
     fld8.put(Token.token("next"), new RecordField(r8, true));
     fld8.put(Token.token("x"), new RecordField(ITEM_ZM));
@@ -560,17 +561,15 @@ public final class SeqTypeTest {
 
     combine(RECORD_O, FUNCTION_O, FUNCTION_O, op);
     combine(RECORD_O, MAP_O, MAP_O, op);
-    combine(RECORD_O, r1, RECORD_O, op);
+    combine(RECORD_O, r1, r5, op);
     combine(FUNCTION_O, r1, FUNCTION_O, op);
     combine(MAP_O, r1, MAP_O, op);
     combine(r1, r2, r3, op);
     combine(r1, r3, r3, op);
-    combine(r4, r1, r4, op);
+    combine(r1, r1, r1, op);
     combine(r5, r1, r5, op);
-    combine(r5, r4, r5, op);
-    combine(r1, r6, r6, op);
-    combine(r2, r6, r6, op);
-    combine(r4, r6, r7, op);
+    combine(r1, r6, r7, op);
+    combine(r2, r6, r11, op);
     combine(r5, r6, r7, op);
     combine(r8, r9, r10, op);
   }
@@ -761,7 +760,6 @@ public final class SeqTypeTest {
     final TokenObjectMap<RecordField> fld1 = new TokenObjectMap<>(),
         fld2 = new TokenObjectMap<>(),
         fld3 = new TokenObjectMap<>(),
-        fld4 = new TokenObjectMap<>(),
         fld5 = new TokenObjectMap<>(),
         fld6 = new TokenObjectMap<>(),
         fld7 = new TokenObjectMap<>(),
@@ -771,7 +769,6 @@ public final class SeqTypeTest {
     fld1.put(Token.token("a"), new RecordField(INTEGER_O));
     fld2.put(Token.token("a"), new RecordField(STRING_O));
     fld3.put(Token.token("a"), new RecordField(ANY_ATOMIC_TYPE_O));
-    fld4.put(Token.token("a"), new RecordField(INTEGER_O));
     fld5.put(Token.token("a"), new RecordField(INTEGER_O, true));
     fld6.put(Token.token("b"), new RecordField(INTEGER_O, true));
     fld7.put(Token.token("a"), new RecordField(INTEGER_O));
@@ -788,20 +785,14 @@ public final class SeqTypeTest {
       r2 = SeqType.get(new RecordType(fld2), EXACTLY_ONE),
       // record(a as xs:anyAtomicType)
       r3 = SeqType.get(new RecordType(fld3), EXACTLY_ONE),
-      // record(a as xs:integer, *)
-      r4 = SeqType.get(new RecordType(fld4, true), EXACTLY_ONE),
-      // record(a as xs:integer?, *)
-      r5 = SeqType.get(new RecordType(fld5, true), EXACTLY_ONE),
-      // record(b as xs:integer?, *)
-      r6 = SeqType.get(new RecordType(fld6, true), EXACTLY_ONE),
-      // record(a as xs:integer, b as xs:integer?, *)
-      r7 = SeqType.get(new RecordType(fld7, true), EXACTLY_ONE),
+      // record(a? as xs:integer)
+      r5 = SeqType.get(new RecordType(fld5), EXACTLY_ONE),
+      // record(b? as xs:integer)
+      r6 = SeqType.get(new RecordType(fld6), EXACTLY_ONE),
       // r8 record(next? as r8, x, y)
       r8 = SeqType.get(new RecordType(r8Name, ii), EXACTLY_ONE),
-      // r9 record(next? as r8, x, z)
-      r9 = SeqType.get(new RecordType(r9Name, ii), EXACTLY_ONE),
-      // record(a as xs:integer?, b as xs:integer?, *)
-      r10 = SeqType.get(new RecordType(fld10, true), EXACTLY_ONE);
+      // r9 record(next? as r9, x, z)
+      r9 = SeqType.get(new RecordType(r9Name, ii), EXACTLY_ONE);
 
     fld8.put(Token.token("next"), new RecordField(r8, true));
     fld8.put(Token.token("x"), new RecordField(ITEM_ZM));
@@ -821,18 +812,16 @@ public final class SeqTypeTest {
 
     combine(RECORD_O, FUNCTION_O, RECORD_O, op);
     combine(RECORD_O, MAP_O, RECORD_O, op);
-    combine(RECORD_O, r1, r1, op);
+    combine(RECORD_O, r1, null, op);
     combine(FUNCTION_O, r1, r1, op);
     combine(MAP_O, r1, r1, op);
     combine(r1, r2, null, op);
     combine(r1, r3, r1, op);
-    combine(r4, r1, r1, op);
+    combine(r1, r1, r1, op);
     combine(r5, r1, r1, op);
-    combine(r5, r4, r4, op);
-    combine(r1, r6, r1, op);
-    combine(r2, r6, r2, op);
-    combine(r4, r6, r7, op);
-    combine(r5, r6, r10, op);
+    combine(r1, r6, null, op);
+    combine(r2, r6, null, op);
+    combine(r5, r6, null, op);
     combine(r8, r9, null, op);
   }
 
@@ -856,23 +845,6 @@ public final class SeqTypeTest {
     assertFalse(DATE_TIME_O.mayBeNumber());
     assertFalse(DATE_TIME_STAMP_O.mayBeNumber());
     assertFalse(ERROR_O.mayBeNumber());
-
-    assertTrue(ITEM_O.mayBeFunction());
-    assertTrue(FUNCTION_O.mayBeFunction());
-    assertTrue(MAP_O.mayBeFunction());
-    assertTrue(ARRAY_O.mayBeFunction());
-    assertTrue(RECORD_O.mayBeFunction());
-    assertFalse(ANY_ATOMIC_TYPE_O.mayBeFunction());
-    assertFalse(NUMERIC_O.mayBeFunction());
-    assertFalse(INTEGER_O.mayBeFunction());
-    assertFalse(BYTE.seqType().mayBeFunction());
-    assertFalse(STRING_O.mayBeFunction());
-    assertFalse(NODE_O.mayBeFunction());
-    assertFalse(ELEMENT_O.mayBeFunction());
-    assertFalse(NMTOKENS_O.mayBeFunction());
-    assertFalse(DATE_TIME_O.mayBeFunction());
-    assertFalse(DATE_TIME_STAMP_O.mayBeFunction());
-    assertFalse(ERROR_O.mayBeFunction());
 
     assertTrue(ITEM_O.mayBeFunction());
     assertTrue(FUNCTION_O.mayBeFunction());

--- a/basex-core/src/test/java/org/basex/query/expr/RecordTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/RecordTest.java
@@ -28,9 +28,9 @@ public final class RecordTest extends SandboxTest {
     query("{ 'x': () } instance of record(x)", true);
     query("{} instance of record(x)", false);
 
-    query("{ 'x': (), 'y': () } instance of record(x, *)", true);
+    query("{ 'x': (), 'y': () } instance of record(x, y?)", true);
     query("{ 'x': (), 'y': () } instance of record(x)", false);
-    query("{ 'x': (), 0: () } instance of record(x, *)", true);
+    query("{ 'x': (), 0: () } instance of record(x, y?)", false);
     query("{ 'x': (), 0: () } instance of record(x)", false);
 
     query("declare record local:coord(x, y); "
@@ -130,9 +130,9 @@ public final class RecordTest extends SandboxTest {
         + "cx:complex(3, 2), cx:complex(3)",
         "{\"r\":3,\"i\":2}\n{\"r\":3,\"i\":()}");
     query("declare namespace p = 'P'\n;"
-        + "declare record p:person(first as xs:string, last as xs:string, *);\n"
-        + "p:person('John', 'Smith', { 'last': 'Miller', 'middle': 'A.' })",
-        "{\"first\":\"John\",\"last\":\"Smith\",\"middle\":\"A.\"}");
+        + "declare record p:person(first as xs:string, last as xs:string);\n"
+        + "p:person('John', 'Smith')",
+        "{\"first\":\"John\",\"last\":\"Smith\"}");
     // recursive record type constructor function
     query("declare function local:f($x, $y) {local:list($x, $y)};\n"
         + "declare record local:list (value as item()*, next? as local:list);\n"
@@ -197,17 +197,6 @@ public final class RecordTest extends SandboxTest {
     check("declare record local:x(x); local:x(1) => map:remove(1)", "{\"x\":1}",
         empty(func));
 
-    check("declare record local:x(x, *); local:x(1) => map:remove('x')", "{}",
-        type(func, "record(*)"));
-    check("declare record local:x(x, *); local:x(1) => map:remove(<_>x</_>)", "{}",
-        type(func, "record(*)"));
-    check("declare record local:x(x, *); local:x(1) => map:remove('y')", "{\"x\":1}",
-        type(func, "local:x"));
-    check("declare record local:x(x, *); local:x(1) => map:remove(<_>y</_>)", "{\"x\":1}",
-        type(func, "local:x"));
-    check("declare record local:x(x, *); local:x(1) => map:remove(1)", "{\"x\":1}",
-        type(func, "local:x"));
-
     check("declare record local:x(x, y?); local:x(1) => map:remove('x')", "{}",
         type(func, "record(y?)"));
     check("declare record local:x(x, y?); local:x(1) => map:remove(<_>x</_>)", "{}",
@@ -238,17 +227,6 @@ public final class RecordTest extends SandboxTest {
 
     check("declare record local:x(x as xs:int); local:x(1) => map:put('x', <x/>)", "{\"x\":<x/>}",
         type(RecordSet.class, "record(x)"));
-
-    check("declare record local:x(x, *); local:x(1) => map:put('x', 2)", "{\"x\":2}",
-        type(RecordSet.class, "local:x"));
-    check("declare record local:x(x, *); local:x(1) => map:put(<_>x</_>, 2)", "{\"x\":2}",
-        type(RecordSet.class, "local:x"));
-    check("declare record local:x(x, *); local:x(1) => map:put('y', 2)", "{\"x\":1,\"y\":2}",
-        type(func, "local:x"));
-    check("declare record local:x(x, *); local:x(1) => map:put(<_>y</_>, 2)", "{\"x\":1,\"y\":2}",
-        type(func, "local:x"));
-    check("declare record local:x(x, *); local:x(1) => map:put(0, 0)", "{\"x\":1,0:0}",
-        type(func, "local:x"));
 
     check("declare record local:x(x, y?); local:x(1) => map:put('x', 2)", "{\"x\":2}",
         type(func, "local:x"));
@@ -295,40 +273,45 @@ public final class RecordTest extends SandboxTest {
   /** Coercion of records. */
   @Test public void coercion() {
     query("let $m as record() := {} return $m", "{}");
-    query("let $m as record(*) := {} return $m", "{}");
-    query("let $m as record(a?) := {} return $m", "{}");
-    query("let $m as record(a?, *) := {} return $m", "{}");
+    query("let $m as record() := { 'a': 1 } return $m", "{}");
+    query("let $m as record() := { 0: 2 } return $m", "{}");
 
-    query("let $m as record(*) := { 'a': 1 } return $m", "{\"a\":1}");
     query("let $m as record(a) := { 'a': 1 } return $m", "{\"a\":1}");
-    query("let $m as record(a, b?) := { 'a': 1 } return $m", "{\"a\":1}");
-    query("let $m as record(a?, b) := { 'b': 2 } return $m", "{\"b\":2}");
-    query("let $m as record(a?, b?, *) := { 'c': 3 } return $m", "{\"c\":3}");
-    query("let $m as record(a, b?, *) := { 'a': 1 } return $m", "{\"a\":1}");
-    query("let $m as record(a?, b, *) := { 'b': 2 } return $m", "{\"b\":2}");
-    query("let $m as record(a, *) := { 'a': 1 } return $m", "{\"a\":1}");
+    query("let $m as record(a) := { 'a': 1, 'b': 2 } return $m", "{\"a\":1}");
+    query("let $m as record(a) := { 'a': 1, 0: 2 } return $m", "{\"a\":1}");
+    query("let $m as record(b) := { 'a': 1, 'b': 2 } return $m", "{\"b\":2}");
+    query("let $m as record(a) := map { xs:untypedAtomic('a'): 1 } return $m", "{\"a\":1}");
 
-    query("let $m as record(a, *) := { 'a': 1, 'b': 2 } return $m", "{\"a\":1,\"b\":2}");
+    query("let $m as record(a?) := {} return $m", "{}");
+    query("let $m as record(b?) := { 'a': 1 } return $m", "{}");
+    query("let $m as record(a?) := map { xs:untypedAtomic('c'): 3 } return $m", "{}");
+
+    query("let $m as record(a, b?) := { 'a': 1 } return $m", "{\"a\":1}");
+    query("let $m as record(a, b?) := { 'c': 3, 'a': 1 } return $m", "{\"a\":1}");
+    query("let $m as record(a?, b) := { 'b': 2 } return $m", "{\"b\":2}");
+    query("let $m as record(b?, a) := { 'c': 3, 'a': 1 } return $m", "{\"a\":1}");
+
     query("let $m as record(a, b) := { 'a': 1, 'b': 2 } return $m", "{\"a\":1,\"b\":2}");
     query("let $m as record(a, b) := { 'b': 2, 'a': 1 } return $m", "{\"a\":1,\"b\":2}");
-    query("let $m as record(a, b, *) := { 'b': 2, 'a': 1 } return $m", "{\"a\":1,\"b\":2}");
-    query("let $m as record(a, b?, *) := { 'c': 3, 'a': 1 } return $m", "{\"a\":1,\"c\":3}");
-    query("let $m as record(b?, a, *) := { 'c': 3, 'a': 1 } return $m", "{\"a\":1,\"c\":3}");
+    query("let $m as record(b, a) := { 'a': 1, 'x': 9, 'b': 2 } return $m", "{\"b\":2,\"a\":1}");
+    query("let $m as record(b, a) := { xs:untypedAtomic('a'): 1, 'b': 2 } return $m",
+        "{\"b\":2,\"a\":1}");
+
+    query("let $m as record(a?, b?) := { 'c': 3 } return $m", "{}");
+    query("let $m as record(a?, b?) := { 'b': 2, 'c': 3 } return $m", "{\"b\":2}");
+    query("let $m as record(a?, b?) := { 'a': 1, 'c': 3 } return $m", "{\"a\":1}");
+    query("let $m as record(b?, a?) := { 'a': 1, 'b': 2, 'x': 9 } return $m", "{\"b\":2,\"a\":1}");
+    query("let $m as record(a?, b?) := map { xs:untypedAtomic('c'): 3 } return $m", "{}");
+
+    query("fn($r as record(a)) { $r } ({ 'a': 1, 'b': 2 })", "{\"a\":1}");
 
     error("let $m as record(a) := {} return $m", INVTYPE_X);
-    error("let $m as record(a?, b) := {} return $m", INVTYPE_X);
-    error("let $m as record(a, b?) := {} return $m", INVTYPE_X);
-
-    error("let $m as record() := { 'a': 1 } return $m", INVTYPE_X);
     error("let $m as record(b) := { 'a': 1 } return $m", INVTYPE_X);
-    error("let $m as record(b?) := { 'a': 1 } return $m", INVTYPE_X);
-    error("let $m as record(b, *) := { 'a': 1 } return $m", INVTYPE_X);
-    error("let $m as record(a?, b?) := { 'c': 3 } return $m", INVTYPE_X);
-    error("let $m as record(a?, b) := { 'c': 3 } return $m", INVTYPE_X);
-    error("let $m as record(a, b?) := { 'c': 3 } return $m", INVTYPE_X);
-    error("let $m as record(c?, b) := { 'c': 3 } return $m", INVTYPE_X);
 
-    error("let $m as record(a) := { 'a': 1, 'b': 2 } return $m", INVTYPE_X);
-    error("let $m as record(b) := { 'a': 1, 'b': 2 } return $m", INVTYPE_X);
+    error("let $m as record(a?, b) := {} return $m", INVTYPE_X);
+    error("let $m as record(a?, b) := { 'c': 3 } return $m", INVTYPE_X);
+    error("let $m as record(a?, b) := { 'a': 1 } return $m", INVTYPE_X);
+    error("let $m as record(a, b?) := {} return $m", INVTYPE_X);
+    error("let $m as record(a, b?) := { 'c': 3 } return $m", INVTYPE_X);
   }
 }

--- a/basex-core/src/test/java/org/basex/query/expr/XQuery4Test.java
+++ b/basex-core/src/test/java/org/basex/query/expr/XQuery4Test.java
@@ -593,23 +593,20 @@ public final class XQuery4Test extends SandboxTest {
 
   /** Record tests. */
   @Test public void recordTest() {
-    query("{} instance of record(*)", true);
-    query("{} instance of record(x?, *)", true);
-    query("{} instance of record(x?, y?, *)", true);
-    query("{ 'x': 1 } instance of record(x, y?, *)", true);
-    query("{ 'y': 1 } instance of record(x?, y, *)", true);
+    query("{} instance of record()", true);
+    query("{} instance of record(x?)", true);
+    query("{} instance of record(x?, y?)", true);
+    query("{ 'x': 1 } instance of record(x, y?)", true);
+    query("{ 'y': 1 } instance of record(x?, y)", true);
     query("{ 'x': 1 } instance of record(x as xs:integer)", true);
-    query("{ 'x': 1 } instance of record(x as xs:integer, *)", true);
 
-    query("{} instance of record(x, *)", false);
-    query("{ 'x': 1 } instance of record(x?, y, *)", false);
-    query("{ 'y': 1 } instance of record(x, y?, *)", false);
+    query("{} instance of record(x)", false);
+    query("{ 'x': 1 } instance of record(x?, y)", false);
+    query("{ 'y': 1 } instance of record(x, y?)", false);
     query("{ 'x': 1 } instance of record(x as xs:string)", false);
-    query("{ 'x': 1 } instance of record(x as xs:string, *)", false);
     query("{ 'x': 1 } instance of record(x? as xs:string)", false);
-    query("{ 'x': 1 } instance of record(x? as xs:string, *)", false);
 
-    error("{} instance of record(*, x)", WRONGCHAR_X_X);
+    error("{} instance of record(*)", NOSTRNCN_X);
   }
 
   /** While clause. */

--- a/basex-core/src/test/java/org/basex/query/func/MapModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/MapModuleTest.java
@@ -118,9 +118,9 @@ public final class MapModuleTest extends SandboxTest {
     check(record + func.args(" local:x(" + wrap(0) + ")", "x"), true, root(func));
     check(record + func.args(" local:x(" + wrap(0) + ")", "y"), false, root(Bln.class));
 
-    record = "declare record local:x(x as xs:integer, *);";
+    record = "declare record local:x(x as xs:integer);";
     check(record + func.args(" local:x(" + wrap(0) + ")", "x"), true, root(Bln.class));
-    check(record + func.args(" local:x(" + wrap(0) + ")", "y"), false, root(func));
+    check(record + func.args(" local:x(" + wrap(0) + ")", "y"), false, root(Bln.class));
   }
 
   /** Test method. */
@@ -240,10 +240,10 @@ public final class MapModuleTest extends SandboxTest {
         type(func, "xs:integer?"));
     check(record + func.args(" local:x(" + wrap(0) + ")", "y"), "", empty());
 
-    record = "declare record local:x(x as xs:integer, *);";
+    record = "declare record local:x(x as xs:integer);";
     check(record + func.args(" local:x(" + wrap(0) + ")", "x"), 0,
         type(RecordGet.class, "xs:integer"));
-    check(record + func.args(" local:x(" + wrap(0) + ")", "y"), "", root(func));
+    check(record + func.args(" local:x(" + wrap(0) + ")", "y"), "", empty());
   }
 
   /** Test method. */
@@ -473,13 +473,13 @@ public final class MapModuleTest extends SandboxTest {
     check(record + func.args(" local:x(" + wrap(0) + ")", "y", 2), "{\"x\":0,\"y\":2}",
         type(func, "record(x?, y)"));
 
-    record = "declare record local:x(x as xs:integer, *);";
+    record = "declare record local:x(x as xs:integer);";
     check(record + func.args(" local:x(" + wrap(0) + ")", "x", 1), "{\"x\":1}",
         type(RecordSet.class, "local:x"));
     check(record + func.args(" local:x(" + wrap(0) + ")", "x", "y"), "{\"x\":\"y\"}",
-        type(RecordSet.class, "record(x, *)"));
+        type(RecordSet.class, "record(x)"));
     check(record + func.args(" local:x(" + wrap(0) + ")", "y", 2), "{\"x\":0,\"y\":2}",
-        type(func, "local:x"));
+        type(func, "record(x, y)"));
   }
 
   /** Test method. */
@@ -506,11 +506,11 @@ public final class MapModuleTest extends SandboxTest {
     check(record + func.args(" local:x(" + wrap(0) + ")", "y"), "{\"x\":0}",
         empty(func));
 
-    record = "declare record local:x(x as xs:integer, *);";
+    record = "declare record local:x(x as xs:integer);";
     check(record + func.args(" local:x(" + wrap(0) + ")", "x"), "{}",
-        type(func, "record(*)"));
+        empty(func));
     check(record + func.args(" local:x(" + wrap(0) + ")", "y"), "{\"x\":0}",
-        type(func, "local:x"));
+        empty(func));
 
     // GH-2438
     query("let $f := fn($map) { fold-left(map:keys($map), $map, map:remove#2) } " +
@@ -523,7 +523,7 @@ public final class MapModuleTest extends SandboxTest {
 
     query("{ (1 to 6) ! { .: . }[?* = 1] } =>" + func.args(), 1);
 
-    check("declare record local:coord(x, y, *); local:coord(1, 2) =>" + func.args(), 2, root(func));
+    check("declare record local:coord(x, y); local:coord(1, 2) =>" + func.args(), 2, root(func));
     check("declare record local:coord(x, y?); local:coord(1, 2) =>" + func.args(), 2, root(func));
     check("({}, <a/>/*) =>" + func.args(), 0, root(func));
 


### PR DESCRIPTION
This PR consists of three commits:

- bc3ad9f: fixes `instance of` for maps vs. records: maps are no longer treated as instances of record types without validating required fields and their types. This fixes an incorrect result for cases like:
  ```xquery
  map:entries({ 'x': 1 }) instance of record(a)
  ```
- f7073c5: implements the previously missing intersection between records and maps, fixing the wrong result that occurred for
  ```xquery
  let $map := (
    {'x':5, 'y':6}
    => map:put(xs:NCName('x'), true())
    => map:put(xs:NCName('y'), (false(), false()))
  )
  return (
    $map instance of map(xs:NCName, xs:boolean+) or
    $map instance of map(xs:string, xs:boolean+)
  )
  ``` 
- f191685: removes the `extensible` flag from records and adapts record coercion to drop excess fields.