### PR TITLE
Add check for `xml:`-prefixed name to DB wildcard nametests

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/path/NameTest.java
+++ b/basex-core/src/main/java/org/basex/query/expr/path/NameTest.java
@@ -1,5 +1,6 @@
 package org.basex.query.expr.path;
 
+import org.basex.index.name.*;
 import org.basex.data.*;
 import org.basex.query.*;
 import org.basex.query.value.item.*;
@@ -103,9 +104,9 @@ public final class NameTest extends Test {
     }
 
     // check if local element/attribute names occur in database
-    if(!kind.oneOf(Kind.GNODE, Kind.PROCESSING_INSTRUCTION) && name != null &&
-        !(kind == Kind.ELEMENT ? data.elemNames : data.attrNames).contains(name)) {
-      return null;
+    if(!kind.oneOf(Kind.GNODE, Kind.PROCESSING_INSTRUCTION) && name != null) {
+      final Names names = kind == Kind.ELEMENT ? data.elemNames : data.attrNames;
+      if(!names.contains(name) && !names.contains(Token.concat(Token.XML, ':', name))) return null;
     }
     return this;
   }

--- a/basex-core/src/test/java/org/basex/query/NamespaceTest.java
+++ b/basex-core/src/test/java/org/basex/query/NamespaceTest.java
@@ -896,6 +896,15 @@ public final class NamespaceTest extends SandboxTest {
     query("db:get('db')/*:B", "<b:B xmlns:b=\"b\"/>");
   }
 
+  /** Wildcard name test with xml namespace on database content (GH-2642). */
+  @Test public void gh2642() {
+    final String doc = "<x xml:a=''><xml:a/></x>";
+    execute(new CreateDB("db", doc));
+    query("/x[@xml:a]", doc);
+    query("/x[@*:a]", doc);
+    query("/x[*:a]", doc);
+  }
+
   /** Tests fixed default element namespaces. */
   @Test public void fixed() {
     // non-fixed: constructor xmlns="" changes the default namespace seen by enclosed expressions


### PR DESCRIPTION
For wildcard name tests on database nodes backed by `DiskData`, `NameTest.optimize` can reduce the test to empty if the local name is not found in the data’s name table. However, names in the `xml` namespace are stored there with the `xml` prefix, so a lookup by local name alone does not find them. This change checks for the `xml:` -prefixed form before optimizing the result to empty.