### PR TITLE
Add node type merging to choice item type construction

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -3751,32 +3751,12 @@ public class QueryParser extends InputParser {
    * @throws QueryException query exception
    */
   private SeqType choiceItemType() throws QueryException {
-    final ArrayList<SeqType> types = new ArrayList<>() {
-      @Override
-      public boolean add(final SeqType st) {
-        if(contains(st)) return true;
-        // collect alternative item type, merging consecutive EnumTypes into a single instance
-        if(!(st.type instanceof EnumType) || isEmpty()) return super.add(st);
-        final int i = size() - 1;
-        final Type tp = get(i).type;
-        if(!(tp instanceof EnumType)) return super.add(st);
-        remove(i);
-        // re-add merged type (deduped via overridden add)
-        return add(tp.union(st.type).seqType());
-      }
-    };
-
+    final ChoiceItemType.Builder builder = new ChoiceItemType.Builder();
     do {
-      final SeqType st = itemType();
-      // collect alternative item type, flattening nested ChoiceItemTypes into a single instance
-      if(st.type instanceof ChoiceItemType ct) {
-        for(final SeqType s : ct.types) types.add(s);
-      } else {
-        types.add(st);
-      }
+      builder.add(itemType());
     } while(wsConsume("|"));
     check(')');
-    return ChoiceItemType.get(types).seqType();
+    return builder.build().seqType();
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/value/type/Type.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/Type.java
@@ -139,6 +139,18 @@ public interface Type {
     public boolean isExtended() {
       return extended;
     }
+
+    /**
+     * Checks if this is one of the specified IDs.
+     * @param ids IDs
+     * @return result of check
+     */
+    public boolean oneOf(final ID... ids) {
+      for(final ID id : ids) {
+        if(this == id) return true;
+      }
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
The changes here add merging of node types of the same kind to `ChoiceItemType` construction. This is now done in `ChoiceItemType.Builder`.

For `enum` types, only consecutive entries are merged, which is necessary for preserving the order of entries.

For node types, any entries of the same kind are merged into the first entry of that kind. There is no known case where a thus changed order could cause different results.

Fixes #2602.