### PR TITLE
Add `fn:parts-of-dateTime`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -556,6 +556,10 @@ public enum Function implements AFunction {
   PARTITION(FnPartition::new, "partition(input,split-when)",
       params(ITEM_ZM, FuncType.get(BOOLEAN_ZO, ITEM_ZM, ITEM_O, INTEGER_O).seqType()), ARRAY_ZM),
   /** XQuery function. */
+  PARTS_OF_DATETIME(FnPartsOfDateTime::new, "parts-of-dateTime(value)",
+      params(ChoiceItemType.get(DATE_TIME_O, DATE_O, TIME_O, G_YEAR_O, G_YEAR_MONTH_O, G_MONTH_O,
+          G_MONTH_DAY_O, G_DAY_O).seqType(Occ.ZERO_OR_ONE)), Records.DATETIME.get().seqType()),
+  /** XQuery function. */
   PATH(FnPath::new, "path([node,options])",
       params(NODE_ZO, MAP_ZO), STRING_ZO),
   /** XQuery function. */

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnPartsOfDateTime.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnPartsOfDateTime.java
@@ -1,0 +1,52 @@
+package org.basex.query.func.fn;
+
+import java.math.*;
+
+import org.basex.query.*;
+import org.basex.query.func.*;
+import org.basex.query.value.*;
+import org.basex.query.value.item.*;
+import org.basex.query.value.map.*;
+import org.basex.query.value.seq.*;
+import org.basex.query.value.type.*;
+import org.basex.util.*;
+
+/**
+ * Function implementation.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public class FnPartsOfDateTime extends DateTimeFn {
+  /** Return type. */
+  private static final RecordType RETURN_TYPE = Records.DATETIME.get();
+
+  static {
+    if(RETURN_TYPE.fields().size() != 7) throw Util.notExpected();
+  }
+
+  @Override
+  public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
+    final Item value = arg(0).atomItem(qc, ii);
+    if(value.isEmpty()) return Empty.VALUE;
+    final Value coerced = definition.types[0].coerce(value, definition.params[0], qc, null, ii);
+    final ADate date = toDate(value, (BasicType) coerced.type, qc);
+    final long
+        y  = date.yea(),
+        mo = date.mon(),
+        d  = date.day(),
+        h  = date.hour(),
+        mi = date.minute();
+    final BigDecimal s = date.sec();
+    final Value[] values = {
+      y  != Long.MAX_VALUE ? Itr.get(y)  : Empty.VALUE,
+      mo >  0              ? Itr.get(mo) : Empty.VALUE,
+      d  >  0              ? Itr.get(d)  : Empty.VALUE,
+      h  >= 0              ? Itr.get(h)  : Empty.VALUE,
+      mi >= 0              ? Itr.get(mi) : Empty.VALUE,
+      s  != null           ? Dec.get(s)  : Empty.VALUE,
+      date.hasTz()         ? zon(date)   : Empty.VALUE
+    };
+    return new XQRecordMap(values, RETURN_TYPE);
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/value/type/Types.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/Types.java
@@ -121,6 +121,16 @@ public final class Types {
   public static final SeqType TIME_ZO = TIME.seqType(ZERO_OR_ONE);
   /** Zero or one duration. */
   public static final SeqType DURATION_ZO = DURATION.seqType(ZERO_OR_ONE);
+  /** One gYear. */
+  public static final SeqType G_YEAR_O = G_YEAR.seqType();
+  /** One gYearMonth. */
+  public static final SeqType G_YEAR_MONTH_O = G_YEAR_MONTH.seqType();
+  /** One gMonth. */
+  public static final SeqType G_MONTH_O = G_MONTH.seqType();
+  /** One gMonthDay. */
+  public static final SeqType G_MONTH_DAY_O = G_MONTH_DAY.seqType();
+  /** One gDay. */
+  public static final SeqType G_DAY_O = G_DAY.seqType();
 
   /** Single binary. */
   public static final SeqType BINARY_O = BINARY.seqType();

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -2751,6 +2751,67 @@ return
   }
 
   /** Test method. */
+  @Test public void partsOfDateTime() {
+    final Function func = PARTS_OF_DATETIME;
+    query(func.args(" ()"), "");
+    // examples from the spec
+    query(func.args(" xs:dateTime('1999-05-31T13:20:00-05:00')"),
+        "{\"year\":1999,\"month\":5,\"day\":31,\"hours\":13,\"minutes\":20,"
+      + "\"seconds\":0,\"timezone\":\"-PT5H\"}");
+    query(func.args(" xs:time('13:30:04.2678')"),
+        "{\"year\":(),\"month\":(),\"day\":(),\"hours\":13,\"minutes\":30,"
+      + "\"seconds\":4.2678,\"timezone\":()}");
+    query(func.args(" xs:gYearMonth('2007-05Z')"),
+        "{\"year\":2007,\"month\":5,\"day\":(),\"hours\":(),\"minutes\":(),"
+      + "\"seconds\":(),\"timezone\":\"PT0S\"}");
+    // xs:dateTime
+    query(func.args(" text{'2026-02-25T18:29:30.456+01:00'}"),
+        "{\"year\":2026,\"month\":2,\"day\":25,"
+      + "\"hours\":18,\"minutes\":29,\"seconds\":30.456,"
+      + "\"timezone\":\"PT1H\"}");
+    // xs:date
+    query(func.args(" text{'2026-02-25+01:00'}"),
+        "{\"year\":2026,\"month\":2,\"day\":25,"
+      + "\"hours\":(),\"minutes\":(),\"seconds\":(),"
+      + "\"timezone\":\"PT1H\"}");
+    // xs:time
+    query(func.args(" text{'18:29:30.456+01:00'}"),
+        "{\"year\":(),\"month\":(),\"day\":(),"
+      + "\"hours\":18,\"minutes\":29,\"seconds\":30.456,"
+      + "\"timezone\":\"PT1H\"}");
+    // xs:gYear
+    query(func.args(" text{'2026+01:00'}"),
+        "{\"year\":2026,\"month\":(),\"day\":(),"
+      + "\"hours\":(),\"minutes\":(),\"seconds\":(),"
+      + "\"timezone\":\"PT1H\"}");
+    // xs:gYearMonth
+    query(func.args(" text{'2026-02+01:00'}"),
+        "{\"year\":2026,\"month\":2,\"day\":(),"
+      + "\"hours\":(),\"minutes\":(),\"seconds\":(),"
+      + "\"timezone\":\"PT1H\"}");
+    // xs:gMonth
+    query(func.args(" text{'--02+01:00'}"),
+        "{\"year\":(),\"month\":2,\"day\":(),"
+      + "\"hours\":(),\"minutes\":(),\"seconds\":(),"
+      + "\"timezone\":\"PT1H\"}");
+    // xs:gMonthDay
+    query(func.args(" text{'--02-25+01:00'}"),
+        "{\"year\":(),\"month\":2,\"day\":25,"
+      + "\"hours\":(),\"minutes\":(),\"seconds\":(),"
+      + "\"timezone\":\"PT1H\"}");
+    // xs:gDay
+    query(func.args(" text{'---25+01:00'}"),
+        "{\"year\":(),\"month\":(),\"day\":25,"
+      + "\"hours\":(),\"minutes\":(),\"seconds\":(),"
+      + "\"timezone\":\"PT1H\"}");
+
+    error(func.args(" text{'not-a-date'}"), INVTYPE_X);
+    error(func.args(" text{'2026-02-30T18:29:30+01:00'}"), INVTYPE_X);
+    error(func.args(" text{'2026-02-25T18:29:30+15:00'}"), INVTYPE_X);
+    error(func.args(" text{'--13'}"), INVTYPE_X);
+  }
+
+  /** Test method. */
   @Test public void randomNumberGenerator() {
     final Function func = RANDOM_NUMBER_GENERATOR;
 


### PR DESCRIPTION
The changes in this PR add implementation and test for `fn:parts-of-dateTime`.

This fixes these QT4 test cases:

- `Keywords-fn-parts-of-dateTime-1`
- `fo-test-fn-parts-of-dateTime-001`
- `fo-test-fn-parts-of-dateTime-002`
- `fo-test-fn-parts-of-dateTime-003`