### PR TITLE
Fix FLWOR flattening with while clause (#2634)

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/gflwor/GFLWOR.java
+++ b/basex-core/src/main/java/org/basex/query/expr/gflwor/GFLWOR.java
@@ -1038,12 +1038,12 @@ public final class GFLWOR extends ParseExpr {
   }
 
   /**
-   * Checks if this FLWOR expression has only 'for', 'let', 'where', and 'while' clauses.
+   * Checks if this FLWOR expression has only 'for', 'let', and 'where' clauses.
    * @return result of check
    */
   private boolean isFLW() {
     return ((Checks<Clause>) clause -> clause instanceof For || clause instanceof Let ||
-        clause instanceof Where || clause instanceof While).all(clauses);
+        clause instanceof Where).all(clauses);
   }
 
   @Override

--- a/basex-core/src/test/java/org/basex/query/expr/GFLWORTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/GFLWORTest.java
@@ -523,4 +523,14 @@ public final class GFLWORTest extends SandboxTest {
         "1\n2", exists(Pipeline.class));
     check("let $a := <a/>[text()] while $a return $a", "", root(IterFilter.class));
   }
+
+  /** Do not flatten nested FLWOR expressions with while clauses. */
+  @Test public void gh2634() {
+    query("for $max in (1 to 10) return (for $a in 0 to $max while $a < 1 return $a)",
+        "0\n0\n0\n0\n0\n0\n0\n0\n0\n0");
+    query("for $x in (1, 2) return (for $a in (1, 2, 3) while $a < 3 return $a)",
+        "1\n2\n1\n2");
+    query("for $x in (1, 2) for $y in (for $a in (1, 2, 3) while $a < 3 return $a) return ($x, $y)",
+        "1\n1\n1\n2\n2\n1\n2\n2");
+  }
 }


### PR DESCRIPTION
Unlike `where`, a `while` clause terminates the entire tuple stream. Flattening such a FLWOR into an outer loop incorrectly terminates that loop too. Fixed by excluding `while` from the `isFLW()` guard., and added regression tests.
