### PR TITLE
`fn:function-lookup`: find functions from all modules of the executing query

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Functions.java
+++ b/basex-core/src/main/java/org/basex/query/func/Functions.java
@@ -179,7 +179,7 @@ public final class Functions {
     }
 
     // user-defined function
-    final StaticFunc sf = qc.functions.get(info.sc(), name, arity);
+    final StaticFunc sf = qc.functions.get(info.sc(), name, arity, runtime);
     if(sf != null) {
       final Expr func = item(sf, fb, qc);
       if(sf.updating) qc.updating();
@@ -215,7 +215,7 @@ public final class Functions {
       final QueryContext qc) {
 
     final StaticContext sc = info.sc();
-    if(name.hasURI() || qc.functions.get(sc, name, arity) != null) return name;
+    if(name.hasURI() || qc.functions.get(sc, name, arity, false) != null) return name;
     return new QNm(name.local(), sc.funcNS != null ? sc.funcNS : FN_URI);
   }
 
@@ -326,7 +326,7 @@ public final class Functions {
     }
 
     final StaticFuncCall call = new StaticFuncCall(name, fb.args(), fb.keywords, fb.info);
-    qc.functions.setFunc(call, qc);
+    qc.functions.setFunc(call, fb.runtime, qc);
     return call;
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/StaticFuncs.java
+++ b/basex-core/src/main/java/org/basex/query/func/StaticFuncs.java
@@ -56,7 +56,7 @@ public final class StaticFuncs extends ExprInfo implements Iterable<StaticFunc> 
 
     final byte[] modUri = Token.eq(name.uri(), FN_URI) ? FN_URI : QNm.uri(sc.module);
     final StaticFunc sf = new StaticFunc(name, params, expr, anns, vs, info, doc);
-    if(get(sc, name, sf.min, sf.arity()) != null) throw DUPLFUNC_X.get(info, name);
+    if(get(sc, name, sf.min, sf.arity(), false) != null) throw DUPLFUNC_X.get(info, name);
     funcsByModule.computeIfAbsent(modUri, QNmMap::new).computeIfAbsent(name, ArrayList::new).
         add(sf);
     return sf;
@@ -76,14 +76,16 @@ public final class StaticFuncs extends ExprInfo implements Iterable<StaticFunc> 
   /**
    * Assigns a function to a static function call.
    * @param call name function name
+   * @param useDynamicContext {@code true} if function lookup should include the dynamic context
    * @param qc query context
    * @throws QueryException query exception
    */
-  void setFunc(final StaticFuncCall call, final QueryContext qc) throws QueryException {
+  void setFunc(final StaticFuncCall call, final boolean useDynamicContext, final QueryContext qc)
+      throws QueryException {
     final InputInfo info = call.info();
     final QNm name = call.name;
     final int arity = call.arity();
-    final StaticFunc func = get(info.sc(), name, arity);
+    final StaticFunc func = get(info.sc(), name, arity, useDynamicContext);
     if(func != null) {
       if(func.expr == null) throw FUNCNOIMPL_X.get(func.info, func.name.prefixString());
       call.setFunc(func);
@@ -128,10 +130,12 @@ public final class StaticFuncs extends ExprInfo implements Iterable<StaticFunc> 
    * @param sc static context
    * @param qname function name
    * @param arity function arity
+   * @param useDynamicContext {@code true} if function lookup should include the dynamic context
    * @return function if found, {@code null} otherwise
    */
-  public StaticFunc get(final StaticContext sc, final QNm qname, final int arity) {
-    return get(sc, qname, arity, arity);
+  public StaticFunc get(final StaticContext sc, final QNm qname, final int arity,
+      final boolean useDynamicContext) {
+    return get(sc, qname, arity, arity, useDynamicContext);
   }
 
   /**
@@ -140,13 +144,15 @@ public final class StaticFuncs extends ExprInfo implements Iterable<StaticFunc> 
    * @param qname function name
    * @param min minimum function arity
    * @param max maximum function arity
+   * @param useDynamicContext {@code true} if function lookup should include the dynamic context
    * @return function if found, {@code null} otherwise
    */
-  private StaticFunc get(final StaticContext sc, final QNm qname, final int min, final int max) {
+  private StaticFunc get(final StaticContext sc, final QNm qname, final int min, final int max,
+      final boolean useDynamicContext) {
     final byte[] funcUri = qname.uri();
     final byte[] modUri = Token.eq(funcUri, FN_URI) ? FN_URI : QNm.uri(sc.module);
     StaticFunc func = get(modUri, qname, min, max);
-    if(func == null && sc.imports.contains(funcUri)) {
+    if(func == null && (useDynamicContext || sc.imports.contains(funcUri))) {
       func = get(funcUri, qname, min, max);
       if(func != null && func.anns.contains(Annotation.PRIVATE)) func = null;
     }

--- a/basex-core/src/main/java/org/basex/query/func/inspect/InspectFunction.java
+++ b/basex-core/src/main/java/org/basex/query/func/inspect/InspectFunction.java
@@ -1,7 +1,6 @@
 package org.basex.query.func.inspect;
 
 import org.basex.query.*;
-import org.basex.query.ann.*;
 import org.basex.query.func.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.node.*;
@@ -22,16 +21,7 @@ public final class InspectFunction extends StandardFunc {
     StaticFunc func = null;
     if(name != null) {
       final int arity = function.arity();
-      func = qc.functions.get(ii.sc(), name, arity);
-      if(func == null) {
-        for(final StaticFunc sf : qc.functions) {
-          if(!sf.annotations().contains(Annotation.PRIVATE) && sf.funcName().eq(name)
-              && sf.minArity() <= arity && sf.arity() >= arity) {
-            func = sf;
-            break;
-          }
-        }
-      }
+      func = qc.functions.get(ii.sc(), name, arity, true);
     }
     return new PlainDoc(qc, info).function(name, func, function.funcType(), function.annotations());
   }

--- a/basex-core/src/test/java/org/basex/query/ModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/ModuleTest.java
@@ -243,10 +243,10 @@ public final class ModuleTest extends SandboxTest {
         + "};\n"
         + "declare variable $c:hello := 'can you see me now';");
 
-    // function is not visible to fn:function-lookup (not in dynamically known function definitions)
+    // function is visible to fn:function-lookup even when not in static context
     query("import module namespace b = 'b'  at '" + b.path() + "';\n"
-        + "fn:function-lookup(#Q{c}hello, 0)", "");
-    // function is still visible to inspect:functions
+        + "fn:function-lookup(#Q{c}hello, 0)()", "can you see me now");
+    // function is visible to inspect:functions
     query("import module namespace b  = 'b'  at '" + b.path() + "';\n"
         + "inspect:functions()", "Q{c}hello#0");
 
@@ -259,5 +259,21 @@ public final class ModuleTest extends SandboxTest {
     error("import module namespace b = 'b'  at '" + b.path() + "';\n"
         + "declare namespace c = 'c';\n"
         + "$c:hello", QueryError.INVISIBLEVAR_X);
+  }
+
+  /** Tests fn:function-lookup from within a library module for a module imported elsewhere. */
+  @Test public void gh2641() {
+    final IOFile sandbox = sandbox();
+    final IOFile a = new IOFile(sandbox, "a.xqm");
+    final IOFile b = new IOFile(sandbox, "b.xqm");
+    write(a, "module namespace a = 'A';\n"
+        + "declare function a:lookup() {\n"
+        + "  function-lookup(QName('B', 'test'), 0)\n"
+        + "};");
+    write(b, "module namespace b = 'B';\n"
+        + "declare function b:test() {};");
+    query("import module namespace a = 'A' at '" + a.path() + "';\n"
+        + "import module namespace b = 'B' at '" + b.path() + "';\n"
+        + "exists(a:lookup())", true);
   }
 }


### PR DESCRIPTION
Before #2554, `fn:function-lookup` could find any user-defined function declared in the executing query. That PR reorganized static functions by declaring module and introduced a visibility check based on `sc.imports`, which restricted `fn:function-lookup` to only functions statically visible at the call site.

The spec **requires** functions to be accessible if they are statically visible at the point where `fn:function-lookup` is called, but it also **allows** access to functions that are present in the dynamic context, where the actual set of those functions is implementation-defined.

The changes here restore the pre-#2554 behavior by passing a `useDynamicContext` flag through `StaticFuncs.get()` which causes the `sc.imports` check to be skipped, so any non-private user-defined function in the executing query is reachable via
`fn:function-lookup`, regardless of which module issues the call.