### PR TITLE
Fix dynamic namespace inheritance in nested query contexts

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryContext.java
+++ b/basex-core/src/main/java/org/basex/query/QueryContext.java
@@ -153,9 +153,10 @@ public final class QueryContext extends Job implements Closeable {
   /**
    * Constructor.
    * @param parent parent context
+   * @param nsContext inherited namespace context (can be {@code null})
    */
-  public QueryContext(final QueryContext parent) {
-    this(parent.context, parent, parent.info);
+  public QueryContext(final QueryContext parent, final NSDynContext nsContext) {
+    this(parent.context, parent, nsContext, parent.info);
     parent.pushJob(this);
     updates = parent.updates;
   }
@@ -165,20 +166,22 @@ public final class QueryContext extends Job implements Closeable {
    * @param context database context
    */
   public QueryContext(final Context context) {
-    this(context, null, null);
+    this(context, null, null, null);
   }
 
   /**
    * Constructor.
    * @param context database context
    * @param parent parent context (can be {@code null})
+   * @param nsContext inherited namespace context (can be {@code null})
    * @param info query info (can be {@code null})
    */
-  public QueryContext(final Context context, final QueryContext parent, final QueryInfo info) {
+  public QueryContext(final Context context, final QueryContext parent,
+      final NSDynContext nsContext, final QueryInfo info) {
     this.context = context;
     this.parent = parent;
     this.info = info != null ? info : new QueryInfo(context);
-    ns = parent != null ? new NSDynContext(parent.ns) : new NSDynContext(null);
+    ns = new NSDynContext(nsContext);
     resources = parent != null ? parent.resources : new QueryResources(this);
     ftPosData = parent != null ? parent.ftPosData : null;
     shared = parent != null ? parent.shared : new SharedData();

--- a/basex-core/src/main/java/org/basex/query/QueryProcessor.java
+++ b/basex-core/src/main/java/org/basex/query/QueryProcessor.java
@@ -50,7 +50,7 @@ public final class QueryProcessor extends Job implements Closeable {
   public QueryProcessor(final String query, final String uri, final Context ctx,
       final QueryInfo info) {
     this.query = query;
-    qc = pushJob(new QueryContext(ctx, null, info));
+    qc = pushJob(new QueryContext(ctx, null, null, info));
     sc = new StaticContext(qc);
     sc.baseURI(uri != null && uri.isEmpty() ? "./" : uri);
   }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnLoadXQueryModule.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnLoadXQueryModule.java
@@ -91,7 +91,7 @@ public final class FnLoadXQueryModule extends StandardFunc {
       if(!isSupported(version)) throw MODULE_XQUERY_VERSION_X.get(info, version);
     }
 
-    final QueryContext mqc = new QueryContext(qc);
+    final QueryContext mqc = new QueryContext(qc, null);
     for(final byte[] uri : qc.modDeclared) mqc.modDeclared.put(uri, qc.modDeclared.get(uri));
     int nParsed = 0;
     final Value ctx = opt.get(CONTEXT_ITEM);

--- a/basex-core/src/main/java/org/basex/query/func/xquery/XQueryEval.java
+++ b/basex-core/src/main/java/org/basex/query/func/xquery/XQueryEval.java
@@ -75,7 +75,7 @@ public class XQueryEval extends StandardFunc {
     if(!user.has(perm)) throw XQUERY_PERMREQUIRED_X.get(info, perm);
 
     Timer to = null;
-    try(QueryContext qctx = new QueryContext(qc)) {
+    try(QueryContext qctx = new QueryContext(qc, null)) {
       qctx.user = new User(user).permission(perm);
 
       // limit memory consumption: enforce garbage collection and calculate usage

--- a/basex-core/src/main/java/org/basex/query/func/xquery/XQueryTask.java
+++ b/basex-core/src/main/java/org/basex/query/func/xquery/XQueryTask.java
@@ -45,7 +45,7 @@ final class XQueryTask extends RecursiveTask<Value> {
     final int size = end - start;
     if(size == 1) {
       // perform the work
-      try(QueryContext qc = new QueryContext(tc.qc)) {
+      try(QueryContext qc = new QueryContext(tc.qc, tc.qc.ns)) {
         return tc.funcs.get(start).invoke(qc, tc.info);
       } catch(final QueryException ex) {
         if(tc.errors) {

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -2003,6 +2003,13 @@ return
     query(func.args("x", " { 'content': 'module namespace x=\"x\";\ndeclare variable $x:x := 1;', "
         + "'xquery-version': 4.0 }") + "?variables?#Q{x}x", 1);
 
+    // GH-2640
+    error("<e xmlns:p='p'>{\n"
+        + "  load-xquery-module(\"m\", {\n"
+        + "    'content': ``[module namespace m='m'; declare function m:f() {<p:x/>};]``\n"
+        + "  })?functions?#Q{m}f?0()\n"
+        + "}</e>", MODULE_STATIC_ERROR_X_X);
+
     error(func.args(""), MODULE_URI_EMPTY);
     error(func.args("x"), MODULE_NOT_FOUND_X);
     error(func.args("x", " { 'content': '%@?$' }"), MODULE_STATIC_ERROR_X_X);

--- a/basex-core/src/test/java/org/basex/query/func/XQueryModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/XQueryModuleTest.java
@@ -36,6 +36,17 @@ public final class XQueryModuleTest extends SandboxTest {
     // GH-2332
     query("try {" + func.args("declare function local:f() { local:f() }; local:f()") +
         "} catch xquery:error { 'STOP' }", "STOP");
+
+    // GH-2640
+    query("element e { attribute { QName('', 'a') } {}, " + func.args("true()") + " }",
+        "<e a=\"\">true</e>");
+    query("<e xmlns:p='p'\n"
+        + "   p:a='{\n"
+        + "     map:keys(in-scope-namespaces(<x/>))\n"
+        + "   }'\n"
+        + "   p:b='{xquery:eval('\n"
+        + "     map:keys(in-scope-namespaces(<x/>))\n"
+        + "   ')}'/>", "<e xmlns:p=\"p\" p:a=\"p xml\" p:b=\"xml\"/>");
   }
 
   /** Test method. */
@@ -182,6 +193,15 @@ public final class XQueryModuleTest extends SandboxTest {
         + "   => distinct-values()\r\n"
         + " }")
         + "=> distinct-values()", "a b c d e");
+
+    // GH-2640: fork-join inherits parent dynamic namespace context
+    query("<e xmlns:p='p'\n"
+        + "   p:a='{\n"
+        + "     " + func.args(" \n"
+        + "       (1 to 100) ! fn() {map:keys(in-scope-namespaces(<x/>))}\n"
+        + "     ") + "[. = 'p'] => count()\n"
+        + "   }'\n"
+        + "/>", "<e xmlns:p=\"p\" p:a=\"100\"/>");
 
     // optimizations
     check(func.args(" ()"), "", empty());


### PR DESCRIPTION
The changes made for #2600 caused nested query contexts to incorrectly inherit dynamic namespaces from the parent query. This affected `xquery:eval` and `fn:load-xquery-module`.

This change prevents that inheritance for nested queries, while keeping it for `xquery:fork-join`, by passing the namespace as an explicit parameter to `QueryContext` constructors.