### PR TITLE
Fix race condition in `MapMerge` duplicate handling under `fork-join`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/map/MapBuild.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapBuild.java
@@ -33,7 +33,7 @@ public final class MapBuild extends MapMerge {
       final Iter iter = (keys != null ? invoke(keys, args, qc) : item).atomIter(qc, info);
       for(Item key; (key = qc.next(iter)) != null;) {
         final Value old = builder.get(key);
-        final Value val = dups.merge(key, old, value != null ? invoke(value, args, qc) : item);
+        final Value val = dups.merge(key, old, value != null ? invoke(value, args, qc) : item, qc);
         if(val != null) builder.put(key, val);
       }
     }

--- a/basex-core/src/main/java/org/basex/query/func/map/MapDuplicates.java
+++ b/basex-core/src/main/java/org/basex/query/func/map/MapDuplicates.java
@@ -17,11 +17,13 @@ public abstract class MapDuplicates {
    * @param key key
    * @param old old (can be {@code null})
    * @param value value
+   * @param qc query context
    * @return merged value, or new value if the old one is {@code null}
    * @throws QueryException query exception
    */
-  Value merge(final Item key, final Value old, final Value value) throws QueryException {
-    return old != null ? get(key, old, value) : value;
+  Value merge(final Item key, final Value old, final Value value, final QueryContext qc)
+      throws QueryException {
+    return old != null ? get(key, old, value, qc) : value;
   }
 
   /**
@@ -29,10 +31,11 @@ public abstract class MapDuplicates {
    * @param key key
    * @param old old
    * @param value value
+   * @param qc query context
    * @return merged value, or {@code null} if insertion of map entry can be skipped
    * @throws QueryException query exception
    */
-  abstract Value get(Item key, Value old, Value value) throws QueryException;
+  abstract Value get(Item key, Value old, Value value, QueryContext qc) throws QueryException;
 
   /**
    * Returns the result type.

--- a/basex-core/src/test/java/org/basex/query/func/XQueryModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/XQueryModuleTest.java
@@ -152,6 +152,26 @@ public final class XQueryModuleTest extends SandboxTest {
     query(func.args(" (true#0, false#0)", " { 'parallel': 1000000000 }"), "true\nfalse");
     query(func.args(" (true#0, false#0)", " { 'parallel': <_>1</_> }"), "true\nfalse");
 
+    // MapMerge mutable instance variables
+    query("xquery:fork-join(\r\n"
+        + "  for $t in 1 to 100\r\n"
+        + "  return function() {\r\n"
+        + "    for $i in 1 to 10\r\n"
+        + "    let $v := map:build(\r\n"
+        + "      ($i, $i),\r\n"
+        + "      (),\r\n"
+        + "      (),\r\n"
+        + "      { 'duplicates': function($x, $y) { $x * $y } }\r\n"
+        + "    )($i)\r\n"
+        + "    return\r\n"
+        + "      if($v eq $i * $i) then\r\n"
+        + "        $v\r\n"
+        + "      else\r\n"
+        + "        error(xs:QName('err:FAIL'), `{$i}: expected {$i * $i}, but got {$v}`)\r\n"
+        + "  }\r\n"
+        + ")\r\n"
+        + "=> count()", 1000);
+
     // optimizations
     check(func.args(" ()"), "", empty());
     check(func.args(" false#0"), false, root(DynFuncCall.class));


### PR DESCRIPTION
This PR fixes a concurrency issue in `MapMerge` when a function is supplied as the duplicates option and the query runs via `xquery:fork-join`. The duplicate handler was cached and captured a `QueryContext`, and `Invoke` reused a mutable `HofArgs` instance. Under parallel execution, this could corrupt combiner arguments and lead to sporadic errors such as:

```
[XPTY0004] Arithmetics not defined for xs:integer and item(): 1 * ().
```

Changes:

- pass `QueryContext` at call time instead of caching it
- make `Invoke` thread-safe by using `ThreadLocal<HofArgs>`
- add regression test reproducing the failure

Related to #2479.