### PR TITLE
Make `fn:schema-type` return empty sequence for non-schema-types

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/FnSchemaType.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnSchemaType.java
@@ -9,6 +9,7 @@ import org.basex.query.util.list.*;
 import org.basex.query.value.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.map.*;
+import org.basex.query.value.seq.*;
 import org.basex.query.value.type.*;
 import org.basex.query.var.*;
 import org.basex.util.*;
@@ -90,7 +91,7 @@ public class FnSchemaType extends StandardFunc {
             constructor = !type.oneOf(QNAME, NOTATION);
         }
       } else {
-        throw Util.notExpected();
+        return Empty.VALUE;
       }
       final MapBuilder mb = new MapBuilder();
       mb.put("name", name);

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -3142,6 +3142,8 @@ return
   @Test public void schemaType() {
     final Function func = SCHEMA_TYPE;
 
+    query(" declare type t as xs:integer; " + func.args(" #t"), "");
+    query(func.args(" #fn:schema-type-record"), "");
     query(func.args(" #xs:integer") + " ? name", "#integer");
     query(func.args(" #xs:long") + " ? primitive-type() ? name", "#decimal");
     query(func.args(" #xs:positiveInteger") + " ? base-type() ? name", "#nonNegativeInteger");


### PR DESCRIPTION
`fn:schema-type` incorrectly throws when it does not recognize the type name.