### PR TITLE
Add trusted options to XML functions

### DIFF
--- a/basex-core/src/main/java/org/basex/build/xml/SAXHandler.java
+++ b/basex-core/src/main/java/org/basex/build/xml/SAXHandler.java
@@ -221,4 +221,15 @@ public class SAXHandler extends DefaultHandler implements LexicalHandler {
       super(cause);
     }
   }
+
+  /** Exception raised when an external resource is encountered and trusted=false. */
+  public static class TrustedViolationException extends SAXException {
+    /**
+     * Constructor.
+     * @param resource blocked resource identifier, e.g. an entity reference
+     */
+    public TrustedViolationException(final String resource) {
+      super(resource);
+    }
+  }
 }

--- a/basex-core/src/main/java/org/basex/build/xml/SAXWrapper.java
+++ b/basex-core/src/main/java/org/basex/build/xml/SAXWrapper.java
@@ -54,7 +54,17 @@ public final class SAXWrapper extends SingleParser {
       if(reader == null) {
         reader = XmlParser.reader(options);
       }
-      if(reader.getEntityResolver() == null) {
+      final boolean trusted = options.trusted;
+      final boolean dtd = options.get(MainOptions.DTD);
+      final boolean dtdValidation = options.get(MainOptions.DTDVALIDATION);
+      if(!trusted && options.get(MainOptions.XINCLUDE))
+        throw new TrustedViolationException("xinclude");
+      if(!trusted && (dtd || dtdValidation)) {
+        // Block all external resource access: raises FODC0016 via TrustedViolationException
+        reader.setEntityResolver((pubId, sysId) -> {
+          throw new TrustedViolationException(sysId != null ? sysId : pubId != null ? pubId : "");
+        });
+      } else if(reader.getEntityResolver() == null) {
         final EntityResolver er = options.resolver().entityResolver();
         if(er != null) reader.setEntityResolver(er);
       }
@@ -73,6 +83,8 @@ public final class SAXWrapper extends SingleParser {
       final String msg = Util.info(SCANPOS_X_X, source.path(), spex.getLineNumber(),
           spex.getColumnNumber()) + COLS + Util.message(spex);
       throw new IOException(msg, ex);
+    } catch(final TrustedViolationException ex) {
+      throw new IOException(Util.info(EXTACCESS_BLOCKED_X, ex.getMessage()), ex);
     } catch(final JobException ex) {
       throw ex;
     } catch(final Exception ex) {

--- a/basex-core/src/main/java/org/basex/build/xml/SAXWrapper.java
+++ b/basex-core/src/main/java/org/basex/build/xml/SAXWrapper.java
@@ -54,7 +54,7 @@ public final class SAXWrapper extends SingleParser {
       if(reader == null) {
         reader = XmlParser.reader(options);
       }
-      final boolean trusted = options.trusted;
+      final boolean trusted = options.isTrusted();
       final boolean dtd = options.get(MainOptions.DTD);
       final boolean dtdValidation = options.get(MainOptions.DTDVALIDATION);
       if(!trusted && options.get(MainOptions.XINCLUDE))

--- a/basex-core/src/main/java/org/basex/core/CommonOptions.java
+++ b/basex-core/src/main/java/org/basex/core/CommonOptions.java
@@ -25,7 +25,9 @@ public interface CommonOptions {
   /** Internal option: {@link MainOptions#XSDVALIDATION}. */
   StringOption XSD_VALIDATION = new StringOption("xsd-validation", SKIP);
   /** Internal option: {@link MainOptions#XSILOCATION}. */
-  BooleanOption XSI_SCHEMA_LOCATION = new BooleanOption("xsi-schema-location", false);
+  BooleanOption USE_XSI_SCHEMA_LOCATION = new BooleanOption("use-xsi-schema-location", false);
+  /** Trusted option value. No default: absence means "use FNXMLTRUSTED". */
+  BooleanOption TRUSTED = new BooleanOption("trusted");
 
   /** Internal option: {@link MainOptions#STRIPNS}. */
   BooleanOption STRIPNS = new BooleanOption("stripns", false);

--- a/basex-core/src/main/java/org/basex/core/MainOptions.java
+++ b/basex-core/src/main/java/org/basex/core/MainOptions.java
@@ -70,6 +70,8 @@ public final class MainOptions extends Options {
       CommonOptions.SKIP);
   /** Flag for handling xsi:schemaLocation and xsi:noNamespaceSchemaLocation attributes. */
   public static final BooleanOption XSILOCATION = new BooleanOption("XSILOCATION", true);
+  /** Default value for the fn-level XML parser 'trusted' option (fn:doc, fn:parse-xml, etc.). */
+  public static final BooleanOption FNXMLTRUSTED = new BooleanOption("FNXMLTRUSTED", true);
   /** Flag for using XInclude. */
   public static final BooleanOption XINCLUDE = new BooleanOption("XINCLUDE", false);
   /** Path to XML Catalog files. */
@@ -189,6 +191,9 @@ public final class MainOptions extends Options {
 
   // Other
 
+  /** Whether external resources may be accessed. Derived from context, not user-configurable. */
+  public boolean trusted = true;
+
   /** Indexing options. */
   public static final Option<?>[] INDEXING = { MAXCATS, MAXLEN, SPLITSIZE, LANGUAGE, STOPWORDS,
     TEXTINDEX, ATTRINDEX, TOKENINDEX, FTINDEX, TEXTINCLUDE, ATTRINCLUDE, TOKENINCLUDE, FTINCLUDE,
@@ -203,7 +208,7 @@ public final class MainOptions extends Options {
     XMLPARSINGMAP.put(CommonOptions.DTD, DTD);
     XMLPARSINGMAP.put(CommonOptions.DTD_VALIDATION, DTDVALIDATION);
     XMLPARSINGMAP.put(CommonOptions.XSD_VALIDATION, XSDVALIDATION);
-    XMLPARSINGMAP.put(CommonOptions.XSI_SCHEMA_LOCATION, XSILOCATION);
+    XMLPARSINGMAP.put(CommonOptions.USE_XSI_SCHEMA_LOCATION, XSILOCATION);
     XMLPARSINGMAP.put(CommonOptions.XINCLUDE, XINCLUDE);
     XMLPARSINGMAP.put(CommonOptions.CATALOG, CATALOG);
   }

--- a/basex-core/src/main/java/org/basex/core/MainOptions.java
+++ b/basex-core/src/main/java/org/basex/core/MainOptions.java
@@ -191,9 +191,6 @@ public final class MainOptions extends Options {
 
   // Other
 
-  /** Whether external resources may be accessed. Derived from context, not user-configurable. */
-  public boolean trusted = true;
-
   /** Indexing options. */
   public static final Option<?>[] INDEXING = { MAXCATS, MAXLEN, SPLITSIZE, LANGUAGE, STOPWORDS,
     TEXTINDEX, ATTRINDEX, TOKENINDEX, FTINDEX, TEXTINCLUDE, ATTRINCLUDE, TOKENINCLUDE, FTINCLUDE,
@@ -255,6 +252,8 @@ public final class MainOptions extends Options {
 
   /** Resolver instance (lazy instantiation). */
   private XMLResolver resolver;
+  /** Whether external resources may be accessed. Derived from context, not user-configurable. */
+  private boolean trusted = true;
 
   /**
    * Default constructor.
@@ -278,6 +277,7 @@ public final class MainOptions extends Options {
   public MainOptions(final MainOptions options) {
     super(options);
     resolver = options.resolver;
+    trusted = options.trusted;
   }
 
   /**
@@ -289,18 +289,28 @@ public final class MainOptions extends Options {
     this(false);
     for(final Option<?> option : xml ? XMLPARSING : PARSING) put(option, options.get(option));
     resolver = options.resolver;
+    trusted = options.trusted;
   }
 
   /**
    * Constructor, adopting parsing options from the specified instance.
    * @param options options
+   * @param parent parent options
    */
-  public MainOptions(final Options options) {
+  public MainOptions(final Options options, final MainOptions parent) {
     this(false);
     XMLPARSINGMAP.forEach((source, target) -> {
       final Object value = options.get(source);
       if(value != null) put(target, value);
     });
+    final Boolean t = options.get(CommonOptions.TRUSTED);
+    if(parent == null) {
+      resolver = null;
+      trusted = t != null ? t : false;
+    } else {
+      setResolver(parent);
+      trusted = t != null ? t : parent.trusted && parent.get(FNXMLTRUSTED);
+    }
   }
 
   /**
@@ -331,5 +341,13 @@ public final class MainOptions extends Options {
     final String catalog = get(CATALOG);
     if(resolver == null || !catalog.equals(resolver.catalog())) resolver = new XMLResolver(catalog);
     return resolver;
+  }
+
+  /**
+   * Returns whether external resources may be accessed when parsing XML.
+   * @return trusted flag
+   */
+  public boolean isTrusted() {
+    return trusted;
   }
 }

--- a/basex-core/src/main/java/org/basex/core/Text.java
+++ b/basex-core/src/main/java/org/basex/core/Text.java
@@ -562,6 +562,8 @@ public interface Text {
   String NODES_PARSED_X_X = " \"%\" (" + lang("nodes_parsed_%") + ')';
   /** Scanner position. */
   String SCANPOS_X_X = "\"%\" (" + lang("line") + " %)";
+  /** External resource access blocked. */
+  String EXTACCESS_BLOCKED_X = "External resources not available, call is untrusted: %.";
 
   /** Finish database creation. */
   String FINISHING_D = lang("finishing") + DOTS;

--- a/basex-core/src/main/java/org/basex/io/parse/xml/XmlParser.java
+++ b/basex-core/src/main/java/org/basex/io/parse/xml/XmlParser.java
@@ -68,7 +68,8 @@ public final class XmlParser {
     final boolean xsiLocation = options.get(MainOptions.XSILOCATION);
     final SAXParserFactory f = SAXParserFactory.newDefaultInstance();
     // setting these options to false will ignore external entities, rather than rejecting them
-    f.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", dtd);
+    f.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd",
+        dtd || dtdValidation);
     f.setFeature("http://xml.org/sax/features/external-general-entities", dtd);
     f.setFeature("http://xml.org/sax/features/external-parameter-entities", dtd);
     f.setFeature("http://xml.org/sax/features/validation", dtdValidation);

--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -3,6 +3,8 @@ package org.basex.query;
 import static org.basex.query.QueryError.ErrType.*;
 import static org.basex.query.QueryText.*;
 
+import org.basex.core.*;
+
 import org.basex.query.expr.*;
 import org.basex.query.value.*;
 import org.basex.query.value.item.*;
@@ -597,6 +599,8 @@ public enum QueryError {
   NODTDVALIDATION(FODC, 13, "The internal parser does not support DTD validation."),
   /** Error code. */
   XSDVALIDATIONERR_X(FODC, 14, "XSD Validation error: %"),
+  /** Error code. */
+  EXTERNALRESOURCE_X(FODC, 16, Text.EXTACCESS_BLOCKED_X),
 
   /** Error code. */
   FORMATWHICH_X(FODF, 1280, "Unknown decimal format: %."),

--- a/basex-core/src/main/java/org/basex/query/QueryResources.java
+++ b/basex-core/src/main/java/org/basex/query/QueryResources.java
@@ -33,8 +33,12 @@ import org.basex.util.list.*;
 public final class QueryResources {
   /** Default options. */
   public static final DocOptions DOC_OPTIONS = new DocOptions();
-  /** Default options for creating new documents. */
-  private static final MainOptions MAIN_OPTIONS = new MainOptions(DOC_OPTIONS);
+  /** Default options for creating new documents (trusted=false: fn-level default). */
+  private static final MainOptions MAIN_OPTIONS;
+  static {
+    MAIN_OPTIONS = new MainOptions(DOC_OPTIONS);
+    MAIN_OPTIONS.trusted = false;
+  }
 
   /** Database context. */
   private final Context context;
@@ -500,10 +504,13 @@ public final class QueryResources {
     final MainOptions mopts = context.options, options;
     final boolean mainmem = !mopts.get(MainOptions.FORCECREATE);
     if(mainmem) {
-      if(docOpts == DOC_OPTIONS && mopts.resolver().standard()) {
+      if(docOpts == DOC_OPTIONS && mopts.resolver().standard()
+          && !mopts.get(MainOptions.FNXMLTRUSTED)) {
         options = MAIN_OPTIONS;
       } else {
         options = new MainOptions(docOpts);
+        final Boolean trusted = docOpts.get(DocOptions.TRUSTED);
+        options.trusted = trusted != null ? trusted : mopts.get(MainOptions.FNXMLTRUSTED);
         options.setResolver(mopts);
       }
     } else {
@@ -519,6 +526,8 @@ public final class QueryResources {
       return addData(data);
     } catch(final IOException ex) {
       final Throwable th = ex.getCause();
+      if(th instanceof TrustedViolationException)
+        throw EXTERNALRESOURCE_X.get(info, th.getMessage());
       throw !(th instanceof ValidationException) ? IOERR_X.get(info, ex) :
         options.get(MainOptions.DTDVALIDATION) ? DTDVALIDATIONERR_X.get(info, ex) :
           XSDVALIDATIONERR_X.get(info, ex);

--- a/basex-core/src/main/java/org/basex/query/QueryResources.java
+++ b/basex-core/src/main/java/org/basex/query/QueryResources.java
@@ -34,11 +34,7 @@ public final class QueryResources {
   /** Default options. */
   public static final DocOptions DOC_OPTIONS = new DocOptions();
   /** Default options for creating new documents (trusted=false: fn-level default). */
-  private static final MainOptions MAIN_OPTIONS;
-  static {
-    MAIN_OPTIONS = new MainOptions(DOC_OPTIONS);
-    MAIN_OPTIONS.trusted = false;
-  }
+  private static final MainOptions MAIN_OPTIONS = new MainOptions(DOC_OPTIONS, null);
 
   /** Database context. */
   private final Context context;
@@ -508,10 +504,7 @@ public final class QueryResources {
           && !mopts.get(MainOptions.FNXMLTRUSTED)) {
         options = MAIN_OPTIONS;
       } else {
-        options = new MainOptions(docOpts);
-        final Boolean trusted = docOpts.get(DocOptions.TRUSTED);
-        options.trusted = trusted != null ? trusted : mopts.get(MainOptions.FNXMLTRUSTED);
-        options.setResolver(mopts);
+        options = new MainOptions(docOpts, mopts);
       }
     } else {
       docOpts.checkDbAccess(info);

--- a/basex-core/src/main/java/org/basex/query/func/fn/DocOptions.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/DocOptions.java
@@ -22,8 +22,10 @@ public final class DocOptions extends Options {
   public static final BooleanOption XINCLUDE = CommonOptions.XINCLUDE;
   /** XSD validation. */
   public static final StringOption XSD_VALIDATION = CommonOptions.XSD_VALIDATION;
-  /** Flag for using XInclude. */
-  public static final BooleanOption XSI_SCHEMA_LOCATION = CommonOptions.XSI_SCHEMA_LOCATION;
+  /** Flag for using xsi:schemaLocation. */
+  public static final BooleanOption USE_XSI_SCHEMA_LOCATION = CommonOptions.USE_XSI_SCHEMA_LOCATION;
+  /** Whether external resources may be fetched. */
+  public static final BooleanOption TRUSTED = CommonOptions.TRUSTED;
   /** Whether two calls with same URI and options return the same node. */
   public static final BooleanOption STABLE = new BooleanOption("stable", true);
 

--- a/basex-core/src/main/java/org/basex/query/func/fn/Docs.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/Docs.java
@@ -92,8 +92,6 @@ public abstract class Docs extends DynamicFn {
     final Predicate<BooleanOption> bool = o -> options.get(o) == Boolean.TRUE;
     final boolean dtd = bool.test(CommonOptions.DTD) || bool.test(MainOptions.DTD);
     final boolean xinclude = bool.test(CommonOptions.XINCLUDE) || bool.test(MainOptions.XINCLUDE);
-    if(dtd || xinclude) checkPerm(qc, Perm.CREATE);
-
     final boolean intparse = fragment || bool.test(CommonOptions.INTPARSE) ||
         bool.test(MainOptions.INTPARSE);
     final boolean dtdVal = bool.test(CommonOptions.DTD_VALIDATION) ||
@@ -102,6 +100,10 @@ public abstract class Docs extends DynamicFn {
     if(xsdVal == null) xsdVal = options.get(CommonOptions.XSD_VALIDATION);
     final boolean skip = CommonOptions.SKIP.equals(xsdVal);
     final boolean strict = CommonOptions.STRICT.equals(xsdVal);
+    final boolean xsiLocation = !skip &&
+        (bool.test(CommonOptions.USE_XSI_SCHEMA_LOCATION) || bool.test(MainOptions.XSILOCATION));
+    if(dtd || xinclude || dtdVal || xsiLocation) checkPerm(qc, Perm.CREATE);
+
     if(intparse) {
       if(dtdVal) throw NODTDVALIDATION.get(info);
       if(!skip) throw NOXSDVALIDATION_X.get(info, xsdVal);

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnDocAvailable.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnDocAvailable.java
@@ -4,6 +4,7 @@ import static org.basex.query.QueryError.*;
 
 import java.util.*;
 
+import org.basex.core.*;
 import org.basex.query.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.seq.*;
@@ -18,7 +19,8 @@ import org.basex.util.*;
 public class FnDocAvailable extends Docs {
   /** Possible failures. */
   private static final EnumSet<QueryError> ERRORS = EnumSet.of(BASEX_DBPATH1_X, BASEX_DBPATH2_X,
-      IOERR_X, WHICHRES_X, RESDIR_X, INVDOC_X, DTDVALIDATIONERR_X, XSDVALIDATIONERR_X);
+      IOERR_X, WHICHRES_X, RESDIR_X, INVDOC_X, DTDVALIDATIONERR_X, XSDVALIDATIONERR_X,
+      EXTERNALRESOURCE_X);
 
   @Override
   public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
@@ -39,6 +41,15 @@ public class FnDocAvailable extends Docs {
   final Item doc(final QueryContext qc) throws QueryException {
     final DocOptions options = toOptions(arg(1), new DocOptions(), qc);
     check(options, false, qc);
+    final Boolean trustedOpt = options.get(DocOptions.TRUSTED);
+    final boolean trusted = trustedOpt != null ? trustedOpt :
+        qc.context.options.get(MainOptions.FNXMLTRUSTED);
+    if(!trusted) {
+      if(options.get(DocOptions.XINCLUDE)) throw EXTERNALRESOURCE_X.get(info, "'xinclude'");
+      if(options.get(DocOptions.USE_XSI_SCHEMA_LOCATION) &&
+          !CommonOptions.SKIP.equals(options.get(DocOptions.XSD_VALIDATION)))
+          throw EXTERNALRESOURCE_X.get(info, "'use-xsi-schema-location'");
+    }
 
     QueryInput qi = queryInput;
     if(qi == null) {

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnParseXml.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnParseXml.java
@@ -1,5 +1,7 @@
 package org.basex.query.func.fn;
 
+import static org.basex.query.QueryError.*;
+
 import org.basex.core.*;
 import org.basex.query.*;
 import org.basex.query.value.item.*;
@@ -21,6 +23,11 @@ public final class FnParseXml extends FnParseXmlFragment {
     public static final BooleanOption XINCLUDE = CommonOptions.XINCLUDE;
     /** XSD validation. */
     public static final StringOption XSD_VALIDATION = CommonOptions.XSD_VALIDATION;
+    /** Flag for using xsi:schemaLocation. */
+    public static final BooleanOption USE_XSI_SCHEMA_LOCATION =
+        CommonOptions.USE_XSI_SCHEMA_LOCATION;
+    /** Whether external resources may be fetched. */
+    public static final BooleanOption TRUSTED = CommonOptions.TRUSTED;
 
     /** Custom option (see {@link MainOptions#INTPARSE}). */
     public static final BooleanOption INTPARSE = CommonOptions.INTPARSE;
@@ -31,6 +38,15 @@ public final class FnParseXml extends FnParseXmlFragment {
   @Override
   public Item item(final QueryContext qc, final InputInfo ii) throws QueryException {
     final ParseXmlOptions options = toOptions(arg(1), new ParseXmlOptions(), qc);
+    final Boolean trustedOpt = options.get(ParseXmlOptions.TRUSTED);
+    final boolean trusted = trustedOpt != null ? trustedOpt :
+        qc.context.options.get(MainOptions.FNXMLTRUSTED);
+    if(!trusted) {
+      if(options.get(ParseXmlOptions.XINCLUDE)) throw EXTERNALRESOURCE_X.get(info, "'xinclude'");
+      if(options.get(ParseXmlOptions.USE_XSI_SCHEMA_LOCATION) &&
+          !CommonOptions.SKIP.equals(options.get(ParseXmlOptions.XSD_VALIDATION)))
+          throw EXTERNALRESOURCE_X.get(info, "'use-xsi-schema-location'");
+    }
     return parse(qc, false, options);
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnParseXmlFragment.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnParseXmlFragment.java
@@ -74,12 +74,16 @@ public class FnParseXmlFragment extends Docs {
     final IO io = new IOContent(toBytes(value), baseURI, encoding);
 
     final MainOptions mopts = new MainOptions(options);
+    final Boolean trusted = options.get(CommonOptions.TRUSTED);
+    mopts.trusted = trusted != null ? trusted : qc.context.options.get(MainOptions.FNXMLTRUSTED);
     mopts.setResolver(qc.context.options);
     try {
       final boolean ip = fragment || mopts.get(MainOptions.INTPARSE);
       return new DBNode(ip ? new XMLParser(io, mopts, fragment) : Parser.xmlParser(io, mopts));
     } catch(final IOException ex) {
       final Throwable th = ex.getCause();
+      if(th instanceof TrustedViolationException)
+        throw EXTERNALRESOURCE_X.get(info, th.getMessage());
       final QueryException qe = !(th instanceof ValidationException) ? SAXERR_X.get(info, ex) :
         mopts.get(MainOptions.DTDVALIDATION) ? DTDVALIDATIONERR_X.get(info, ex) :
           XSDVALIDATIONERR_X.get(info, ex);

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnParseXmlFragment.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnParseXmlFragment.java
@@ -73,10 +73,7 @@ public class FnParseXmlFragment extends Docs {
     final String encoding = value instanceof Bin ? null : Strings.UTF8;
     final IO io = new IOContent(toBytes(value), baseURI, encoding);
 
-    final MainOptions mopts = new MainOptions(options);
-    final Boolean trusted = options.get(CommonOptions.TRUSTED);
-    mopts.trusted = trusted != null ? trusted : qc.context.options.get(MainOptions.FNXMLTRUSTED);
-    mopts.setResolver(qc.context.options);
+    final MainOptions mopts = new MainOptions(options, qc.context.options);
     try {
       final boolean ip = fragment || mopts.get(MainOptions.INTPARSE);
       return new DBNode(ip ? new XMLParser(io, mopts, fragment) : Parser.xmlParser(io, mopts));

--- a/basex-core/src/test/java/org/basex/core/CatalogTest.java
+++ b/basex-core/src/test/java/org/basex/core/CatalogTest.java
@@ -104,7 +104,7 @@ public final class CatalogTest extends SandboxTest {
     final Function func = DOC;
 
     set(MainOptions.CATALOG, CATALOG);
-    query(func.args("http://doc.xml", " { 'dtd': true() }"), "<doc>X</doc>");
+    query(func.args("http://doc.xml", " { 'dtd': true(), 'trusted': true() }"), "<doc>X</doc>");
     query(func.args("http://doc.xml", " { 'dtd': false() }"), "<doc/>");
   }
 
@@ -114,7 +114,7 @@ public final class CatalogTest extends SandboxTest {
 
     set(MainOptions.CATALOG, CATALOG);
     query(func.args("<!DOCTYPE xml SYSTEM 'http://dtd.dtd'><doc>&amp;x;</doc>",
-        " { 'dtd': true() }"), "<doc>X</doc>");
+        " { 'dtd': true(), 'trusted': true() }"), "<doc>X</doc>");
     query(func.args("<!DOCTYPE xml SYSTEM 'http://dtd.dtd'><doc>&amp;x;</doc>",
         " { 'dtd': 'no' }"), "<doc/>");
   }

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -878,14 +878,39 @@ public final class FnModuleTest extends SandboxTest {
     final String doc2 = write.apply("doc2.xml",
         "<root2 xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
         + "xsi:noNamespaceSchemaLocation=\"schema.xsd\"/>");
-    query(func.args(doc1, " { 'xsd-validation': 'strict', 'xsi-schema-location': true() }"),
+    query(func.args(doc1, " { 'xsd-validation': 'strict', 'use-xsi-schema-location': true(),"
+        + " 'trusted': true() }"),
         "<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
         + "xsi:noNamespaceSchemaLocation=\"schema.xsd\"/>");
+    error(func.args(doc1, " { 'xsd-validation': 'strict', 'use-xsi-schema-location': false(),"
+        + " 'trusted': true() }"), IOERR_X);
+    error(func.args(doc2, " { 'xsd-validation': 'strict', 'use-xsi-schema-location': true(),"
+        + " 'trusted': true() }"), XSDVALIDATIONERR_X);
+    error(func.args(doc1, " { 'xsd-validation': 'strict', 'use-xsi-schema-location': true(),"
+        + " 'trusted': false()  }"),
+        EXTERNALRESOURCE_X);
+    error("xquery:eval(``[" + func.args(doc2, " { 'xsd-validation': 'strict', 'use-xsi-schema-locat"
+        + "ion': true(), 'trusted': true() }") + "]``, (), {'permission': 'write'})",
+        XQUERY_PERM_X);
 
-    error(func.args(doc1, " { 'xsd-validation': 'strict', 'xsi-schema-location': false() }"),
-        IOERR_X);
-    error(func.args(doc2, " { 'xsd-validation': 'strict', 'xsi-schema-location': true() }"),
-        XSDVALIDATIONERR_X);
+    final String docWithExtDtd = write.apply("ext-dtd.xml",
+        "<!DOCTYPE root SYSTEM 'validate.dtd'><root/>");
+    write.apply("validate.dtd", "<!ELEMENT root (#PCDATA)>");
+    query(func.args(docWithExtDtd, " { 'dtd-validation': 'yes', 'trusted': true() }"), "<root/>");
+    error(func.args(docWithExtDtd, " { 'dtd-validation': 'yes', 'trusted': false() }"),
+        EXTERNALRESOURCE_X);
+    error("xquery:eval(``[" + func.args(docWithExtDtd, " { 'dtd-validation': 'yes', 'trusted': true"
+        + "() }") + "]``, (), {'permission': 'read'})", XQUERY_PERM_X);
+
+    final String xincDoc = write.apply("xinclude.xml",
+        "<?xml version='1.0'?>"
+        + "<root xmlns:xi='http://www.w3.org/2001/XInclude'>"
+        + "<xi:include href='doc1.xml'/></root>");
+    query("exists(" + func.args(xincDoc, " { 'xinclude': true(), 'trusted': true() }")
+        + "/root/root)", true);
+    error(func.args(xincDoc, " { 'xinclude': true(), 'trusted': false() }"), EXTERNALRESOURCE_X);
+    error("xquery:eval(``[exists(" + func.args(xincDoc, " { 'xinclude': true(), 'trusted': true() }"
+        ) + "/root/root)" + "]``, (), {'permission': 'none'})", XQUERY_PERM_X);
   }
 
   /** Test method. */
@@ -896,6 +921,12 @@ public final class FnModuleTest extends SandboxTest {
     query(func.args("/"), false);
     query(func.args("/a/b/c/d/e"), false);
     query(func.args(DOC, " {}"), true);
+    query(func.args(DOC, " { 'xinclude': true(), 'trusted': true() }"), true);
+    query(func.args(DOC, " { 'xinclude': true(), 'trusted': false() }"), false);
+    query(func.args(DOC, " { 'use-xsi-schema-location': true(), 'trusted': true() }"), true);
+    query(func.args(DOC, " { 'use-xsi-schema-location': true(), 'trusted': false() }"), true);
+    query(func.args(DOC, " { 'use-xsi-schema-location': true(), 'trusted': false(), "
+        + "'xsd-validation': 'strict' }"), false);
   }
 
   /**
@@ -2727,32 +2758,49 @@ return
         + "<!ELEMENT a (#PCDATA | b)*>"
         + "<!ELEMENT b EMPTY>"
         + "<!ENTITY e SYSTEM '" + path + "'>]>";
-    query(func.args(dtd + "<a>&amp;e;</a>"), "<a><b/></a>");
+    error(func.args(dtd + "<a>&amp;e;</a>", " { 'trusted': false() }"), EXTERNALRESOURCE_X);
+    query(func.args(dtd + "<a>&amp;e;</a>", " { 'trusted': true() }"), "<a><b/></a>");
     query(func.args(dtd + "<a>&amp;e;</a>", " { 'dtd': 'no' }"), "<a/>");
-    query(func.args(dtd + "<a>&amp;e;</a>", " { 'dtd': 'yes' }"), "<a><b/></a>");
-    query(func.args(dtd + "<b>&amp;e;</b>", " { 'dtd': 'yes' }"), "<b><b/></b>");
+    query(func.args(dtd + "<a>&amp;e;</a>", " { 'dtd': 'yes', 'trusted': true() }"), "<a><b/></a>");
+    query(func.args(dtd + "<b>&amp;e;</b>", " { 'dtd': 'yes', 'trusted': true() }"), "<b><b/></b>");
     query(func.args(dtd + "<a><b/></a>", " { 'dtd-validation': 'yes' }"), "<a><b/></a>");
-    query(func.args(dtd + "<a>&amp;e;</a>", " { 'dtd-validation': 'no' }"), "<a><b/></a>");
-    query(func.args(dtd + "<a>&amp;e;</a>", " { 'dtd-validation': 'yes' }"), "<a><b/></a>");
-    query(func.args(dtd + "<a>&amp;e;</a>", " { 'dtd-validation': 'yes', 'dtd': 'yes' }"),
+    query(func.args(dtd + "<a>&amp;e;</a>", " { 'dtd-validation': 'no', 'trusted': true() }"),
         "<a><b/></a>");
+    query(func.args(dtd + "<a>&amp;e;</a>", " { 'dtd-validation': 'yes', 'trusted': true() }"),
+        "<a><b/></a>");
+    query(func.args(dtd + "<a>&amp;e;</a>", " { 'dtd-validation': 'yes', 'dtd': 'yes', 'trusted': "
+        + "true() }"), "<a><b/></a>");
+    error(func.args("<!DOCTYPE root SYSTEM 'src/test/resources/validate.dtd'><root/>",
+        " { 'dtd-validation': 'yes', 'trusted': false() }"), EXTERNALRESOURCE_X);
+    query(func.args("<!DOCTYPE root SYSTEM 'src/test/resources/validate.dtd'><root/>",
+        " { 'dtd-validation': 'yes', 'trusted': true() }"), "<root/>");
     query(func.args("<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' "
         + "xsi:noNamespaceSchemaLocation='src/test/resources/validate.xsd'/>",
-        " { 'xsd-validation': 'strict' }"),
+        " { 'xsd-validation': 'strict', 'use-xsi-schema-location': true(), 'trusted': true() }"),
         "<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
         + "xsi:noNamespaceSchemaLocation=\"src/test/resources/validate.xsd\"/>");
 
     query(func.args("<a xmlns:xi='http://www.w3.org/2001/XInclude'><xi:include href='" + path
         + "'/></a>", " { 'xinclude': 'no' }"), "<a xmlns:xi=\"http://www.w3.org/2001/XInclude\">"
         + "<xi:include href=\"" + path + "\"/></a>");
+    error(func.args("<a xmlns:xi='http://www.w3.org/2001/XInclude'><xi:include href='" + path
+        + "'/></a>", " { 'xinclude': true(), 'trusted': false() }"), EXTERNALRESOURCE_X);
     query(func.args("<a xmlns:xi='http://www.w3.org/2001/XInclude'><xi:include href='" + path
-        + "'/></a>", " { 'xinclude': 'yes' }"), "<a xmlns:xi=\"http://www.w3.org/2001/XInclude\">"
+        + "'/></a>", " { 'xinclude': true(), 'trusted': true() }"),
+        "<a xmlns:xi=\"http://www.w3.org/2001/XInclude\">"
         + "<b xml:base=\"src/test/resources/parse-xml.entity\"/></a>");
 
-    error(func.args(dtd + "<b>&amp;e;</b>", " { 'dtd-validation': 'yes' }"), DTDVALIDATIONERR_X);
+    error(func.args("<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' "
+        + "xsi:noNamespaceSchemaLocation='src/test/resources/validate.xsd'/>",
+        " { 'xsd-validation': 'strict', 'use-xsi-schema-location': true(), 'trusted': false() }"),
+        EXTERNALRESOURCE_X);
+
+    error(func.args(dtd + "<b>&amp;e;</b>",
+        " { 'dtd-validation': 'yes', 'trusted': true() }"), DTDVALIDATIONERR_X);
     error(func.args("<a xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' "
         + "xsi:noNamespaceSchemaLocation='src/test/resources/validate.xsd'/>",
-        " { 'xsd-validation': 'strict' }"), XSDVALIDATIONERR_X);
+        " { 'xsd-validation': 'strict', 'use-xsi-schema-location': true(),"
+        + " 'trusted': true() }"), XSDVALIDATIONERR_X);
     error(func.args("<a/>", " { 'catalog': 'catalog.xml' }"), INVALIDOPTION_X);
   }
 

--- a/basex-tests/src/main/java/org/basex/tests/w3c/QT3TS.java
+++ b/basex-tests/src/main/java/org/basex/tests/w3c/QT3TS.java
@@ -126,6 +126,7 @@ public final class QT3TS extends Main {
     sopts.set(SerializerOptions.OMIT_XML_DECLARATION, YesNo.NO);
     ctx.options.set(MainOptions.SERIALIZER, sopts);
     ctx.options.set(MainOptions.DTD, true);
+    ctx.options.set(MainOptions.FNXMLTRUSTED, false);
 
     final XdmValue doc = new XQuery("doc('" + file(false, CATALOG) + "')", ctx).value();
     final String version = asString("*:catalog/@version", doc);


### PR DESCRIPTION
This PR adds support for the XQuery 4.0 `trusted` option to `fn:doc`, `fn:doc-available`, `fn:parse-xml`, and `fn:parse-xml-fragment`.

It also renames `xsi-schema-location` to `use-xsi-schema-location` (this is a breaking change).

External-resource features are now protected on two levels:
- `Perm.CREATE` is required for options that may trigger external access (`dtd`, `dtd-validation`, `xinclude`, and `use-xsi-schema-location`  with active XSD validation)
- the fn-level `trusted` option decides whether this access is actually allowed, otherwise `FODC0016` is raised

`dtd-validation` may now trigger external DTD loading independently of `dtd`.

The implementation-defined default for omitted fn-level `trusted` is controlled by `FNXMLTRUSTED`. It defaults to `true` for backwards-compatible behavior. The QT3 test driver sets `FNXMLTRUSTED` to `false` to test the spec default.