### PR TITLE
 Fix `fn:replace` callback arguments for unmatched groups

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/FnReplace.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnReplace.java
@@ -50,7 +50,10 @@ public final class FnReplace extends RegExFn {
       while(matcher.find()) {
         final ValueBuilder groups = new ValueBuilder(qc);
         final int gc = matcher.groupCount();
-        for(int g = 0; g < gc; g++) groups.add(Atm.get(matcher.group(g + 1)));
+        for(int g = 0; g < gc; g++) {
+          final String grp = matcher.group(g + 1);
+          groups.add(grp == null ? Atm.EMPTY : Atm.get(grp));
+        }
         args.set(0, Atm.get(matcher.group())).set(1, groups.value());
         final Item item = invoke(action, args, qc).atomItem(qc, info);
         matcher.appendReplacement(sb, item.isEmpty() ? "" :

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -3233,6 +3233,9 @@ return
     query(func.args("c", "c", " fn($k, $g) { upper-case($k) }"), "C");
     query(func.args("de", ".", " fn($k, $g) { $k || $k }"), "ddee");
 
+    // GH-2692: unmatched groups supplied to replacement functions are zero-length strings
+    query(func.args("", "(X)?", " fn($_, $groups) { $groups[1] }"), "");
+
     query(func.args("Chapter 9", "[0-9]+", " fn($k, $g) { string(number($k) + 1) }"),
         "Chapter 10");
     query("let $map := { 'LAX': 'Los Angeles', 'LHR': 'London' } return"


### PR DESCRIPTION
When `fn:replace` is called with a replacement function, unmatched optional capturing groups must be supplied to the callback as zero-length `xs:untypedAtomic` values. Currently the `Matcher.group`'s returned value `null` is passed directly to `Atm.get`, causing a `NullPointerException` for expressions such as:

```xquery
replace("", "(X)?", fn($_, $groups) { $groups[1] })
```

The fix maps `null` capture groups to `Atm.EMPTY` when building the callback’s `$groups` sequence.

A regression test has been added to `FnModuleTest.replace`.

This was orinally reported in #2692.