### PR TITLE
Add `fn:regex` and `fn:compiled-regex-record`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryContext.java
+++ b/basex-core/src/main/java/org/basex/query/QueryContext.java
@@ -26,6 +26,7 @@ import org.basex.io.serial.*;
 import org.basex.query.ann.*;
 import org.basex.query.expr.*;
 import org.basex.query.func.*;
+import org.basex.query.util.regex.*;
 import org.basex.query.func.java.*;
 import org.basex.query.iter.*;
 import org.basex.query.scope.*;
@@ -101,6 +102,8 @@ public final class QueryContext extends Job implements Closeable {
   /** Scoring flag. */
   public boolean scoring;
 
+  /** Compiled regular expression cache (shared with parent context). */
+  public final TokenObjectMap<RegExpr> regexPatterns;
   /** Available collations. */
   public TokenObjectMap<Collation> collations;
   /** Profiling results. */
@@ -185,6 +188,7 @@ public final class QueryContext extends Job implements Closeable {
     resources = parent != null ? parent.resources : new QueryResources(this);
     ftPosData = parent != null ? parent.ftPosData : null;
     shared = parent != null ? parent.shared : new SharedData();
+    regexPatterns = parent != null ? parent.regexPatterns : new TokenObjectMap<>();
     user = context.user();
   }
 

--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -600,8 +600,11 @@ public enum Function implements AFunction {
   REMOVE(FnRemove::new, "remove(input,positions)",
       params(ITEM_ZM, INTEGER_ZM), ITEM_ZM),
   /** XQuery function. */
+  REGEX(FnRegex::new, "regex(pattern[,flags])",
+      params(STRING_O, STRING_ZO), Records.COMPILED_REGEX.get().seqType()),
+  /** XQuery function. */
   REPLACE(FnReplace::new, "replace(value,pattern[,replacement,flags])",
-      params(STRING_ZO, STRING_O, ITEM_ZO, STRING_ZO), STRING_O),
+      params(STRING_ZO, STRING_O, FnReplace.REPLACEMENT_TYPE, STRING_ZO), STRING_O),
   /** XQuery function. */
   REPLICATE(FnReplicate::new, "replicate(input,count[,multiple])",
       params(ITEM_ZM, INTEGER_O, BOOLEAN_ZO), ITEM_ZM),
@@ -803,6 +806,8 @@ public enum Function implements AFunction {
   /** XQuery function. */
   ATTRIBUTE_CONVERSION_PLAN_RECORD(Records.ATTRIBUTE_CONVERSION_PLAN.get()),
   /** XQuery function. */
+  COMPILED_REGEX_RECORD(Records.COMPILED_REGEX.get()),
+  /** XQuery function. */
   DATETIME_RECORD(Records.DATETIME.get()),
   /** XQuery function. */
   DIVIDED_DECIMALS_RECORD(Records.DIVIDED_DECIMALS.get()),
@@ -812,6 +817,10 @@ public enum Function implements AFunction {
   INFER_ENCODING_RECORD(Records.INFER_ENCODING.get()),
   /** XQuery function. */
   LOAD_XQUERY_MODULE_RECORD(Records.LOAD_XQUERY_MODULE.get()),
+  /** XQuery function. */
+  MATCHING_GROUP_RECORD(Records.MATCHING_GROUP.get()),
+  /** XQuery function. */
+  MATCHING_SEGMENT_RECORD(Records.MATCHING_SEGMENT.get()),
   /** XQuery function. */
   MEMBER_RECORD(Records.MEMBER.get()),
   /** XQuery function. */

--- a/basex-core/src/main/java/org/basex/query/func/Records.java
+++ b/basex-core/src/main/java/org/basex/query/func/Records.java
@@ -2,6 +2,8 @@ package org.basex.query.func;
 
 import static org.basex.query.QueryText.*;
 
+import org.basex.query.expr.path.*;
+import org.basex.query.func.fn.*;
 import org.basex.query.util.hash.*;
 import org.basex.query.util.list.*;
 import org.basex.query.value.item.*;
@@ -18,7 +20,9 @@ import org.basex.util.hash.*;
 public enum Records {
   /** Record definition. */
   ATTRIBUTE_CONVERSION_PLAN(FN_URI, "attribute-conversion-plan",
-      field("type", EnumType.get("numeric", "boolean", "string", "skip").seqType())),
+    field("type", EnumType.get("numeric", "boolean", "string", "skip").seqType())),
+  /** Record definition. */
+  COMPILED_REGEX(FN_URI, "compiled-regex"),
   /** Record definition. */
   DATETIME(FN_URI, "dateTime",
     field("year", Types.INTEGER_ZO, true),
@@ -100,7 +104,7 @@ public enum Records {
       BUILT_IN.put(record.get().name(), record.get());
     }
 
-    // recursive definitions
+    // definitions requiring (possibly recursive) forward references
     final RecordType rng = RANDOM_NUMBER_GENERATOR.get();
     rng.add("number", false, Types.DOUBLE_O).
         add("next", false, FuncType.get(rng.seqType()).seqType()).
@@ -117,6 +121,20 @@ public enum Records {
         add("matches", true, FuncType.get(Types.BOOLEAN_O, Types.ANY_ATOMIC_TYPE_O).seqType()).
         add("constructor", true, FuncType.get(Types.ANY_ATOMIC_TYPE_ZM,
             Types.ANY_ATOMIC_TYPE_ZO).seqType());
+
+    final RecordType crx = COMPILED_REGEX.get();
+    crx.add("pattern", false, Types.STRING_O).
+        add("flags", false, Types.STRING_O).
+        add("matches", false, FuncType.get(Types.BOOLEAN_O, Types.STRING_O).seqType()).
+        add("tokenize", false, FuncType.get(Types.STRING_ZM, Types.STRING_O).seqType()).
+        add("replace", false, FuncType.get(Types.STRING_O, Types.STRING_O, ChoiceItemType.get(
+            BasicType.STRING, FuncType.get(Types.ITEM_ZO, Types.UNTYPED_ATOMIC_O,
+                Types.UNTYPED_ATOMIC_ZM)).seqType(Occ.ZERO_OR_ONE)).seqType()).
+        add("analyze-string", false, FuncType.get(
+            NodeType.get(NameTest.get(FnAnalyzeString.Q_ANALYZE_STRING_RESULT)).seqType(),
+            Types.STRING_O).seqType()).
+        add("matching-segments", false, FuncType.get(
+            MATCHING_SEGMENT.get().seqType(Occ.ZERO_OR_MORE), Types.STRING_O).seqType());
   }
 
   /** Record type. */

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnAnalyzeString.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnAnalyzeString.java
@@ -6,6 +6,7 @@ import static org.basex.util.Token.*;
 import java.util.regex.*;
 
 import org.basex.query.*;
+import org.basex.query.util.regex.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.node.*;
 import org.basex.util.*;
@@ -40,7 +41,7 @@ public final class FnAnalyzeString extends RegExFn {
     final byte[] pattern = toToken(arg(1), qc);
     final byte[] flags = toZeroToken(arg(2), qc);
 
-    final RegExpr regExpr = regExpr(pattern, flags);
+    final RegExpr regExpr = regExpr(pattern, flags, qc);
     final Matcher matcher = regExpr.pattern.matcher(value);
     final FBuilder root = FElem.build(Q_ANALYZE_STRING_RESULT).ns();
     int start = 0;

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnMatches.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnMatches.java
@@ -32,7 +32,7 @@ public final class FnMatches extends RegExFn {
       final int ch = patternChar(pattern);
       if(ch != -1) return contains(value, ch);
     }
-    return pattern(pattern, flags).matcher(string(value)).find();
+    return pattern(pattern, flags, qc).matcher(string(value)).find();
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnMatchingSegments.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnMatchingSegments.java
@@ -26,7 +26,7 @@ public final class FnMatchingSegments extends RegExFn {
     final byte[] pattern = toToken(arg(1), qc);
     final byte[] flags = toZeroToken(arg(2), qc);
 
-    final Matcher matcher = pattern(pattern, flags).matcher(value);
+    final Matcher matcher = pattern(pattern, flags, qc).matcher(value);
     final ValueBuilder vb = new ValueBuilder(qc);
     while(matcher.find()) {
       final MapBuilder groups = new MapBuilder();

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnRegex.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnRegex.java
@@ -1,0 +1,83 @@
+package org.basex.query.func.fn;
+
+import static org.basex.query.func.Function.*;
+
+import org.basex.query.*;
+import org.basex.query.func.*;
+import org.basex.query.util.list.*;
+import org.basex.query.value.item.*;
+import org.basex.query.value.map.*;
+import org.basex.query.value.type.*;
+import org.basex.query.var.*;
+import org.basex.util.*;
+
+/**
+ * Function implementation.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public final class FnRegex extends RegExFn {
+  @Override
+  public XQMap item(final QueryContext qc, final InputInfo ii) throws QueryException {
+    final byte[] pattern = toToken(arg(0), qc);
+    final byte[] flags = toZeroToken(arg(1), qc);
+
+    // validate pattern and pre-warm cache
+    regExpr(pattern, flags, qc);
+    final Str pat = Str.get(pattern);
+    final Str flg = Str.get(flags);
+    final XQMap map = new MapBuilder().
+        put("pattern", pat).
+        put("flags", flg).
+        put("matches", unaryStringFunc(MATCHES, qc, pat, flg)).
+        put("tokenize", unaryStringFunc(TOKENIZE, qc, pat, flg)).
+        put("replace", replaceFunc(qc, pat, flg)).
+        put("analyze-string", unaryStringFunc(ANALYZE_STRING, qc, pat, flg)).
+        put("matching-segments", unaryStringFunc(MATCHING_SEGMENTS, qc, pat, flg)).
+        map();
+    map.type = Records.COMPILED_REGEX.get();
+    return map;
+  }
+
+  /**
+   * Creates a function item for a built-in, taking a single string input, closing over the
+   * compiled pattern and flags.
+   * @param fn built-in function
+   * @param qc query context
+   * @param pat pattern
+   * @param flg flags
+   * @return function item
+   */
+  private FuncItem unaryStringFunc(final Function fn, final QueryContext qc,
+      final Str pat, final Str flg) {
+    final FuncDefinition def = fn.definition();
+    final Var s = new Var(new QNm("s"), null, qc, info, 0, null);
+    final Var[] params = { s };
+    return new FuncItem(info,
+        fn.get(info, new VarRef(info, s), pat, flg),
+        params, AnnList.EMPTY,
+        FuncType.get(def.seqType, Types.STRING_O),
+        params.length, def.name);
+  }
+
+  /**
+   * Creates a function item for {@code fn:replace}, taking string and replacement inputs, closing
+   * over the compiled pattern and flags.
+   * @param qc query context
+   * @param pat pattern
+   * @param flg flags
+   * @return function item
+   */
+  private FuncItem replaceFunc(final QueryContext qc, final Str pat, final Str flg) {
+    final FuncDefinition def = REPLACE.definition();
+    final Var s = new Var(new QNm("s"), null, qc, info, 0, null);
+    final Var rep = new Var(new QNm("replacement"), null, qc, info, 1, null);
+    final Var[] params = { s, rep };
+    return new FuncItem(info,
+        REPLACE.get(info, new VarRef(info, s), pat, new VarRef(info, rep), flg),
+        params, AnnList.EMPTY,
+        FuncType.get(def.seqType, Types.STRING_O, FnReplace.REPLACEMENT_TYPE),
+        params.length, def.name);
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnReplace.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnReplace.java
@@ -7,8 +7,10 @@ import java.util.regex.*;
 
 import org.basex.query.*;
 import org.basex.query.func.*;
+import org.basex.query.util.regex.*;
 import org.basex.query.value.*;
 import org.basex.query.value.item.*;
+import org.basex.query.value.type.*;
 import org.basex.util.*;
 
 /**
@@ -18,6 +20,11 @@ import org.basex.util.*;
  * @author Christian Gruen
  */
 public final class FnReplace extends RegExFn {
+  /** Type of the replacement argument. */
+  public static final SeqType REPLACEMENT_TYPE =
+      ChoiceItemType.get(BasicType.STRING, FuncType.get(Types.ITEM_ZO,
+          Types.UNTYPED_ATOMIC_O, Types.UNTYPED_ATOMIC_ZM)).seqType(Occ.ZERO_OR_ONE);
+
   @Override
   public Str item(final QueryContext qc, final InputInfo ii) throws QueryException {
     final byte[] value = toZeroToken(arg(0), qc);
@@ -34,7 +41,7 @@ public final class FnReplace extends RegExFn {
       final int sp = patternChar(pattern), rp = func ? -1 : patternChar(replace);
       if(sp != -1 && rp != -1) return Str.get(replace(value, sp, rp));
     }
-    final RegExpr regExpr = regExpr(pattern, flags);
+    final RegExpr regExpr = regExpr(pattern, flags, qc);
     final Matcher matcher = regExpr.pattern.matcher(string(value));
 
     if(func) {

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnTokenize.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnTokenize.java
@@ -56,7 +56,7 @@ public final class FnTokenize extends RegExFn {
       }
     }
 
-    final Pattern p = pattern(pattern, flags);
+    final Pattern p = pattern(pattern, flags, qc);
     return vl == 0 ? Empty.ITER : new Iter() {
       final String string = Token.string(value);
       final Matcher matcher = p.matcher(string);
@@ -89,7 +89,7 @@ public final class FnTokenize extends RegExFn {
       if(ch != -1) return vl == 0 ? Empty.VALUE : StrSeq.get(Token.split(value, ch, true));
     }
 
-    final Pattern p = pattern(pattern, flags);
+    final Pattern p = pattern(pattern, flags, qc);
     if(vl == 0) return Empty.VALUE;
 
     final TokenList tl = new TokenList();

--- a/basex-core/src/main/java/org/basex/query/func/fn/RegExFn.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/RegExFn.java
@@ -4,15 +4,14 @@ import static java.util.regex.Pattern.*;
 import static org.basex.query.QueryError.*;
 import static org.basex.util.Token.*;
 
-import java.util.*;
 import java.util.regex.*;
 
 import org.basex.query.*;
 import org.basex.query.func.*;
+import org.basex.query.util.regex.*;
 import org.basex.query.util.regex.parse.*;
 import org.basex.util.*;
 import org.basex.util.Token;
-import org.basex.util.hash.*;
 
 /**
  * Regular expression functions.
@@ -20,78 +19,40 @@ import org.basex.util.hash.*;
  * @author BaseX Team, BSD License
  * @author Christian Gruen
  */
-abstract class RegExFn extends StandardFunc {
+public abstract class RegExFn extends StandardFunc {
   /** Regex characters. */
   static final byte[] REGEX_CHARS = Token.token("\\^$.|?*+()[]{}");
-
-  /** Pattern cache. */
-  private final TokenObjectMap<RegExpr> patterns = new TokenObjectMap<>();
-
-  /**
-   * Regular expression pattern.
-   */
-  static class RegExpr {
-    /** Pattern. */
-    final Pattern pattern;
-    /** Group info. */
-    private GroupInfo groupInfo;
-
-    /**
-     * Constructor.
-     * @param pattern pattern
-     */
-    RegExpr(final Pattern pattern) {
-      this.pattern = pattern;
-      groupInfo = null;
-    }
-
-    /**
-     * Returns the parent group IDs of capturing groups.
-     * @return parent group IDs.
-     */
-    int[] getParentGroups() {
-      if(groupInfo == null) groupInfo = GroupScanner.groupInfo(pattern.pattern());
-      return groupInfo.parentGroups;
-    }
-
-    /**
-     * Returns the assertion flags of capturing groups.
-     * @return assertion flags.
-     */
-    boolean[] getAssertionFlags() {
-      if(groupInfo == null) groupInfo = GroupScanner.groupInfo(pattern.pattern());
-      return groupInfo.assertionFlags;
-    }
-  }
 
   /**
    * Returns a regular expression pattern.
    * @param pattern pattern
    * @param flags flags (can be {@code null})
+   * @param qc query context
    * @return pattern modifier
    * @throws QueryException query exception
    */
-  final Pattern pattern(final byte[] pattern, final byte[] flags)
+  final Pattern pattern(final byte[] pattern, final byte[] flags, final QueryContext qc)
       throws QueryException {
-    return regExpr(pattern, flags).pattern;
+    return regExpr(pattern, flags, qc).pattern;
   }
 
   /**
-   * Returns a regular expression pattern.
+   * Returns a compiled regular expression.
    * @param pattern pattern
    * @param flags flags
-   * @return pattern modifier
+   * @param qc query context
+   * @return compiled regular expression
    * @throws QueryException query exception
    */
-  final RegExpr regExpr(final byte[] pattern, final byte[] flags)
+  final RegExpr regExpr(final byte[] pattern, final byte[] flags, final QueryContext qc)
       throws QueryException {
 
     final byte[] key = Token.concat(pattern, '\b', flags);
-    synchronized(patterns) {
-      RegExpr regExpr = patterns.get(key);
+    synchronized(qc.regexPatterns) {
+      RegExpr regExpr = qc.regexPatterns.get(key);
       if(regExpr == null) {
         regExpr = parse(pattern, flags);
-        patterns.put(key, regExpr);
+        qc.regexPatterns.put(key, regExpr);
       }
       return regExpr;
     }
@@ -148,189 +109,6 @@ abstract class RegExFn extends StandardFunc {
     } catch(final PatternSyntaxException | ParseException | TokenMgrError ex) {
       Util.debug(ex);
       throw REGINVALID_X.get(info, regex);
-    }
-  }
-
-  /**
-   * Information about capturing groups.
-   */
-  public static class GroupInfo {
-    /** Parent group: element i contains the parent group ID of capturing group i+1. */
-    public final int[] parentGroups;
-    /** Assertion status: element i tells whether capturing group i+1 occurs in an assertion. */
-    public final boolean[] assertionFlags;
-
-    /**
-     * Constructor.
-     * @param parentGroup parent group IDs
-     * @param assertionFlags inside of assertion indicators
-     */
-    GroupInfo(final int[] parentGroup, final boolean[] assertionFlags) {
-      parentGroups = parentGroup;
-      this.assertionFlags = assertionFlags;
-    }
-  }
-
-  /**
-   * Analyze the nesting of capturing groups in a Java regular expression.
-   */
-  protected static final class GroupScanner {
-    /** The pattern. */
-    private final String pattern;
-    /** Pattern length. */
-    private final int len;
-    /** Current position. */
-    private int pos;
-    /** Length of most recent code point. */
-    private int chrCount;
-
-    /** Constructor.
-     * @param pattern a Java regular expression.
-     */
-    private GroupScanner(final String pattern) {
-      this.pattern = pattern;
-      len = pattern.length();
-      pos = 0;
-    }
-
-    /**
-     * Find the parent groups of capturing groups in a Java regular expression.
-     * @param pattern the regular expression.
-     * @return an array indicating the parent group ID for each capturing group, where element i
-     * contains the parent group ID of capturing group i+1.
-     */
-    public static GroupInfo groupInfo(final String pattern) {
-      final GroupScanner gnd = new GroupScanner(pattern);
-      final Stack<Integer> open = new Stack<>();
-      open.push(0);
-      int[] parentGroups = { };
-      boolean[] inAssertion = { };
-      boolean quoted = false;
-      int classLevel = 0;
-      int assrtMark = 0;
-      for(;;) {
-        switch(gnd.nxtToken()) {
-          case EOP:
-            return new GroupInfo(parentGroups, inAssertion);
-          case LBRACKET:
-            if(!quoted) ++classLevel;
-            break;
-          case RBRACKET:
-            if(!quoted) --classLevel;
-            break;
-          case LQUOTE:
-            if(classLevel == 0) quoted = true;
-            break;
-          case RQUOTE:
-            if(classLevel == 0) quoted = false;
-            break;
-          case CAPT_LPAREN:
-            if(!quoted && classLevel == 0) {
-              parentGroups = Arrays.copyOf(parentGroups, parentGroups.length + 1);
-              parentGroups[parentGroups.length - 1] = open.peek();
-              inAssertion = Arrays.copyOf(inAssertion, inAssertion.length + 1);
-              inAssertion[inAssertion.length - 1] = assrtMark != 0;
-              open.push(parentGroups.length);
-            }
-            break;
-          case ASSRT_LPAREN:
-            if(!quoted && classLevel == 0) {
-              open.push(open.peek());
-              if(assrtMark == 0) assrtMark = open.size();
-            }
-            break;
-          case LPAREN:
-            if(!quoted && classLevel == 0) open.push(open.peek());
-            break;
-          case RPAREN:
-            if(!quoted && classLevel == 0) {
-              if(open.size() == assrtMark) assrtMark = 0;
-              open.pop();
-            }
-            break;
-          default:
-        }
-      }
-    }
-
-    /**
-     * Return the next token.
-     * @return next token
-     */
-    private Token nxtToken() {
-      switch(nxtCp()) {
-        case -1: return Token.EOP;
-        case ']': return Token.RBRACKET;
-        case '[': return Token.LBRACKET;
-        case ')': return Token.RPAREN;
-        case '\\': return switch(nxtCp()) {
-          case -1 -> Token.EOP;
-          case 'Q' -> Token.LQUOTE;
-          case 'E' -> Token.RQUOTE;
-          default -> Token.OTHER;
-        };
-        case '(':
-          switch(nxtCp()) {
-            case '?':
-              return switch(nxtCp()) {
-                case '=', '!' -> Token.ASSRT_LPAREN;
-                case '<' -> switch(nxtCp()) {
-                                    case '=', '!' -> Token.ASSRT_LPAREN;
-                                    default -> {
-                                      reset();
-                                      yield Token.CAPT_LPAREN;
-                                    }
-                                  };
-                default -> {
-                  reset();
-                  yield Token.LPAREN;
-                }
-              };
-            default:
-              reset();
-              return Token.CAPT_LPAREN;
-          }
-        default: return Token.OTHER;
-      }
-    }
-
-    /**
-     * Fetch the next code point.
-     * @return the next code point.
-     */
-    private int nxtCp() {
-      final int cp;
-      if(pos < len) {
-        cp = pattern.codePointAt(pos);
-        chrCount = Character.charCount(cp);
-        pos += chrCount;
-      }
-      else {
-        cp = -1;
-        chrCount = 0;
-      }
-      return cp;
-    }
-
-    /**
-     * Reset current position to before the most recent code point.
-     */
-    private void reset() {
-      pos -= chrCount;
-    }
-
-    /** Relevant token types. */
-    private enum Token {
-      /** End of pattern.                         */ EOP,
-      /** Capturing group's left parenthesis.     */ CAPT_LPAREN,
-      /** Non-capturing group's left parenthesis. */ LPAREN,
-      /** Assertion's left parenthesis.           */ ASSRT_LPAREN,
-      /** Right parenthesis.                      */ RPAREN,
-      /** Left square bracket.                    */ LBRACKET,
-      /** Right square bracket.                   */ RBRACKET,
-      /** Left quote.                             */ LQUOTE,
-      /** Right quote.                            */ RQUOTE,
-      /** Anything else.                          */ OTHER,
     }
   }
 }

--- a/basex-core/src/main/java/org/basex/query/util/regex/RegExpr.java
+++ b/basex-core/src/main/java/org/basex/query/util/regex/RegExpr.java
@@ -1,0 +1,228 @@
+package org.basex.query.util.regex;
+
+import java.util.*;
+import java.util.regex.*;
+
+/**
+ * Compiled regular expression (pattern and lazily computed group metadata).
+ *
+ * @author BaseX Team, BSD License
+ * @author Christian Gruen
+ */
+public class RegExpr {
+  /** Pattern. */
+  public final Pattern pattern;
+  /** Group info (volatile: lazily set once, may be read from concurrent child contexts). */
+  private volatile GroupInfo groupInfo;
+
+  /**
+   * Constructor.
+   * @param pattern pattern
+   */
+  public RegExpr(final Pattern pattern) {
+    this.pattern = pattern;
+    groupInfo = null;
+  }
+
+  /**
+   * Returns the parent group IDs of capturing groups.
+   * @return parent group IDs.
+   */
+  public int[] getParentGroups() {
+    if(groupInfo == null) groupInfo = GroupScanner.groupInfo(pattern.pattern());
+    return groupInfo.parentGroups;
+  }
+
+  /**
+   * Returns the assertion flags of capturing groups.
+   * @return assertion flags.
+   */
+  public boolean[] getAssertionFlags() {
+    if(groupInfo == null) groupInfo = GroupScanner.groupInfo(pattern.pattern());
+    return groupInfo.assertionFlags;
+  }
+
+  /**
+   * Information about capturing groups.
+   */
+  public static class GroupInfo {
+    /** Parent group: element i contains the parent group ID of capturing group i+1. */
+    public final int[] parentGroups;
+    /** Assertion status: element i tells whether capturing group i+1 occurs in an assertion. */
+    public final boolean[] assertionFlags;
+
+    /**
+     * Constructor.
+     * @param parentGroup parent group IDs
+     * @param assertionFlags inside of assertion indicators
+     */
+    GroupInfo(final int[] parentGroup, final boolean[] assertionFlags) {
+      parentGroups = parentGroup;
+      this.assertionFlags = assertionFlags;
+    }
+  }
+
+  /**
+   * Analyzes the nesting of capturing groups in a Java regular expression.
+   */
+  public static final class GroupScanner {
+    /** The pattern. */
+    private final String pattern;
+    /** Pattern length. */
+    private final int len;
+    /** Current position. */
+    private int pos;
+    /** Length of most recent code point. */
+    private int chrCount;
+
+    /**
+     * Constructor.
+     * @param pattern a Java regular expression.
+     */
+    private GroupScanner(final String pattern) {
+      this.pattern = pattern;
+      len = pattern.length();
+      pos = 0;
+    }
+
+    /**
+     * Find the parent groups of capturing groups in a Java regular expression.
+     * @param pattern the regular expression.
+     * @return an array indicating the parent group ID for each capturing group, where element i
+     * contains the parent group ID of capturing group i+1.
+     */
+    public static GroupInfo groupInfo(final String pattern) {
+      final GroupScanner gnd = new GroupScanner(pattern);
+      final Stack<Integer> open = new Stack<>();
+      open.push(0);
+      int[] parentGroups = { };
+      boolean[] inAssertion = { };
+      boolean quoted = false;
+      int classLevel = 0;
+      int assrtMark = 0;
+      for(;;) {
+        switch(gnd.nxtToken()) {
+          case EOP:
+            return new GroupInfo(parentGroups, inAssertion);
+          case LBRACKET:
+            if(!quoted) ++classLevel;
+            break;
+          case RBRACKET:
+            if(!quoted) --classLevel;
+            break;
+          case LQUOTE:
+            if(classLevel == 0) quoted = true;
+            break;
+          case RQUOTE:
+            if(classLevel == 0) quoted = false;
+            break;
+          case CAPT_LPAREN:
+            if(!quoted && classLevel == 0) {
+              parentGroups = Arrays.copyOf(parentGroups, parentGroups.length + 1);
+              parentGroups[parentGroups.length - 1] = open.peek();
+              inAssertion = Arrays.copyOf(inAssertion, inAssertion.length + 1);
+              inAssertion[inAssertion.length - 1] = assrtMark != 0;
+              open.push(parentGroups.length);
+            }
+            break;
+          case ASSRT_LPAREN:
+            if(!quoted && classLevel == 0) {
+              open.push(open.peek());
+              if(assrtMark == 0) assrtMark = open.size();
+            }
+            break;
+          case LPAREN:
+            if(!quoted && classLevel == 0) open.push(open.peek());
+            break;
+          case RPAREN:
+            if(!quoted && classLevel == 0) {
+              if(open.size() == assrtMark) assrtMark = 0;
+              open.pop();
+            }
+            break;
+          default:
+        }
+      }
+    }
+
+    /**
+     * Return the next token.
+     * @return next token
+     */
+    private Token nxtToken() {
+      switch(nxtCp()) {
+        case -1: return Token.EOP;
+        case ']': return Token.RBRACKET;
+        case '[': return Token.LBRACKET;
+        case ')': return Token.RPAREN;
+        case '\\': return switch(nxtCp()) {
+          case -1 -> Token.EOP;
+          case 'Q' -> Token.LQUOTE;
+          case 'E' -> Token.RQUOTE;
+          default -> Token.OTHER;
+        };
+        case '(':
+          switch(nxtCp()) {
+            case '?':
+              return switch(nxtCp()) {
+                case '=', '!' -> Token.ASSRT_LPAREN;
+                case '<' -> switch(nxtCp()) {
+                                    case '=', '!' -> Token.ASSRT_LPAREN;
+                                    default -> {
+                                      reset();
+                                      yield Token.CAPT_LPAREN;
+                                    }
+                                  };
+                default -> {
+                  reset();
+                  yield Token.LPAREN;
+                }
+              };
+            default:
+              reset();
+              return Token.CAPT_LPAREN;
+          }
+        default: return Token.OTHER;
+      }
+    }
+
+    /**
+     * Fetch the next code point.
+     * @return the next code point.
+     */
+    private int nxtCp() {
+      final int cp;
+      if(pos < len) {
+        cp = pattern.codePointAt(pos);
+        chrCount = Character.charCount(cp);
+        pos += chrCount;
+      }
+      else {
+        cp = -1;
+        chrCount = 0;
+      }
+      return cp;
+    }
+
+    /**
+     * Reset current position to before the most recent code point.
+     */
+    private void reset() {
+      pos -= chrCount;
+    }
+
+    /** Relevant token types. */
+    private enum Token {
+      /** End of pattern.                         */ EOP,
+      /** Capturing group's left parenthesis.     */ CAPT_LPAREN,
+      /** Non-capturing group's left parenthesis. */ LPAREN,
+      /** Assertion's left parenthesis.           */ ASSRT_LPAREN,
+      /** Right parenthesis.                      */ RPAREN,
+      /** Left square bracket.                    */ LBRACKET,
+      /** Right square bracket.                   */ RBRACKET,
+      /** Left quote.                             */ LQUOTE,
+      /** Right quote.                            */ RQUOTE,
+      /** Anything else.                          */ OTHER,
+    }
+  }
+}

--- a/basex-core/src/main/java/org/basex/query/value/type/Types.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/Types.java
@@ -84,6 +84,8 @@ public final class Types {
   public static final SeqType UNTYPED_ATOMIC_O = UNTYPED_ATOMIC.seqType();
   /** Zero or one untyped atomic. */
   public static final SeqType UNTYPED_ATOMIC_ZO = UNTYPED_ATOMIC.seqType(ZERO_OR_ONE);
+  /** Zero or more untyped atomics. */
+  public static final SeqType UNTYPED_ATOMIC_ZM = UNTYPED_ATOMIC.seqType(ZERO_OR_MORE);
 
   /** Single URI. */
   public static final SeqType ANY_URI_O = ANY_URI.seqType();

--- a/basex-core/src/test/java/org/basex/query/expr/RecordTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/RecordTest.java
@@ -2,9 +2,11 @@ package org.basex.query.expr;
 
 import static org.basex.query.QueryError.*;
 import static org.basex.query.func.Function.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.basex.*;
 import org.basex.query.func.*;
+import org.basex.query.util.hash.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.map.*;
 import org.basex.query.value.seq.*;
@@ -374,5 +376,17 @@ public final class RecordTest extends SandboxTest {
     // named record (runtime evaluation)
     check("declare record local:r(AA, AB); (local:r(0, <a/>), local:r(0, <a/>))?AA",
         "0\n0", exists(REPLICATE));
+  }
+
+  /** Checks that every built-in record type has a constructor function in {@link Function}. */
+  @Test public void builtInRecordsHaveConstructors() {
+    final QNmSet funcNames = new QNmSet();
+    for(final Function f : Function.values()) {
+      funcNames.add(f.definition().name);
+    }
+    for(final Records record : Records.values()) {
+      assertTrue(funcNames.contains(record.get().name()),
+          "Missing constructor function for " + record);
+    }
   }
 }

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -3067,6 +3067,48 @@ return
   }
 
   /** Test method. */
+  @Test public void regex() {
+    final Function func = REGEX;
+
+    query(func.args("abc") + "?pattern", "abc");
+    query(func.args("abc") + "?flags", "");
+    query(func.args("abc", "i") + "?flags", "i");
+    query(func.args("a") + " instance of fn:compiled-regex-record", true);
+    query(func.args("^a.*a+$") + "?matches('alpha')", true);
+    query(func.args("^a.*a+$") + "?matches('beta')", false);
+    query(func.args("kiki", "i") + "?matches('Kikikerikih!!')", true);
+    query(func.args("kiki", "i") + "?matches('Kikeriki!')", false);
+    query(func.args(",") + "?tokenize('a,b,c')", "a\nb\nc");
+    query(func.args("\\s+") + "?tokenize('hello world')", "hello\nworld");
+    query(func.args("[0-9]+") + "?replace('abc123def', '0')", "abc0def");
+    query(func.args("[aeiou]", "i") + "?replace('Hello World', '*')", "H*ll* W*rld");
+    query(func.args("[0-9]+") + "?analyze-string('abc123') => node-name() => expanded-QName()",
+        "Q{http://www.w3.org/2005/xpath-functions}analyze-string-result");
+    query(func.args("[0-9]+") + "?analyze-string('abc123def')//fn:match/text()", "123");
+    query(func.args("[0-9]+") + "?analyze-string('abc123def')//fn:non-match/text()", "abc\ndef");
+
+    // spec examples
+    query("let $r := " + func.args("^a.*a+$") +
+        " return ('alpha','beta','gamma','delta')[$r?matches(.)]", "alpha");
+    query("let $r := " + func.args("kiki", "i") +
+        " return some $k in ('Kikeriki!','Kikikerikih!!') satisfies $r?matches($k)", true);
+    query("let $r := " + func.args("[0-9]+") +
+        " return ('Chapter 1','Chapter 2','Chapter 3','Appendix 12')" +
+        "!$r?replace(., fn($k,$g) { number($k) + 1 })",
+        "Chapter 2\nChapter 3\nChapter 4\nAppendix 13");
+    final String ms = func.args("([A-Z])([0-9]+)") + "?matching-segments('A1,C15,,D24, X50,')";
+    query("count(" + ms + ')', 4);
+    query(ms + "[2]?substring", "C15");
+    query(ms + "[2]?position", 4);
+    query(ms + "[2]?groups?1?group", "C");
+    query(ms + "[2]?groups?2?group", 15);
+    query(ms + "[2]?groups?2?position", 5);
+
+    error(func.args("+"), REGINVALID_X);
+    error(func.args("x", "X"), REGFLAG_X);
+  }
+
+  /** Test method. */
   @Test public void replace() {
     final Function func = REPLACE;
 

--- a/basex-core/src/test/java/org/basex/query/func/fn/RegexTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/fn/RegexTest.java
@@ -7,6 +7,7 @@ import java.util.regex.*;
 import java.util.stream.*;
 
 import org.basex.*;
+import org.basex.query.util.regex.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.*;
 import org.junit.jupiter.params.provider.*;
@@ -26,7 +27,7 @@ public final class RegexTest extends SandboxTest {
   @ParameterizedTest
   @MethodSource
   public void testParentGroups(final String regex, final int[] parentGroups) {
-    final int[] actualGroups = RegExFn.GroupScanner.groupInfo(regex).parentGroups;
+    final int[] actualGroups = RegExpr.GroupScanner.groupInfo(regex).parentGroups;
     assertArrayEquals(parentGroups, actualGroups,
         () -> "Unexpected result: " + Arrays.toString(actualGroups));
     assertEquals(Pattern.compile(regex).matcher("").groupCount(), parentGroups.length);


### PR DESCRIPTION
These changes add support for the new `fn:regex` function and the built-in `fn:compiled-regex-record` type.

`fn:regex` is implemented by constructing a map of `FuncItem` closures over the constant pattern and flags. Each closure body is a fresh `StandardFunc` instance (`FnMatches`, `FnTokenize`, etc.). Prior to this change, each such instance had its own per-instance regex cache. The per-instance cache has been replaced by a single per-query cache on `QueryContext`, shared by all `RegExFn` instances within a query. The pattern compiled eagerly in `fn:regex` is therefore found immediately by any subsequent member function call - fulfilling the spec's intent of compiling once and reusing.

`RegExpr`, `GroupInfo`, and `GroupScanner` were moved from inner classes of `RegExFn` to a new top-level class `org.basex.query.util.regex.RegExpr`. This was done in order to avoid `QueryContext` depending on a type defined inside a concrete function implementation. The only code changes are visibility adjustments required by the package move: the class, its constructor, the pattern field, and the two accessor methods are now public (they were package-private, but callers in `org.basex.query.func.fn` and `org.basex.query` require access), algorithmic logic is identical.

This fixes QT4 tests

- `Keywords-fn-regex-1`
- `fo-test-fn-regex-001`
- `fo-test-fn-regex-002`
- `fo-test-fn-regex-004`

Additionally, a test has been added to verify that constructor functions exist for all built-in record types, and constructor functions have been added where they were missing.