### PR TITLE
2 fixes of canonical XML serialization

### DIFF
--- a/basex-core/src/main/java/org/basex/io/serial/MarkupSerializer.java
+++ b/basex-core/src/main/java/org/basex/io/serial/MarkupSerializer.java
@@ -148,6 +148,8 @@ abstract class MarkupSerializer extends StandardSerializer {
         out.print(E_QUOT);
       } else if(cp == 0x9 || cp == 0xA) {
         printHex(cp);
+      } else if(canonical && cp == '>') {
+        out.print(cp);
       } else {
         printChar(cp);
       }
@@ -244,6 +246,7 @@ abstract class MarkupSerializer extends StandardSerializer {
   protected void startOpen(final QNm name) throws IOException {
     if(opened.isEmpty()) checkRoot(name);
     if(sep) indent();
+    if(canonical && root) indent = false;
     out.print(ELEM_O);
     out.print(name.string());
     indAttrLength = out.lineLength();

--- a/basex-core/src/test/java/org/basex/query/SerializerTest.java
+++ b/basex-core/src/test/java/org/basex/query/SerializerTest.java
@@ -19,6 +19,7 @@ public final class SerializerTest extends SandboxTest {
   /** Test: method=xml. */
   @Test public void xml() {
     query(METHOD.arg("xml") + "<html/>", "<html/>");
+    query(METHOD.arg("xml") + "<x a='1 > 0'>1 > 0</x>", "<x a=\"1 &gt; 0\">1 &gt; 0</x>");
     query(METHOD.arg("xml") + INDENT_ATTRIBUTES.arg("yes") + "<x a='1' b='2' c='3'/>",
         "<x a=\"1\"\n"
         + "   b=\"2\"\n"
@@ -382,6 +383,17 @@ public final class SerializerTest extends SandboxTest {
   /** Canonical serialization. */
   @Test public void canonical() {
     final String option = METHOD.arg("xml") + CANONICAL.arg("yes");
+
+    query(option + "parse-xml('<doc>Hello, world!<!--C2--></doc><!--C3-->')",
+        "<doc>Hello, world!<!--C2--></doc>\n<!--C3-->");
+    query(option + "parse-xml('<!--C1--><doc>Hello, world!<!--C2--></doc><!--C3-->')",
+        "<!--C1-->\n<doc>Hello, world!<!--C2--></doc>\n<!--C3-->");
+    query(option + "parse-xml('<!--C0--><!--C1--><doc>Hello, world!<!--C2--></doc><!--C3-->')",
+        "<!--C0-->\n<!--C1-->\n<doc>Hello, world!<!--C2--></doc>\n<!--C3-->");
+    query(option + "document { comment {'C1'}, <doc>Hello, world!<!--C2--></doc>, comment {'C3'} }",
+        "<!--C1-->\n<doc>Hello, world!<!--C2--></doc>\n<!--C3-->");
+    query(option + "<x a='1 > 0'>1 > 0</x>", "<x a=\"1 > 0\">1 &gt; 0</x>");
+
     // relative namespace URIs are not allowed
     error(option + "<x xmlns='relative'/>", SERCANONURI);
     // document must only have one element root node


### PR DESCRIPTION
New QT4 tests for canonical XML serialization have uncovered these deficiencies of the BaseX implementation:

- indentation may incorrectly be turned on. This is caused by the newline requirement of nodes preceding the root element being implemented via indentation. The fix is to reset the indentation flag when serializing an element in canonical mode.

- a greater-than sign in attribute content was represented as `&gt;`. Canonical XML does not allow this escaping for attribute values, so attribute serialization now leaves `>` literal in canonical mode.