### PR TITLE
Add implementation of `fn:system-properties`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -709,6 +709,9 @@ public enum Function implements AFunction {
   SUM(FnSum::new, "sum(values[,zero])",
       params(ANY_ATOMIC_TYPE_ZM, ANY_ATOMIC_TYPE_ZO), ANY_ATOMIC_TYPE_ZO),
   /** XQuery function. */
+  SYSTEM_PROPERTIES(FnSystemProperties::new, "system-properties()", params(),
+      MapType.get(BasicType.QNAME, ANY_ATOMIC_TYPE_O).seqType()),
+  /** XQuery function. */
   TAIL(FnTail::new, "tail(input)",
       params(ITEM_ZM), ITEM_ZM),
   /** XQuery function. */

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnInvisibleXml.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnInvisibleXml.java
@@ -3,7 +3,6 @@ package org.basex.query.func.fn;
 import static org.basex.query.QueryError.*;
 
 import java.io.*;
-import java.util.*;
 
 import org.basex.io.*;
 import org.basex.query.*;
@@ -28,6 +27,9 @@ import de.bottlecaps.markup.*;
  * @author Gunther Rademacher
  */
 public final class FnInvisibleXml extends StandardFunc {
+  /** Required class names. */
+  private static final String[] CLASSES = { "de.bottlecaps.markup.Blitz",
+      "de.bottlecaps.markup.BlitzException", "de.bottlecaps.markup.BlitzParseException"};
   /** The function's argument type. */
   public static final SeqType ARG_TYPE = ChoiceItemType.get(BasicType.STRING,
       NodeType.get(NameTest.get(new QNm("ixml")))).seqType(Occ.ZERO_OR_ONE);
@@ -37,8 +39,7 @@ public final class FnInvisibleXml extends StandardFunc {
   @Override
   public FuncItem item(final QueryContext qc, final InputInfo ii) throws QueryException {
     if(generator == null) {
-      for(final String className : Arrays.asList("de.bottlecaps.markup.Blitz",
-          "de.bottlecaps.markup.BlitzException", "de.bottlecaps.markup.BlitzParseException")) {
+      for(final String className : CLASSES) {
         if(!Reflect.available(className)) {
           throw BASEX_CLASSPATH_X_X.get(info, definition.name, className);
         }
@@ -46,6 +47,17 @@ public final class FnInvisibleXml extends StandardFunc {
       generator = new Generator();
     }
     return generator.generate(qc);
+  }
+
+  /**
+   * Checks if Invisible XML support is available.
+   * @return result of check
+   */
+  public static boolean available() {
+    for(final String className : CLASSES) {
+      if(!Reflect.available(className)) return false;
+    }
+    return true;
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnSystemProperties.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnSystemProperties.java
@@ -1,0 +1,48 @@
+package org.basex.query.func.fn;
+
+import java.math.*;
+
+import org.basex.query.*;
+import org.basex.query.func.*;
+import org.basex.query.value.item.*;
+import org.basex.query.value.map.*;
+import org.basex.util.*;
+
+/**
+ * Function implementation.
+ *
+ * @author BaseX Team, BSD License
+ */
+public final class FnSystemProperties extends StandardFunc {
+  /** XPath version. */
+  private static final Dec XPATH_VERSION = Dec.get(BigDecimal.valueOf(4));
+  /** XSD version. */
+  private static final Dec XSD_VERSION = Dec.get(BigDecimal.valueOf(11, 1));
+
+  @Override
+  public XQMap item(final QueryContext qc, final InputInfo ii) throws QueryException {
+    return new MapBuilder().
+        put(property("xpath-version"), XPATH_VERSION).
+        put(property("xsd-version"), XSD_VERSION).
+        put(property("product-name"), Str.get(Prop.NAME)).
+        put(property("product-version"), Str.get(Prop.VERSION)).
+        put(property("schema-aware"), Bln.FALSE).
+        put(property("accepts-typed-data"), Bln.FALSE).
+        put(property("supports-xinclude"), Bln.TRUE).
+                   // supports-dtd: false, because id/idref is not fully supported
+        put(property("supports-dtd"), Bln.FALSE).
+        put(property("supports-invisible-xml"), Bln.get(FnInvisibleXml.available())).
+        put(property("supports-dynamic-xquery"), Bln.TRUE).
+                   // supports-dynamic-xslt: false, because fn:transform is not available
+        put(property("supports-dynamic-xslt"), Bln.FALSE).map();
+  }
+
+  /**
+   * Returns a no-namespace QName for a standardized property name.
+   * @param local local name
+   * @return QName
+   */
+  private static QNm property(final String local) {
+    return new QNm(local, "");
+  }
+}

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -16,6 +16,7 @@ import org.basex.query.expr.*;
 import org.basex.query.expr.List;
 import org.basex.query.expr.constr.*;
 import org.basex.query.expr.gflwor.*;
+import org.basex.query.func.fn.*;
 import org.basex.query.func.prof.ProfType.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.seq.*;
@@ -3782,6 +3783,27 @@ return
         1, type(SUM, "xs:integer?"));
     check(func.args(" (1, 2)[. = 1]", " ('a', 'b')[. = 'a']"),
         1, type(SUM, "xs:anyAtomicType?"));
+  }
+
+  /** Test method. */
+  @Test public void systemProperties() {
+    final Function func = SYSTEM_PROPERTIES;
+
+    query("map:size(" + func.args() + ')', 11);
+    query(func.args() + "?#xpath-version", 4);
+    query(func.args() + "?#xsd-version", 1.1);
+    query(func.args() + "?#product-name", Prop.NAME);
+    query(func.args() + "?#product-version", Prop.VERSION);
+    query(func.args() + "?#schema-aware", false);
+    query(func.args() + "?#accepts-typed-data", false);
+    query(func.args() + "?#supports-xinclude", true);
+    query(func.args() + "?#supports-dtd", false);
+    query(func.args() + "?#supports-invisible-xml", FnInvisibleXml.available());
+    query(func.args() + "?#supports-dynamic-xquery", true);
+    query(func.args() + "?#supports-dynamic-xslt", false);
+
+    query("every $k in map:keys(" + func.args() + ") satisfies $k instance of xs:QName", true);
+    query("every $v in " + func.args() + "?* satisfies $v instance of xs:anyAtomicType", true);
   }
 
   /** Test method. */


### PR DESCRIPTION
Implements `fn:system-properties` and adds tests for the standard properties.

This fixes QT4 test cases

- `Keywords-fn-system-properties-1`
- `fo-test-fn-system-properties-001`
- `fo-test-fn-system-properties-002`