### PR TITLE
Add duplicate removal of `ChoiceItemType` members

### DIFF
--- a/basex-core/src/main/java/org/basex/io/parse/csv/CsvW3Converter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/csv/CsvW3Converter.java
@@ -3,8 +3,6 @@ package org.basex.io.parse.csv;
 import static org.basex.query.QueryError.*;
 import static org.basex.query.value.type.Types.*;
 
-import java.util.*;
-
 import org.basex.build.csv.*;
 import org.basex.query.*;
 import org.basex.query.expr.*;
@@ -123,8 +121,7 @@ public final class CsvW3Converter extends CsvXQueryConverter {
         final QueryContext qc, final InputInfo ii) {
       final VarScope vs = new VarScope();
       final SeqType rowType = POSITIVE_INTEGER_O;
-      final SeqType colType = new ChoiceItemType(
-          Arrays.asList(STRING_O, POSITIVE_INTEGER_O)).seqType();
+      final SeqType colType = ChoiceItemType.get(STRING_O, POSITIVE_INTEGER_O).seqType();
       final Var row = vs.addNew(new QNm("row"), rowType, qc, ii);
       final Var col = vs.addNew(new QNm("column"), colType, qc, ii);
       final Get get = new Get(ii, rows, columnIndex, new VarRef(ii, row), new VarRef(ii, col));

--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -3747,27 +3747,29 @@ public class QueryParser extends InputParser {
     final ArrayList<SeqType> types = new ArrayList<>() {
       @Override
       public boolean add(final SeqType st) {
-        // collect alternative item type, combining consecutive EnumTypes into a single instance
+        if(contains(st)) return true;
+        // collect alternative item type, merging consecutive EnumTypes into a single instance
         if(!(st.type instanceof EnumType) || isEmpty()) return super.add(st);
         final int i = size() - 1;
         final Type tp = get(i).type;
         if(!(tp instanceof EnumType)) return super.add(st);
-        set(i, tp.union(st.type).seqType());
-        return true;
+        remove(i);
+        // re-add merged type (deduped via overridden add)
+        return add(tp.union(st.type).seqType());
       }
     };
 
     do {
       final SeqType st = itemType();
-      // collect alternative item type, combining nested ChoiceItemTypes into a single instance
-      if(st.type instanceof ChoiceItemType) {
-        types.addAll(((ChoiceItemType) st.type).types);
+      // collect alternative item type, flattening nested ChoiceItemTypes into a single instance
+      if(st.type instanceof ChoiceItemType ct) {
+        for(final SeqType s : ct.types) types.add(s);
       } else {
         types.add(st);
       }
     } while(wsConsume("|"));
     check(')');
-    return types.size() == 1 ? types.get(0) : new ChoiceItemType(types).seqType();
+    return ChoiceItemType.get(types).seqType();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnNodeTypeAnnotation.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnNodeTypeAnnotation.java
@@ -2,8 +2,6 @@ package org.basex.query.func.fn;
 
 import static org.basex.query.value.type.BasicType.*;
 
-import java.util.*;
-
 import org.basex.query.*;
 import org.basex.query.value.*;
 import org.basex.query.value.node.*;
@@ -17,8 +15,8 @@ import org.basex.query.value.type.*;
  */
 public final class FnNodeTypeAnnotation extends FnSchemaType {
   /** The function's argument type. */
-  private static final SeqType ARG_TYPE = new ChoiceItemType(
-      Arrays.asList(Types.ELEMENT_O, Types.ATTRIBUTE_O)).seqType();
+  private static final SeqType ARG_TYPE =
+      ChoiceItemType.get(Types.ELEMENT_O, Types.ATTRIBUTE_O).seqType();
 
   @Override
   public Value value(final QueryContext qc) throws QueryException {

--- a/basex-core/src/main/java/org/basex/query/value/type/Types.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/Types.java
@@ -5,8 +5,6 @@ import static org.basex.query.value.type.ListType.*;
 import static org.basex.query.value.type.NodeType.*;
 import static org.basex.query.value.type.Occ.*;
 
-import java.util.*;
-
 import org.basex.util.hash.*;
 
 /**
@@ -140,7 +138,7 @@ public final class Types {
   public static final SeqType BASE64_BINARY_ZM = BASE64_BINARY.seqType(ZERO_OR_MORE);
 
   /** String or xs:hex-binary or xs:base64-binary. */
-  public static final ChoiceItemType STRING_OR_BINARY =
+  public static final Type STRING_OR_BINARY =
       ChoiceItemType.get(STRING_O, HEX_BINARY_O, BASE64_BINARY_O);
   /** Single string or xs:hex-binary or xs:base64-binary. */
   public static final SeqType STRING_OR_BINARY_O = STRING_OR_BINARY.seqType();
@@ -188,10 +186,9 @@ public final class Types {
   public static final SeqType NMTOKENS_O = NMTOKENS.seqType();
 
   /** Gregorian type. */
-  public static final SeqType GREGORIAN_ZO = new ChoiceItemType(Arrays.asList(
-      DATE_TIME.seqType(), DATE.seqType(), TIME.seqType(), G_YEAR.seqType(),
-      G_YEAR_MONTH.seqType(), G_MONTH.seqType(), G_MONTH_DAY.seqType(), G_DAY.seqType())).
-      seqType(ZERO_OR_ONE);
+  public static final SeqType GREGORIAN_ZO = ChoiceItemType.get(DATE_TIME.seqType(), DATE.seqType(),
+      TIME.seqType(), G_YEAR.seqType(), G_YEAR_MONTH.seqType(), G_MONTH.seqType(),
+      G_MONTH_DAY.seqType(), G_DAY.seqType()).seqType(ZERO_OR_ONE);
 
   // types that instantiate sequence types must be placed last to avoid circular dependencies
 

--- a/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
+++ b/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
@@ -5,7 +5,6 @@ import static org.basex.query.value.type.Occ.*;
 import static org.basex.query.value.type.Types.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.*;
 import java.util.function.*;
 
 import org.basex.query.util.hash.*;
@@ -223,17 +222,17 @@ public final class SeqTypeTest {
 
     final SeqType
       // (xs:date | xs:string)
-      c1 = SeqType.get(new ChoiceItemType(Arrays.asList(DATE_O, STRING_O)), EXACTLY_ONE),
+      c1 = SeqType.get(ChoiceItemType.get(DATE_O, STRING_O), EXACTLY_ONE),
       // (element() | xs:string)
-      c2 = SeqType.get(new ChoiceItemType(Arrays.asList(ELEMENT_O, STRING_O)), EXACTLY_ONE),
+      c2 = SeqType.get(ChoiceItemType.get(ELEMENT_O, STRING_O), EXACTLY_ONE),
       // (xs:NMTOKENS | xs:string)
-      c3 = SeqType.get(new ChoiceItemType(Arrays.asList(NMTOKENS_O, STRING_O)), EXACTLY_ONE),
+      c3 = SeqType.get(ChoiceItemType.get(NMTOKENS_O, STRING_O), EXACTLY_ONE),
       // (array(*) | xs:string)
-      c4 = SeqType.get(new ChoiceItemType(Arrays.asList(ARRAY_O, STRING_O)), EXACTLY_ONE),
+      c4 = SeqType.get(ChoiceItemType.get(ARRAY_O, STRING_O), EXACTLY_ONE),
       // (map(*) | xs:string)
-      c5 = SeqType.get(new ChoiceItemType(Arrays.asList(MAP_O, STRING_O)), EXACTLY_ONE),
+      c5 = SeqType.get(ChoiceItemType.get(MAP_O, STRING_O), EXACTLY_ONE),
       // (function(*) | xs:string)
-      c6 = SeqType.get(new ChoiceItemType(Arrays.asList(FUNCTION_O, STRING_O)), EXACTLY_ONE);
+      c6 = SeqType.get(ChoiceItemType.get(FUNCTION_O, STRING_O), EXACTLY_ONE);
 
     assertTrue(c1.instanceOf(c1));
     assertFalse(c1.instanceOf(c2));
@@ -464,17 +463,17 @@ public final class SeqTypeTest {
 
     final SeqType
       // (xs:date | xs:string)
-      c1 = SeqType.get(new ChoiceItemType(Arrays.asList(DATE_O, STRING_O)), EXACTLY_ONE),
+      c1 = SeqType.get(ChoiceItemType.get(DATE_O, STRING_O), EXACTLY_ONE),
       // (element() | xs:string)
-      c2 = SeqType.get(new ChoiceItemType(Arrays.asList(ELEMENT_O, STRING_O)), EXACTLY_ONE),
+      c2 = SeqType.get(ChoiceItemType.get(ELEMENT_O, STRING_O), EXACTLY_ONE),
       // (xs:NMTOKENS | xs:string)
-      c3 = SeqType.get(new ChoiceItemType(Arrays.asList(NMTOKENS_O, STRING_O)), EXACTLY_ONE),
+      c3 = SeqType.get(ChoiceItemType.get(NMTOKENS_O, STRING_O), EXACTLY_ONE),
       // (array(*) | xs:string)
-      c4 = SeqType.get(new ChoiceItemType(Arrays.asList(ARRAY_O, STRING_O)), EXACTLY_ONE),
+      c4 = SeqType.get(ChoiceItemType.get(ARRAY_O, STRING_O), EXACTLY_ONE),
       // (map(*) | xs:string)
-      c5 = SeqType.get(new ChoiceItemType(Arrays.asList(MAP_O, STRING_O)), EXACTLY_ONE),
+      c5 = SeqType.get(ChoiceItemType.get(MAP_O, STRING_O), EXACTLY_ONE),
       // (function(*) | xs:string)
-      c6 = SeqType.get(new ChoiceItemType(Arrays.asList(FUNCTION_O, STRING_O)), EXACTLY_ONE);
+      c6 = SeqType.get(ChoiceItemType.get(FUNCTION_O, STRING_O), EXACTLY_ONE);
 
     combine(c1, op);
     combine(c1, DATE_O, ANY_ATOMIC_TYPE_O, op);
@@ -714,17 +713,17 @@ public final class SeqTypeTest {
 
     final SeqType
       // (xs:date | xs:string)
-      c1 = SeqType.get(new ChoiceItemType(Arrays.asList(DATE_O, STRING_O)), EXACTLY_ONE),
+      c1 = SeqType.get(ChoiceItemType.get(DATE_O, STRING_O), EXACTLY_ONE),
       // (element() | xs:string)
-      c2 = SeqType.get(new ChoiceItemType(Arrays.asList(ELEMENT_O, STRING_O)), EXACTLY_ONE),
+      c2 = SeqType.get(ChoiceItemType.get(ELEMENT_O, STRING_O), EXACTLY_ONE),
       // (xs:NMTOKENS | xs:string)
-      c3 = SeqType.get(new ChoiceItemType(Arrays.asList(NMTOKENS_O, STRING_O)), EXACTLY_ONE),
+      c3 = SeqType.get(ChoiceItemType.get(NMTOKENS_O, STRING_O), EXACTLY_ONE),
       // (array(*) | xs:string)
-      c4 = SeqType.get(new ChoiceItemType(Arrays.asList(ARRAY_O, STRING_O)), EXACTLY_ONE),
+      c4 = SeqType.get(ChoiceItemType.get(ARRAY_O, STRING_O), EXACTLY_ONE),
       // (map(*) | xs:string)
-      c5 = SeqType.get(new ChoiceItemType(Arrays.asList(MAP_O, STRING_O)), EXACTLY_ONE),
+      c5 = SeqType.get(ChoiceItemType.get(MAP_O, STRING_O), EXACTLY_ONE),
       // (function(*) | xs:string)
-      c6 = SeqType.get(new ChoiceItemType(Arrays.asList(FUNCTION_O, STRING_O)), EXACTLY_ONE);
+      c6 = SeqType.get(ChoiceItemType.get(FUNCTION_O, STRING_O), EXACTLY_ONE);
 
     combine(c1, op);
     combine(c1, DATE_O, DATE_O, op);


### PR DESCRIPTION
This PR adds duplicate removal of `ChoiceItemType` members. 

Duplicate elimination is performed at the points where the member lists are assembled:

 - `QueryParser.choiceItemType`
 - `ChoiceItemType.intersect`
 
Instead of handling duplicates in the `ChoiceItemType` constructor, the lists are normalized at construction time to avoid additional allocations and conditional logic in the constructor.

Also some refactoring has been done to simplify `ChoiceItemType` instantiation.