### PR TITLE
Migrate publishing logic from OSSRH to Central Portal

### DIFF
--- a/basex-core/src/main/java/org/basex/query/value/Value.java
+++ b/basex-core/src/main/java/org/basex/query/value/Value.java
@@ -128,7 +128,7 @@ public abstract class Value extends Expr implements Iterable<Item> {
   /**
    * Returns a subsequence with the given start and length.
    * @param pos position of first item (>= 0)
-   * @param length number of items (1 < length < size())
+   * @param length number of items (1 &lt; length &lt; size())
    * @param job interruptible job
    * @return new subsequence
    */

--- a/basex-core/src/main/java/org/basex/query/value/array/XQArray.java
+++ b/basex-core/src/main/java/org/basex/query/value/array/XQArray.java
@@ -131,7 +131,7 @@ public abstract class XQArray extends XQStruct {
   /**
    * Returns a subsequence with the given start and length.
    * @param pos position of first member (>= 0)
-   * @param length number of members (1 < length < size())
+   * @param length number of members (1 &lt; length &lt; size())
    * @param job interruptible job
    * @return new subarray
    */

--- a/pom.xml
+++ b/pom.xml
@@ -222,16 +222,12 @@
 
   <profiles>
     <profile>
-      <id>ossrh</id>
+      <id>central</id>
       <distributionManagement>
         <snapshotRepository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+          <id>basex-publish</id>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
-        <repository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
       </distributionManagement>
       <build>
         <plugins>
@@ -268,6 +264,7 @@
                   <goal>sign</goal>
                 </goals>
                 <configuration>
+                  <keyname>cg@basex.org</keyname>
                   <!-- This is necessary for gpg to not try to use the pinentry programs -->
                   <gpgArguments>
                     <arg>--pinentry-mode</arg>
@@ -293,6 +290,18 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.10.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>basex-publish</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
           </plugin>
         </plugins>
       </build>
@@ -397,7 +406,7 @@
           <version>3.3.1</version>
           <configuration>
             <tagNameFormat>@{project.version}</tagNameFormat>
-            <releaseProfiles>ossrh</releaseProfiles>
+            <releaseProfiles>central</releaseProfiles>
             <scmCommentPrefix>Release: </scmCommentPrefix>
           </configuration>
         </plugin>
@@ -463,18 +472,6 @@
             <linkXRef>false</linkXRef>
             <consoleOutput>true</consoleOutput>
             <violationSeverity>warning</violationSeverity>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.7.0</version>
-          <extensions>true</extensions>
-          <configuration>
-            <serverId>ossrh</serverId>
-            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>true</autoReleaseAfterClose>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
These changes replace the outdated OSSRH publishing configuration in `pom.xml` by the new settings for the Central Portal. The profile was consequently renamed from `ossrh` to `central`. 

As prerequisites,

- the private key `cg@basex.org` must be present in the gpg keyring (use `gpg --list-secret-keys` to verify)
- the `basex-publish` user token for Central Portal must be present in `~/.m2/settings.xml`, e.g.

   ```xml
   <?xml version="1.0" encoding="UTF-8"?>
   <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
             http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <servers>
       <server>
         <id>basex-publish</id>
         <username>actual username</username>
         <password>actual password</password>
       </server>
     </servers>
   </settings>
   ```

Publishing can then be done fully automated, with `MAVEN_GPG_PASSPHRASE` set to the actual passphrase for the `cg@basex.org` key, by running

```sh
mvn clean deploy -Pcentral
```

Versions 12.1 through 12.3 have now been published using this approach (note that this publishing was done using `org.sonatype.central:central-publishing-maven-plugin:0.7.0`, while this PR moves forward to `...:0.10.0`).

In addition to the `pom.xml` changes, two Javadoc warnings have been fixed, which were reported in the build log.

Fixes #2649