### PR TITLE
Add missing `fn:dateTime-record` constructor function

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -793,6 +793,8 @@ public enum Function implements AFunction {
   // Predefined record constructor functions
 
   /** XQuery function. */
+  DATETIME_RECORD(Records.DATETIME.get()),
+  /** XQuery function. */
   DIVIDED_DECIMALS_RECORD(Records.DIVIDED_DECIMALS.get()),
   /** XQuery function. */
   INFER_ENCODING_RECORD(Records.INFER_ENCODING.get()),

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -414,6 +414,7 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args(" {\"day\": 3,"
         + " \"timezone\": xs:dayTimeDuration('PT1H') }"),
         "---03+01:00");
+    query(func.args(" dateTime-record(day:=4)"), "---04");
 
     // empty map
     error(func.args(" {}"), INVDATETIMEFIELDS_X);


### PR DESCRIPTION
`fn:dateTime-record` has not been registered yet.