### PR TITLE
Fix NPE for filter with `and` predicate in path step

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/path/Path.java
+++ b/basex-core/src/main/java/org/basex/query/expr/path/Path.java
@@ -85,11 +85,6 @@ public abstract class Path extends ParseExpr {
       if(expr instanceof ContextValue) {
         // rewrite context value reference to self step
         expr = Step.get(expr.info(info), SELF, NodeTest.GNODE);
-      } else if(expr instanceof final Filter filter) {
-        // rewrite filter expression to self step with predicates
-        if(filter.root instanceof ContextValue) {
-          expr = Step.get(filter.info(), SELF, NodeTest.GNODE, filter.exprs);
-        }
       }
       tmp.add(expr);
       axes = axes && expr instanceof Step;

--- a/basex-core/src/test/java/org/basex/query/expr/FilterTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/FilterTest.java
@@ -455,4 +455,11 @@ public final class FilterTest extends SandboxTest {
     check(pre + "!= 0          to last() + 1" + post, "", empty());
     check(pre + "!= last() + 1 to last() + 2" + post, "", empty(Pos.class));
   }
+
+  /** GH-2687: NPE from AndExpr filter over ContextValueRef step. */
+  @Test public void gh2687() {
+    query("()/.[true() and true()]", "");
+    query("declare function all-whitespace($arg) { normalize-space($arg) = '' };\n"
+        + "<a/>/.[true() and all-whitespace('')]", "<a/>");
+  }
 }


### PR DESCRIPTION
As reported by [Andreas Hengsbach on basex-talk](https://mailman.uni-konstanz.de/mailman3/hyperkitty/list/basex-talk@mailman.uni-konstanz.de/thread/OSF4LNEX5BQDWLPMMO6VFP3FJYRJZ7EQ/), an NPE can result from

- a path expression, that has
- a context value step, with
- a filter expression, containing
- an `and` expression, involving
- a function call.

E.g.

```xquery
import module namespace functx = "http://www.functx.com";

<a/>/.[true() and functx:all-whitespace('')]
```

This can also be reproduced as simple as 

```xquery
()/.[true() and true()]
```

It is caused by `Path.get` rewriting a filter expression to a self step with predicates. In the course of this, the predicates are queried for `Flag.POS` (via `mayBePositional()`). But when this is done at parse time, `FuncRef`s are not resolved yet - yielding an NPE for the flags request. 

However it is not necessary to do the rewrite this early, an equivalent rewrite is also done at optimization time, in `Filter.optimize`. So the fix is to just remove it from `Path.get`.