### PR TITLE
File Module: open output files only after retrieving the input argument

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/file/FileWriteBinary.java
+++ b/basex-core/src/main/java/org/basex/query/func/file/FileWriteBinary.java
@@ -10,6 +10,7 @@ import org.basex.io.out.*;
 import org.basex.query.*;
 import org.basex.query.func.archive.*;
 import org.basex.query.value.*;
+import org.basex.query.value.item.*;
 import org.basex.query.value.seq.*;
 
 /**
@@ -36,22 +37,23 @@ public class FileWriteBinary extends FileWriteFn {
     final Path path = toTarget(arg(0), qc);
     final Long offset = toLongOrNull(arg(2), qc);
     if(offset != null) {
+      final byte[] content = toBin(arg(1), qc).binary(info);
       // write file chunk
       try(RandomAccessFile raf = new RandomAccessFile(path.toFile(), "rw")) {
         final long length = raf.length();
         if(offset < 0 || offset > length) throw FILE_OUT_OF_RANGE_X_X.get(info, offset, length);
         raf.seek(offset);
-        raf.write(toBin(arg(1), qc).binary(info));
+        raf.write(content);
+      }
+    } else if(arg(1) instanceof final ArchiveCreate ac) {
+      // optimization: stream archive to disk
+      try(BufferOutput out = BufferOutput.get(new FileOutputStream(path.toFile(), append))) {
+        ac.create(out, qc);
       }
     } else {
-      // write full file
+      final Bin content = toBin(arg(1), qc);
       try(BufferOutput out = BufferOutput.get(new FileOutputStream(path.toFile(), append))) {
-        if(arg(1) instanceof final ArchiveCreate ac) {
-          // optimization: stream archive to disk
-          ac.create(out, qc);
-        } else {
-          IO.write(toBin(arg(1), qc).input(info), out);
-        }
+        IO.write(content.input(info), out);
       }
     }
   }

--- a/basex-core/src/main/java/org/basex/query/func/file/FileWriteFn.java
+++ b/basex-core/src/main/java/org/basex/query/func/file/FileWriteFn.java
@@ -41,10 +41,10 @@ abstract class FileWriteFn extends FileFn {
     final Charset cs = encoding == null || encoding == Strings.UTF8 ? null :
       Charset.forName(encoding);
 
-    try(PrintOutput out = PrintOutput.get(new FileOutputStream(path.toFile(), append))) {
-      if(lines) {
-        final byte[] nl = cs == null ? token(Prop.NL) : Prop.NL.getBytes(cs);
-        final Iter values = arg(1).atomIter(qc, info);
+    if(lines) {
+      final byte[] nl = cs == null ? token(Prop.NL) : Prop.NL.getBytes(cs);
+      final Iter values = arg(1).atomIter(qc, info);
+      try(PrintOutput out = PrintOutput.get(new FileOutputStream(path.toFile(), append))) {
         for(Item item; (item = qc.next(values)) != null;) {
           if(!item.type.isStringOrUntyped()) throw typeError(item, BasicType.STRING, info);
 
@@ -52,10 +52,12 @@ abstract class FileWriteFn extends FileFn {
           out.write(cs == null ? token : string(token).getBytes(cs));
           out.write(nl);
         }
-      } else {
-        // workaround to preserve streamable string items
-        Item value = toAtomItem(arg(1), qc);
-        if(!(value instanceof AStr)) value = Str.get(toToken(value));
+      }
+    } else {
+      // workaround to preserve streamable string items
+      Item value = toAtomItem(arg(1), qc);
+      if(!(value instanceof AStr)) value = Str.get(toToken(value));
+      try(PrintOutput out = PrintOutput.get(new FileOutputStream(path.toFile(), append))) {
         if(cs == null) {
           try(TextInput in = value.stringInput(info)) {
             for(int cp; (cp = in.read()) != -1;) out.print(cp);

--- a/basex-core/src/test/java/org/basex/query/func/FileModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FileModuleTest.java
@@ -549,6 +549,11 @@ public final class FileModuleTest extends SandboxTest {
     query(_FILE_READ_TEXT.args(PATH1), "0");
     query(func.args(PATH1, bin, 1));
     query(_FILE_READ_TEXT.args(PATH1), "00");
+
+    // GH-2674: read and write same file: content is read before file is truncated
+    query(func.args(PATH1, bin));
+    query(func.args(PATH1, _LAZY_CACHE.args(_FILE_READ_BINARY.args(PATH1))));
+    query(_FILE_READ_TEXT.args(PATH1), "0");
   }
 
   /** Test method. */
@@ -567,6 +572,11 @@ public final class FileModuleTest extends SandboxTest {
     query(_FILE_READ_TEXT.args(PATH1), "\u00b0");
     query(func.args(PATH2, _FILE_READ_TEXT.args(PATH1)));
     query(_FILE_READ_TEXT.args(PATH2), "\u00b0");
+
+    // GH-2674: read and write same file: content is read before file is truncated
+    query(func.args(PATH1, "hello"));
+    query(func.args(PATH1, _LAZY_CACHE.args(_FILE_READ_TEXT.args(PATH1))));
+    query(_FILE_READ_TEXT.args(PATH1), "hello");
   }
 
   /** Test method. */
@@ -580,5 +590,10 @@ public final class FileModuleTest extends SandboxTest {
     query(_FILE_SIZE.args(PATH1), 1 + Prop.NL.length());
     query(func.args(PATH1, "\u00fc", "US-ASCII"));
     query(_FILE_READ_TEXT_LINES.args(PATH1), "?");
+
+    // GH-2674: read and write same file: content is read before file is truncated
+    query(func.args(PATH1, "hello"));
+    query(func.args(PATH1, _LAZY_CACHE.args(_FILE_READ_TEXT_LINES.args(PATH1))));
+    query(_FILE_READ_TEXT_LINES.args(PATH1), "hello");
   }
 }


### PR DESCRIPTION
#2674 is caused by `FileWriteFn.write` truncating its output file before processing its input argument. `FileWriteBinary.write` has the same problem. Both are fixed here.