### PR TITLE
Modify Jetty http port configuration to use optional system property

### DIFF
--- a/basex-api/src/main/webapp/WEB-INF/jetty.xml
+++ b/basex-api/src/main/webapp/WEB-INF/jetty.xml
@@ -1,13 +1,16 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
   <!-- Default connector. The Jetty stop port can be specified 
-       in the .basex or pom.xml configuration file.  -->
+       in the .basex or pom.xml configuration file.
+       The Jetty http port can be specified here or by setting
+       the Java System Property jetty.http.port.
+  -->
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
         <Arg name="server"><Ref refid="Server"/></Arg>
         <Set name="host">0.0.0.0</Set>
-        <Set name="port">8080</Set>
+        <Set name="port"><SystemProperty name="jetty.http.port" default="8080"/></Set>
         <Set name="idleTimeout">60000</Set>
         <Set name="reuseAddress">true</Set>
       </New>


### PR DESCRIPTION
This pull request updates the Jetty configuration file webapp/WEB-INF/jetty.xml to allow http port specification via Java system property `jetty.http.port`. The default value is kept as port 8080.

The system property name `jetty.http.port` appears be used in Jetty since Jetty version 9.

This change makes it possible to specify the http port number when launching BaseX http server. For example, the http port can be specified when launching from the command line:

```bat
set BASEX_JVM=-Djetty.http.port=9999 & basexhttp
```

I've used this in a few different BaseX projects and have found it helpful to be able to specify the http port in this way instead of editing the jetty.xml file.