### PR TITLE
Fix concurrency issues in `SharedData` caches

### DIFF
--- a/basex-core/src/main/java/org/basex/query/util/SharedData.java
+++ b/basex-core/src/main/java/org/basex/query/util/SharedData.java
@@ -64,10 +64,12 @@ public final class SharedData {
    * @return QName
    */
   public QNm qName(final byte[] name, final byte[] uri) {
-    return qnames.computeIfAbsent(
-      uri != null ? Token.concat(name, Token.cpToken(' '), uri) : name,
-      () -> new QNm(name, uri)
-    );
+    synchronized(qnames) {
+      return qnames.computeIfAbsent(
+          uri != null ? Token.concat(name, Token.cpToken(' '), uri) : name,
+          () -> new QNm(name, uri)
+        );
+    }
   }
 
   /**
@@ -76,7 +78,9 @@ public final class SharedData {
    * @return shared token
    */
   public byte[] token(final byte[] token) {
-    return token.length == 0 ? Token.EMPTY : tokens.put(token);
+    synchronized (tokens) {
+      return token.length == 0 ? Token.EMPTY : tokens.put(token);
+    }
   }
 
   /**
@@ -85,12 +89,14 @@ public final class SharedData {
    * @return new or already registered record type
    */
   public RecordType record(final RecordType rt) {
-    final ArrayList<RecordType> types = recordTypes.computeIfAbsent(rt.fields().size(),
-        ArrayList::new);
-    for(final RecordType type : types) {
-      if(type.equals(rt)) return type;
+    synchronized(recordTypes) {
+      final ArrayList<RecordType> types = recordTypes.computeIfAbsent(rt.fields().size(),
+          ArrayList::new);
+      for(final RecordType type : types) {
+        if(type.equals(rt)) return type;
+      }
+      types.add(rt);
+      return rt;
     }
-    types.add(rt);
-    return rt;
   }
 }

--- a/basex-core/src/test/java/org/basex/query/util/SharedDataTest.java
+++ b/basex-core/src/test/java/org/basex/query/util/SharedDataTest.java
@@ -1,0 +1,50 @@
+package org.basex.query.util;
+
+import org.basex.*;
+import org.junit.jupiter.api.*;
+
+/**
+ * XQuery shared data tests.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public final class SharedDataTest extends SandboxTest {
+  /** Number of test iterations. */
+  private static final int N = 100;
+
+  /** Concurrent usage of SharedData#qnames. */
+  @Test public void qname() {
+    query("xquery:fork-join(\n"
+        + "  for $i in 1 to " + N + "\n"
+        + "  return fn() { element { 'x' || $i } {} }\n"
+        + ")\n"
+        + "=> count()", N);
+  }
+
+  /** Concurrent usage of SharedData#tokens. */
+  @Test public void token() {
+    query("xquery:fork-join(\n"
+        + "  for $i in 1 to " + N + "\n"
+        + "  return fn() {\n"
+        + "    element { `e{$i}` } {\n"
+        + "      (1 to $i) ! attribute { `a{.}` } { `{$i}-{.}` }\n"
+        + "    }\n"
+        + "  }\n"
+        + ")\n"
+        + "=> count()", N);
+  }
+
+  /** Concurrent usage of SharedData#recordTypes. */
+  @Test public void recordType() {
+    query("xquery:fork-join(\n"
+        + "  for $i in 1 to " + N + "\n"
+        + "  return function() { \n"
+        + "    let $type := 'record(' || string-join((1 to $i) ! ('a' || .), ',') || ')'\n"
+        + "    let $rec := `{{ {string-join((1 to $i) ! `'a{.}':{.}`, ',')} }}`\n"
+        + "    return xquery:eval(`fn() as {$type} {{ {$rec} }} ()`)\n"
+        + "  }\n"
+        + ")\n"
+        + "=> count()", N);
+  }
+}


### PR DESCRIPTION
The failure described in #2479 is caused by concurrent access to the caches in `SharedData`.

This PR adds a regression test for each affected `SharedData` cache and synchronizes access to prevent these race conditions.