### PR TITLE
Skip reserved-function-name check for URIQualifiedLiteral

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -926,8 +926,9 @@ public class QueryParser extends InputParser {
    */
   private void functionDecl(final AnnList anns) throws QueryException {
     final InputInfo ii = info();
+    final int p = pos;
     final QNm name = eQName(sc.funcNS, FUNCNAME);
-    if(reserved(name)) throw error(RESERVED_X, name.local());
+    if(reserved(name, p)) throw error(RESERVED_X, name.local());
 
     wsCheck("(");
     if(!anns.contains(Annotation.PRIVATE)) {
@@ -949,9 +950,11 @@ public class QueryParser extends InputParser {
   /**
    * Checks if the specified name equals a reserved keyword.
    * @param name name
+   * @param p position of the first character of the name
    * @return result of check
    */
-  private static boolean reserved(final QNm name) {
+  private boolean reserved(final QNm name, final int p) {
+    if(p + 1 < input.length && input[p] == 'Q' && input[p + 1] == '{') return false;
     return !name.hasPrefix() && KEYWORDS.contains(name.string());
   }
 
@@ -2023,8 +2026,9 @@ public class QueryParser extends InputParser {
           if(ex == null) ex = arrayConstructor();
           if(ex == null) ex = functionItem();
           if(ex == null) {
+            final int p = pos;
             name = eQName(null, ARROWSPEC_X);
-            if(reserved(name)) throw error(RESERVED_X, name.local());
+            if(reserved(name, p)) throw error(RESERVED_X, name.local());
           }
         }
         final InputInfo ii = info();
@@ -2717,7 +2721,7 @@ public class QueryParser extends InputParser {
     final QNm name = eQName(null, null);
     if(name != null && wsConsumeWs("#")) {
       final Expr num = numericLiteral(Integer.MAX_VALUE, false, false);
-      if(reserved(name)) {
+      if(reserved(name, p)) {
         if(num != null) throw error(RESERVED_X, name.local());
       } else if(num instanceof final Itr itr) {
         final int i = (int) itr.itr();
@@ -2972,7 +2976,7 @@ public class QueryParser extends InputParser {
   private Expr functionCall() throws QueryException {
     final int p = pos;
     final QNm name = eQName(null, null);
-    if(name != null && !reserved(name)) {
+    if(name != null && !reserved(name, p)) {
       skipWs();
       if(current('(')) {
         final FuncBuilder fb = argumentList(true, null);

--- a/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java
+++ b/basex-core/src/test/java/org/basex/query/simple/SimpleTest.java
@@ -322,6 +322,15 @@ public final class SimpleTest extends QueryTest {
       { "Arith 4", strings("P6M"), "string(xs:yearMonthDuration('P1Y') * <_>.5</_>)" },
       { "Arith 5", strings("P2Y"), "string(xs:yearMonthDuration('P1Y') div .5)" },
       { "Arith 6", strings("P2Y"), "string(xs:yearMonthDuration('P1Y') div <_>.5</_>)" },
+
+      { "URIQualifiedName 1", strings("abc"), "declare function local:text($t) {$t}; "
+          + "Q{http://www.w3.org/2005/xquery-local-functions}text#1('abc')"},
+      { "URIQualifiedName 2", strings("abc"), "declare function Q{http://www.w3.org/2005/xquery-loc"
+          + "al-functions}text($t) {$t}; local:text('abc')"},
+      { "URIQualifiedName 3", strings("abc"), "declare function local:text($t) {$t}; "
+          + "Q{http://www.w3.org/2005/xquery-local-functions}text('abc')"},
+      { "URIQualifiedName 4", strings("abc"), "declare function local:text($t) {$t}; "
+          + "'abc' => Q{http://www.w3.org/2005/xquery-local-functions}text()"},
     };
   }
 }


### PR DESCRIPTION
The XQuery spec, since 1.0, contains a constraint named `reserved-function-names` with a formulation like this or similar:

> Unprefixed function names spelled the same way as language keywords could make the language impossible to parse. For instance, element(foo) could be taken either as a [FunctionCall](https://qt4cg.org/specifications/xquery-40/xquery-40.html#doc-xquery40-FunctionCall) or as an ElementTest. Therefore, an unprefixed function name must not be any of the names in A.4 Reserved Function Names.

The current implementation in BaseX focuses on "unprefixed" and thus tests the absence of a prefix. This may result in a URIQualifiedName being rejected, if its local name is in the list of reserved names.

I do not consider this as correct. The motivation behind the constraint is the ambiguity that arises when a plain name is used. For a URIQualifiedName, this ambiguity does not exist - the `Q{uri}local-name` form unambiguously stands for a QName.

I thus propose to make the implementation focus on the spec's wording "function names spelled the same way as language keywords", and treating URIQualifiedNames as outside the constraint's scope.

This is implemented in this PR.