### PR TITLE
Add new built-in record types

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -239,7 +239,8 @@ public enum Function implements AFunction {
   /** XQuery function. */
   ELEMENT_TO_MAP_PLAN(FnElementToMapPlan::new, "element-to-map-plan(input)",
       params(ChoiceItemType.get(NodeType.DOCUMENT, NodeType.ELEMENT).seqType(Occ.ZERO_OR_MORE)),
-      RECORD_O.mapType(BasicType.STRING).seqType()),
+      ChoiceItemType.get(Records.ELEMENT_CONVERSION_PLAN.get(),
+          Records.ATTRIBUTE_CONVERSION_PLAN.get()).seqType().mapType(BasicType.STRING).seqType()),
   /** XQuery function. */
   ELEMENT_WITH_ID(FnElementWithId::new, "element-with-id(values[,node])",
       params(STRING_ZM, NODE_ZO), ELEMENT_ZM),
@@ -793,9 +794,13 @@ public enum Function implements AFunction {
   // Predefined record constructor functions
 
   /** XQuery function. */
+  ATTRIBUTE_CONVERSION_PLAN_RECORD(Records.ATTRIBUTE_CONVERSION_PLAN.get()),
+  /** XQuery function. */
   DATETIME_RECORD(Records.DATETIME.get()),
   /** XQuery function. */
   DIVIDED_DECIMALS_RECORD(Records.DIVIDED_DECIMALS.get()),
+  /** XQuery function. */
+  ELEMENT_CONVERSION_PLAN_RECORD(Records.ELEMENT_CONVERSION_PLAN.get()),
   /** XQuery function. */
   INFER_ENCODING_RECORD(Records.INFER_ENCODING.get()),
   /** XQuery function. */

--- a/basex-core/src/main/java/org/basex/query/func/Records.java
+++ b/basex-core/src/main/java/org/basex/query/func/Records.java
@@ -17,6 +17,9 @@ import org.basex.util.hash.*;
  */
 public enum Records {
   /** Record definition. */
+  ATTRIBUTE_CONVERSION_PLAN(FN_URI, "attribute-conversion-plan",
+      field("type", EnumType.get("numeric", "boolean", "string", "skip").seqType())),
+  /** Record definition. */
   DATETIME(FN_URI, "dateTime",
     field("year", Types.INTEGER_O, true),
     field("month", Types.INTEGER_O, true),
@@ -31,6 +34,12 @@ public enum Records {
     field("quotient", Types.DECIMAL_O),
     field("remainder", Types.DECIMAL_O)
   ),
+  /** Record definition. */
+  ELEMENT_CONVERSION_PLAN(FN_URI, "element-conversion-plan",
+    field("layout", EnumType.get("empty", "empty-plus", "simple", "simple-plus", "list",
+        "list-plus", "record", "sequence", "mixed", "xml", "error", "deep-skip").seqType()),
+    field("child", Types.STRING_ZO, true),
+    field("type", EnumType.get("numeric", "boolean", "string").seqType(), true)),
   /** Record definition. */
   INFER_ENCODING(BIN_URI, "infer-encoding",
     field("encoding", Types.STRING_O),


### PR DESCRIPTION
This change adds two new built-in record types:
  - `fn:attribute-conversion-plan-record`
  - `fn:element-conversion-plan-record`