### PR TITLE
Ignore `file:copy` and `file:move` on identical source and target paths

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/file/FileCopy.java
+++ b/basex-core/src/main/java/org/basex/query/func/file/FileCopy.java
@@ -40,9 +40,18 @@ public class FileCopy extends FileFn {
     Path trg = absolute(toPath(arg(1), qc));
 
     // ignore operations on identical, canonical source and target path
-    if(src.equals(trg)) return;
+    if(src.toString().equals(trg.toString())) return;
 
     if(Files.isDirectory(trg)) {
+      if(src.equals(trg)) {
+        // case-insensitive file system: rename directory to different capitalization
+        if(!copy) {
+          final Path tmp = src.resolveSibling(UUID.randomUUID().toString());
+          Files.move(src, tmp);
+          Files.move(tmp, trg);
+        }
+        return;
+      }
       // target is a directory: attach file name
       trg = trg.resolve(src.getFileName());
       if(!Files.isDirectory(src) && Files.isDirectory(trg))

--- a/basex-core/src/main/java/org/basex/query/func/file/FileCopy.java
+++ b/basex-core/src/main/java/org/basex/query/func/file/FileCopy.java
@@ -39,6 +39,9 @@ public class FileCopy extends FileFn {
     final Path src = absolute(source);
     Path trg = absolute(toPath(arg(1), qc));
 
+    // ignore operations on identical, canonical source and target path
+    if(src.equals(trg)) return;
+
     if(Files.isDirectory(trg)) {
       // target is a directory: attach file name
       trg = trg.resolve(src.getFileName());
@@ -49,7 +52,6 @@ public class FileCopy extends FileFn {
       throw FILE_IS_DIR_X.get(info, src.toAbsolutePath());
     }
 
-    // ignore operations on identical, canonical source and target path
     relocate(src, trg, copy, qc);
   }
 

--- a/basex-core/src/test/java/org/basex/query/func/FileModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FileModuleTest.java
@@ -338,6 +338,15 @@ public final class FileModuleTest extends SandboxTest {
     query(func.args(PATH1, PATH1));
     query(_FILE_EXISTS.args(PATH1), true);
     query(_FILE_DELETE.args(PATH1));
+
+    // rename directory to different capitalization (GH-2652)
+    final String upper = PATH + "X", lower = PATH + "x";
+    query(_FILE_CREATE_DIR.args(upper));
+    query(func.args(upper, lower));
+    final File[] matches = new File(PATH).listFiles(f -> f.getName().equalsIgnoreCase("x"));
+    assertEquals(1, matches.length);
+    assertEquals("x", matches[0].getName());
+    query(_FILE_DELETE.args(lower));
   }
 
   /** Test method. */

--- a/basex-core/src/test/java/org/basex/query/func/FileModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FileModuleTest.java
@@ -134,6 +134,13 @@ public final class FileModuleTest extends SandboxTest {
     query(func.args(PATH2, PATH2));
     query(_FILE_SIZE.args(PATH1), 1);
     query(_FILE_SIZE.args(PATH2), 1);
+
+    // same source and target directory (GH-2652)
+    query(_FILE_DELETE.args(PATH1));
+    query(_FILE_CREATE_DIR.args(PATH1));
+    query(func.args(PATH1, PATH1));
+    query(_FILE_EXISTS.args(PATH1), true);
+    query(_FILE_DELETE.args(PATH1));
   }
 
   /** Test method. */
@@ -324,6 +331,13 @@ public final class FileModuleTest extends SandboxTest {
     query(func.args(PATH + "../" + NAME + '/' + NAME, PATH1));
     query(_FILE_SIZE.args(PATH1), 1);
     query(_FILE_EXISTS.args(PATH2), false);
+
+    // same source and target directory (GH-2652)
+    query(_FILE_DELETE.args(PATH1));
+    query(_FILE_CREATE_DIR.args(PATH1));
+    query(func.args(PATH1, PATH1));
+    query(_FILE_EXISTS.args(PATH1), true);
+    query(_FILE_DELETE.args(PATH1));
   }
 
   /** Test method. */


### PR DESCRIPTION
When the source and target of `file:copy` and `file:move` refer to the same directory, this executes forever, creating a deeply nested structure.

The change in this PR explicitly ignores this situation, in fact implementing what a comment in `FileCopy.relocate` already suggested.