### PR TITLE
Ensure balanced calls to `openElem`/`closeElem` in `CsvBuilder`

### DIFF
--- a/basex-core/src/main/java/org/basex/build/csv/CsvBuilder.java
+++ b/basex-core/src/main/java/org/basex/build/csv/CsvBuilder.java
@@ -25,6 +25,8 @@ final class CsvBuilder extends CsvConverter {
   private final Builder builder;
   /** Current line. */
   private int line;
+  /** Record element is open. */
+  private boolean elemOpen;
 
   /**
    * Constructor.
@@ -42,6 +44,7 @@ final class CsvBuilder extends CsvConverter {
   public void record() throws IOException {
     finishRecord();
     builder.openElem(Q_RECORD.string(), atts, nsp);
+    elemOpen = true;
     col = -1;
     line++;
   }
@@ -98,6 +101,9 @@ final class CsvBuilder extends CsvConverter {
    * @throws IOException I/O exception
    */
   private void finishRecord() throws IOException {
-    if(col >= 0) builder.closeElem();
+    if(elemOpen) {
+      builder.closeElem();
+      elemOpen = false;
+    }
   }
 }

--- a/basex-core/src/test/java/org/basex/build/CsvParserTest.java
+++ b/basex-core/src/test/java/org/basex/build/CsvParserTest.java
@@ -138,4 +138,26 @@ public final class CsvParserTest extends SandboxTest {
     execute(new CreateDB(NAME, FILE));
     assertEquals("true", query("exists(//entry[@name = 'Name'])"));
   }
+
+  /**
+   * CSV Parsing: empty lines #2653.
+   */
+  @Test public void gh2653() {
+    write(new IOFile(TEMP), "");
+    execute(new CreateDB(NAME, TEMP));
+    query(".", "<csv/>");
+
+    write(new IOFile(TEMP), "\n");
+    execute(new CreateDB(NAME, TEMP));
+    query(".", "<csv><record/></csv>");
+
+    write(new IOFile(TEMP), "\n\n");
+    execute(new CreateDB(NAME, TEMP));
+    query(".", "<csv><record/><record/></csv>");
+
+    write(new IOFile(TEMP), "X\n\nY\n");
+    execute(new CreateDB(NAME, TEMP));
+    query(".", "<csv><record><entry>X</entry></record><record/><record><entry>Y</entry></record></c"
+        + "sv>");
+  }
 }


### PR DESCRIPTION
For empty rows, `CsvBuilder` failed to issue `closeElem` for the `<record>` element to the underlying database `Builder`. This left one or more elements open, so when the document was closed, `closeDoc` left the document with its preliminary size of 0. When walking through a document with size 0, the size never advances while allocating resources, causing the OOM.

The fix is to make sure `closeElem` is always called for `<record>`, even when the row is empty.