### PR TITLE
Fix HTML content escaping

### DIFF
--- a/basex-core/src/main/java/org/basex/io/serial/HTMLSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/HTMLSerializer.java
@@ -176,7 +176,6 @@ final class HTMLSerializer extends XhtmlHtmlSerializer {
       sep = false;
       super.finishClose();
     }
-    if(SCRIPTS.contains(lc(elem.local()))) script++;
   }
 
   @Override

--- a/basex-core/src/test/java/org/basex/query/SerializerTest.java
+++ b/basex-core/src/test/java/org/basex/query/SerializerTest.java
@@ -358,6 +358,12 @@ public final class SerializerTest extends SandboxTest {
     contains(option + "<html><style/><body><script>&amp;&amp;</script></body></html>", ">&&<");
   }
 
+  /** HTML Serialization: restore escaping following empty script tags. */
+  @Test public void gh2645() {
+    final String option = METHOD.arg("html");
+    contains(option + "<html><script/><body>&amp;&amp;</body></html>", ">&amp;&amp;<");
+  }
+
   /** HTML5 indentation. */
   @Test public void indentHTML5() {
     final String option = METHOD.arg("html") + INDENT.arg("on");


### PR DESCRIPTION
In `HTMLSerializer.finishEmpty`, `script++` was incremented for empty `<script>`/`<style>` elements, but `finishClose` (which does `script--`) is never called for empty elements. This left `script > 0` permanently, suppressing text escaping for the rest of the document.

Minimal reproduction:

```xquery
declare option output:method 'html';
declare option output:html-version '5.0';
<html><head><script src="x.js"/></head><body>{ '<tag>' }</body></html>
```

Expected: `&lt;tag&gt;`
Actual: `<tag>`

This regression was introduced by a168d7f on behalf of #2575. 