### PR TITLE
Serialize xs:double/xs:float negative zero as -0

### DIFF
--- a/basex-core/src/main/java/org/basex/io/serial/json/JsonSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/json/JsonSerializer.java
@@ -178,7 +178,8 @@ public abstract class JsonSerializer extends StandardSerializer {
       if(type.oneOf(BasicType.DOUBLE, BasicType.FLOAT) || canonical && type.isNumber()) {
         final double d = item.dbl(null);
         if(Double.isFinite(d)) {
-          out.print(Dbl.string(d));
+          final byte[] s = Dbl.string(d);
+          out.print(canonical && s == NEGATIVE_ZERO ? token(0) : s);
         } else {
           if(canonical) throw SERNUMBER_X.getIO(d);
           out.print(d == Double.POSITIVE_INFINITY ? JsonConstants.INF :

--- a/basex-core/src/main/java/org/basex/query/value/item/Dbl.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/Dbl.java
@@ -168,7 +168,7 @@ public final class Dbl extends ANum {
    */
   public static byte[] string(final double value) {
     // handle known edge cases
-    if(value == 0) return Token.token(0);
+    if(value == 0) return 1 / value > 0 ? Token.token(0) : Token.NEGATIVE_ZERO;
     if(value == Double.MIN_VALUE) return Token.token("5e-324");
     if(value == -Double.MIN_VALUE) return Token.token("-5e-324");
     if(value == 1e23) return Token.token("1e+23");

--- a/basex-core/src/test/java/org/basex/io/serial/json/BaseXSerializerTest.java
+++ b/basex-core/src/test/java/org/basex/io/serial/json/BaseXSerializerTest.java
@@ -22,6 +22,7 @@ public final class BaseXSerializerTest extends SandboxTest {
     serialize("()", "");
     serialize("1", "1");
     serialize("1, 2", "1\n2");
+    serialize("xs:double('-0'), xs:float('-0')", "-0\n-0");
 
     // nodes
     serialize("<x/>", "<x/>");

--- a/basex-core/src/test/java/org/basex/io/serial/json/JsonSerializerTest.java
+++ b/basex-core/src/test/java/org/basex/io/serial/json/JsonSerializerTest.java
@@ -27,6 +27,8 @@ public final class JsonSerializerTest extends SandboxTest {
     final JsonFormat format = JsonFormat.DIRECT;
     serialize("'x'", "'x'", format);
     serialize("1", "1", format);
+    serialize("xs:double('-0')", "-0", format);
+    serialize("xs:float('-0')", "-0", format);
     serialize("true()", "true", format);
     serialize("<_/>", "'<_\\/>'", format);
 
@@ -64,6 +66,8 @@ public final class JsonSerializerTest extends SandboxTest {
     final JsonFormat format = JsonFormat.ATTRIBUTES;
     serialize("'x'", "'x'", format);
     serialize("1", "1", format);
+    serialize("xs:double('-0')", "-0", format);
+    serialize("xs:float('-0')", "-0", format);
     serialize("true()", "true", format);
     serialize("<_/>", "'<_\\/>'", format);
 
@@ -116,6 +120,8 @@ public final class JsonSerializerTest extends SandboxTest {
     serialize("{ 'A': false() }", "{'A':false}", format);
     serialize("{ true(): false() }", "{'true':false}", format);
     serialize("{ 1: 'E' }", "{'1':'E'}", format);
+    serialize("{ 0: xs:double('-0') }", "{'0':-0}", format);
+    serialize("{ 0: xs:float('-0') }", "{'0':-0}", format);
 
     serialize("{ 'A': 1 div 0.0e0 }", "{'A':1e9999}", format);
     serialize("{ 'A': -1 div 0.0e0 }", "{'A':-1e9999}", format);
@@ -129,6 +135,8 @@ public final class JsonSerializerTest extends SandboxTest {
     serialize("[ 2 ]", "[2]", format);
     serialize("[ 2, 3 ]", "[2,3]", format);
     serialize("[ 2, (), 4 ]", "[2,null,4]", format);
+    serialize("[ xs:double('-0') ]", "[-0]", format);
+    serialize("[ xs:float('-0') ]", "[-0]", format);
 
     error("[ (1, 2) ]", format, SERJSONSEQ);
 
@@ -146,7 +154,8 @@ public final class JsonSerializerTest extends SandboxTest {
     serialize("1", "1", format);
 
     serialize("0.0e0", "0", format);
-    serialize("-0.0e0", "0", format);
+    serialize("-0.0e0", "-0", format);
+    serialize("xs:float('-0')", "-0", format);
     serialize("1e-6", "0.000001", format);
     serialize("1e-7", "1e-7", format);
     serialize("1e20", "100000000000000000000", format);

--- a/basex-core/src/test/java/org/basex/query/SerializerTest.java
+++ b/basex-core/src/test/java/org/basex/query/SerializerTest.java
@@ -262,6 +262,7 @@ public final class SerializerTest extends SandboxTest {
     query(option + "1234567890e0", "1.23456789e9");
     query(option + "xs:double('NaN')", "NaN");
     query(option + "xs:double('INF')", "INF");
+    query(option + "xs:double('-0')", "-0.0e0");
     query(option + "xs:byte(1)", 1);
     query(option + "false()", "false()");
     query(option + "'A'", "\"A\"");
@@ -273,6 +274,7 @@ public final class SerializerTest extends SandboxTest {
     query(option + "true#0", "fn:true#0");
     query(option + "fn() {}", "fn() as empty-sequence() { () }");
     query(option + "xs:float(1)", "xs:float(\"1\")");
+    query(option + "xs:float('-0')", "xs:float(\"-0\")");
 
     query(option + "[]", "[]");
     query(option + "[ 1 ]", "[1]");
@@ -281,6 +283,7 @@ public final class SerializerTest extends SandboxTest {
     query(option + "[ 1234567890e0 ]", "[1.23456789e9]");
     query(option + "[ xs:double('NaN') ]", "[NaN]");
     query(option + "[ xs:double('INF') ]", "[INF]");
+    query(option + "[ xs:double('-0') ]", "[-0.0e0]");
     query(option + "[ xs:byte(1) ]", "[1]");
     query(option + "[ false() ]", "[false()]");
     query(option + "[ 'A' ]", "[\"A\"]");
@@ -292,6 +295,7 @@ public final class SerializerTest extends SandboxTest {
     query(option + "[ true#0 ]", "[fn:true#0]");
     query(option + "[ fn() {} ]", "[fn() as empty-sequence() { () }]");
     query(option + "[ xs:float(1) ]", "[xs:float(\"1\")]");
+    query(option + "[ xs:float('-0')]", "[xs:float(\"-0\")]");
 
     query(option + "{ 1: (), 2: 3, 4: (5, 6) }", "{1:(),2:3,4:(5,6)}");
   }
@@ -305,6 +309,7 @@ public final class SerializerTest extends SandboxTest {
     query("1234567890e0", 1234567890);
     query("xs:double('NaN')", "NaN");
     query("xs:double('INF')", "INF");
+    query("xs:double('-0')", "-0");
     query("xs:byte(1)", 1);
     query("false()", "false");
     query("'A'", "A");
@@ -316,6 +321,7 @@ public final class SerializerTest extends SandboxTest {
     query("true#0", "fn:true#0");
     query("fn() {}", "fn() as empty-sequence() { () }");
     query("xs:float(1)", 1);
+    query("xs:float('-0')", "-0");
 
     query("[]", "[]");
     query("[ 1 ]", "[1]");

--- a/basex-core/src/test/java/org/basex/query/func/BinModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/BinModuleTest.java
@@ -410,7 +410,7 @@ public final class BinModuleTest extends SandboxTest {
     query(func.args(hex("0000000000000000"), 0),                           0);
     query(func.args(hex("3FF0000000000000"), 0),                           1);
     query(func.args(hex("BFF0000000000000"), 0),                           -1);
-    query(func.args(hex("8000000000000000"), 0),                           0);
+    query(func.args(hex("8000000000000000"), 0),                           "-0");
     query(func.args(hex("0000000000000000"), 0),                           0);
     query(func.args(hex("7FF0000000000000"), 0),                           "INF");
     query(func.args(hex("FFF0000000000000"), 0),                           "-INF");

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -3189,6 +3189,8 @@ return
 
     final String canonicalJson = " {'method': 'json', 'canonical': true()}";
     query(func.args(" [0x7fff_ffff_ffff_ffff]", canonicalJson), "[9223372036854776000]");
+    query(func.args(" [xs:double('-0')]", " {'method': 'json'}"), "[-0]");
+    query(func.args(" [xs:double('-0')]", canonicalJson), "[0]");
 
     // The tests below were adapted from Apache 2.0–licensed code from project
     // erdtman/java-json-canonicalization at https://github.com/erdtman/java-json-canonicalization
@@ -3436,6 +3438,8 @@ return
     query(func.args("A"), "A");
     query(func.args(wrap("A")), "A");
     query("(" + wrap("A") + ", 1, 'X') ! " + func.args(), "A\n1\nX");
+    query(func.args(" xs:float('-0')"), "-0");
+    query(func.args(" xs:double('-0')"), "-0");
 
     check("for $s in ('a', 'b') return " + func.args(" $s"), "a\nb", empty(func));
     check("for $s in (<a/>, <b/>) return " + func.args(" $s"), "\n", exists(func));

--- a/basex-core/src/test/java/org/basex/query/func/JsonModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/JsonModuleTest.java
@@ -120,7 +120,7 @@ public final class JsonModuleTest extends SandboxTest {
     query(func.args("0E1", options), 0);
     query(func.args("0E-1", options), 0);
     query(func.args("0E+1", options), 0);
-    query(func.args("-0E+1", options), "0");
+    query(func.args("-0E+1", options), "-0");
     query(func.args("0E00", options), 0);
     query(func.args("123e-123", options), "1.23e-121");
     query(func.args("123.4e-123", options), "1.234e-121");


### PR DESCRIPTION
While reviewing qtspecs PR `#2522` for changes requiring implementation in BaseX, some inconsistency was detected in how BaseX handles negative zero (`-0`) for `xs:double` and `xs:float`.

Casting is already correct - `xs:double('-0')` preserves the negative zero value internally, as confirmed by `1 div xs:double('-0')` returning `-INF`. However, serialization is not correct: negative zero was output as `0` for `xs:double`, while it was output as `-0` for `xs:float`.

The serialization spec recommends that negative zero be output with a leading minus sign in non-canonical JSON serialization. For other output methods, outputting `-0` is consistent with preserving the sign bit. Canonical JSON is the exception: RFC 8785 (referenced by the spec) mandates `0` there.

This PR fixes `Dbl.string` to return `-0` for negative zero, and adds a canonical-mode check in `JsonSerializer` to suppress the minus sign when required. Tests are added across the affected serialization paths (adaptive, BaseX, JSON direct/attributes/W3, `fn:serialize`, string cast, `bin:unpack-double`, `json:parse`).
