### PR TITLE
Add missing NDT checks

### DIFF
--- a/basex-core/src/main/java/org/basex/query/CompileContext.java
+++ b/basex-core/src/main/java/org/basex/query/CompileContext.java
@@ -376,7 +376,10 @@ public final class CompileContext {
   public Expr replicate(final Expr expr, final Expr count, final InputInfo info)
       throws QueryException {
     final ExprList args = new ExprList().add(expr).add(count);
-    if(expr.has(Flag.NDT, Flag.CNS)) args.add(Bln.TRUE);
+    // force repeated evaluation for side-effecting input and for calls through an unresolved
+    // variable that may be bound to a nondeterministic function. If the variable is later replaced
+    // with a deterministic function, FnReplicate drops the flag again, so nothing is pessimized.
+    if(expr.has(Flag.NDT, Flag.CNS) || expr.mayInvokeVariable()) args.add(Bln.TRUE);
     return function(Function.REPLICATE, info, args.finish());
   }
 

--- a/basex-core/src/main/java/org/basex/query/expr/Arith.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Arith.java
@@ -5,6 +5,7 @@ import static org.basex.query.QueryText.*;
 import org.basex.query.*;
 import org.basex.query.CompileContext.*;
 import org.basex.query.func.*;
+import org.basex.query.util.*;
 import org.basex.query.value.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.seq.*;
@@ -72,8 +73,9 @@ public class Arith extends Arr {
     if(expr == this && Function.COUNT.is(expr1) && calc == Calc.ADD && Function.COUNT.is(expr2)) {
       expr = cc.function(Function.COUNT, info, List.get(cc, info, expr1.arg(0), expr2.arg(0)));
     }
-    if(expr == this && numbers && noArrays && st1.one() && st2.one()) {
+    if(expr == this && numbers && noArrays && st1.one() && st2.one() && !has(Flag.NDT)) {
       // example: number($a) + 0 → number($a)
+      // nondeterministic operands must not be dropped, in order to preserve side effects
       final Expr ex = calc.optimize(expr1, expr2, info, cc);
       if(ex != null) {
         expr = ex;

--- a/basex-core/src/main/java/org/basex/query/expr/Arr.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Arr.java
@@ -167,7 +167,11 @@ public abstract class Arr extends ParseExpr {
   final Expr emptyExpr() {
     // pre-evaluate if one value is empty (e.g.: () = local:expensive() )
     for(final Expr expr : exprs) {
-      if(expr.seqType().zero()) return expr;
+      if(expr.seqType().zero()) {
+        // keep expression if returning the empty operand would drop a nondeterministic sibling
+        if(((Checks<Expr>) ex -> ex != expr && ex.has(Flag.NDT)).any(exprs)) break;
+        return expr;
+      }
     }
     return this;
   }

--- a/basex-core/src/main/java/org/basex/query/expr/Cmp.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Cmp.java
@@ -239,6 +239,9 @@ public abstract class Cmp extends Arr {
 
     // distinct values checks
     final Expr arg = expr1.arg(0), count = exprs[1];
+    // keep nondeterministic input: the count comparisons below may skip its evaluation
+    if(arg.has(Flag.NDT)) return this;
+
     if(COUNT.is(count)) {
       final Expr carg = count.arg(0);
       // count(E) = count(distinct-values(E))

--- a/basex-core/src/main/java/org/basex/query/expr/Expr.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Expr.java
@@ -251,6 +251,24 @@ public abstract class Expr extends ExprInfo {
   }
 
   /**
+   * Checks if this expression may invoke a function through an unresolved variable. Such a call is
+   * treated as deterministic until the variable reference is replaced (inlined) with the function
+   * it is bound to, whose nondeterminism can then be determined. Side-effect-dropping rewrites must
+   * be deferred until then.
+   * @return {@code true} if a function may be invoked through a variable
+   */
+  public final boolean mayInvokeVariable() {
+    // return true iff the search was aborted, i.e. such a call was found
+    return !accept(new ASTVisitor() {
+      @Override
+      public boolean dynFuncCall(final Expr func) {
+        // abort when the invoked function is an unresolved variable
+        return !(func instanceof VarRef);
+      }
+    });
+  }
+
+  /**
    * Checks if inlining is possible.
    * This function is called by {@link InlineContext#inlineable}.
    *

--- a/basex-core/src/main/java/org/basex/query/expr/List.java
+++ b/basex-core/src/main/java/org/basex/query/expr/List.java
@@ -5,6 +5,7 @@ import static org.basex.query.QueryText.*;
 import org.basex.query.*;
 import org.basex.query.CompileContext.*;
 import org.basex.query.iter.*;
+import org.basex.query.util.*;
 import org.basex.query.util.list.*;
 import org.basex.query.value.*;
 import org.basex.query.value.item.*;
@@ -236,7 +237,12 @@ public final class List extends Arr {
     } else if(mode == Simplify.DISTINCT) {
       final int el = exprs.length;
       final ExprList list = new ExprList(el);
-      for(final Expr ex : exprs) list.addUnique(ex.simplifyFor(mode, cc));
+      for(final Expr ex : exprs) {
+        // do not drop duplicate nondeterministic operands, as this would discard side effects
+        final Expr sx = ex.simplifyFor(mode, cc);
+        if(sx.has(Flag.NDT)) list.add(sx);
+        else list.addUnique(sx);
+      }
       exprs = list.finish();
       if(exprs.length != el) {
         // remove duplicate list expressions

--- a/basex-core/src/main/java/org/basex/query/expr/SimpleMap.java
+++ b/basex-core/src/main/java/org/basex/query/expr/SimpleMap.java
@@ -322,7 +322,10 @@ public abstract class SimpleMap extends Mapping {
     }
 
     exprType.assign(exprs[ls - 1], new long[] { min, max });
-    return size() == 0 && !has(Flag.NDT, Flag.HOF) ? cc.emptySeq(this) : null;
+    // do not drop a map with an empty result that may still have side effects (nondeterministic,
+    // higher-order, or a function invoked through a variable)
+    return size() == 0 && !has(Flag.NDT, Flag.HOF) && !mayInvokeVariable()
+        ? cc.emptySeq(this) : null;
   }
 
   /**
@@ -363,6 +366,9 @@ public abstract class SimpleMap extends Mapping {
   @Override
   public final Expr simplifyFor(final Simplify mode, final CompileContext cc)
       throws QueryException {
+
+    // do not simplify nondeterministic map, in order to preserve side effects
+    if(((Checks<Expr>) ex -> ex.has(Flag.NDT)).any(exprs)) return this;
 
     Expr expr = this;
     final int el = exprs.length;

--- a/basex-core/src/main/java/org/basex/query/expr/Switch.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Switch.java
@@ -97,7 +97,8 @@ public final class Switch extends ParseExpr {
       for(int e = 1; e < el; e++) {
         final Expr expr = group.exprs[e];
         // check if same case expression exists more than once
-        boolean remove = cases.contains(expr);
+        // (nondeterministic duplicates are kept, as they would otherwise lose their side effects)
+        boolean remove = cases.contains(expr) && !expr.has(Flag.NDT);
         if(!remove && cnd != null) {
           // pre-evaluate values; skip remaining checks if match is found
           if(expr instanceof Value) {

--- a/basex-core/src/main/java/org/basex/query/expr/gflwor/GFLWOR.java
+++ b/basex-core/src/main/java/org/basex/query/expr/gflwor/GFLWOR.java
@@ -7,6 +7,7 @@ import org.basex.query.*;
 import org.basex.query.CompileContext.*;
 import org.basex.query.expr.*;
 import org.basex.query.expr.path.*;
+import org.basex.query.func.DynFuncCall;
 import org.basex.query.func.Function;
 import org.basex.query.func.fn.*;
 import org.basex.query.iter.*;
@@ -136,8 +137,9 @@ public final class GFLWOR extends ParseExpr {
 
   @Override
   public Expr simplifyFor(final Simplify mode, final CompileContext cc) throws QueryException {
-    return cc.simplify(this, mode == Simplify.COUNT &&
-        clauses.removeIf(OrderBy.class::isInstance) ? optimize(cc) : this, mode);
+    // when counting, order is irrelevant: drop order-by clauses, but keep nondeterministic keys
+    return cc.simplify(this, mode == Simplify.COUNT && clauses.removeIf(
+        clause -> clause instanceof OrderBy && !clause.has(Flag.NDT)) ? optimize(cc) : this, mode);
   }
 
   /**
@@ -392,10 +394,14 @@ public final class GFLWOR extends ParseExpr {
         if(last) {
           // merge with return expression
           //   for $c in 1 to 3 return $c → 1 to 3
-          final Expr expr = inline(inline, rtrn, fl, cc);
-          if(expr != null) {
-            rtrn = expr;
-            changing = true;
+          // do not merge while the return references a preceding let bound to a nondeterministic
+          // function: the let-inlining above must run first, so cc.replicate sees the call's NDT
+          if(!referencesNdtFunction(rtrn, c)) {
+            final Expr expr = inline(inline, rtrn, fl, cc);
+            if(expr != null) {
+              rtrn = expr;
+              changing = true;
+            }
           }
         } else {
           // rewrite for/let combinations to a single for clause
@@ -431,6 +437,21 @@ public final class GFLWOR extends ParseExpr {
     }
 
     return changed;
+  }
+
+  /**
+   * Checks if an expression references the variable of a preceding let clause that is bound to a
+   * nondeterministic function item or closure.
+   * @param expr expression
+   * @param max index of the first clause that is not considered
+   * @return result of check
+   */
+  private boolean referencesNdtFunction(final Expr expr, final int max) {
+    for(int c = 0; c < max; c++) {
+      if(clauses.get(c) instanceof final Let lt && expr.count(lt.var) != VarUsage.NEVER &&
+          DynFuncCall.containsNdtFunction(lt.expr)) return true;
+    }
+    return false;
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/func/DynFuncCall.java
+++ b/basex-core/src/main/java/org/basex/query/func/DynFuncCall.java
@@ -12,10 +12,13 @@ import org.basex.query.ann.*;
 import org.basex.query.expr.*;
 import org.basex.query.expr.List;
 import org.basex.query.iter.*;
+import org.basex.query.scope.*;
 import org.basex.query.util.*;
 import org.basex.query.util.list.*;
 import org.basex.query.value.*;
+import org.basex.query.value.array.*;
 import org.basex.query.value.item.*;
+import org.basex.query.value.map.*;
 import org.basex.query.value.type.*;
 import org.basex.query.var.*;
 import org.basex.util.*;
@@ -68,6 +71,11 @@ public final class DynFuncCall extends FuncCall {
   @Override
   public Expr optimize(final CompileContext cc) throws QueryException {
     final Expr func = body();
+    // the call is nondeterministic if the invoked function is (a function item is a value and so
+    // carries no flag of its own, hence the explicit check)
+    if(func.has(Flag.NDT) || func instanceof final Value value && containsNdtFunction(value)) {
+      ndt = true;
+    }
 
     // ()() → ()
     if(func.seqType().zero()) return func;
@@ -123,6 +131,47 @@ public final class DynFuncCall extends FuncCall {
       }
     }
     return this;
+  }
+
+  /**
+   * Checks if an expression contains a nondeterministic function item or closure.
+   * @param expr expression
+   * @return result of check
+   */
+  public static boolean containsNdtFunction(final Expr expr) {
+    return expr instanceof Value value ? containsNdtFunction(value) :
+      !expr.accept(new ASTVisitor() {
+        @Override
+        public boolean funcItem(final FuncItem func) {
+          return !func.ndt();
+        }
+
+        @Override
+        public boolean inlineFunc(final Scope scope) {
+          return !(scope instanceof final Closure cl && cl.has(Flag.NDT));
+        }
+      });
+  }
+
+  /**
+   * Checks if a value contains a nondeterministic function item or closure.
+   * @param value value
+   * @return result of check
+   */
+  private static boolean containsNdtFunction(final Value value) {
+    for(final Item item : value) {
+      if(item instanceof final FuncItem fi && fi.ndt()) return true;
+      if(item instanceof final XQArray array) {
+        for(final Value member : array.members()) {
+          if(containsNdtFunction(member)) return true;
+        }
+      } else if(item instanceof final XQMap map) {
+        for(final XQMap.Entry entry : map.entries()) {
+          if(containsNdtFunction(entry.value())) return true;
+        }
+      }
+    }
+    return false;
   }
 
   @Override
@@ -204,6 +253,11 @@ public final class DynFuncCall extends FuncCall {
     return Flag.UPD.oneOf(flags) && (updating || sc().mixUpdates) ||
            Flag.NDT.oneOf(flags) && (ndt || updating || sc().mixUpdates) ||
            super.has(Flag.remove(flags, Flag.UPD));
+  }
+
+  @Override
+  public boolean accept(final ASTVisitor visitor) {
+    return visitor.dynFuncCall(body()) && super.accept(visitor);
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/func/StandardFunc.java
+++ b/basex-core/src/main/java/org/basex/query/func/StandardFunc.java
@@ -195,7 +195,7 @@ public abstract class StandardFunc extends Arr {
           final int hof = hofOffsets(), al = args().length;
           for(int a = 0; a < al; a++) {
             if((hof & 1 << a) != 0 && (!(arg(a) instanceof final Item item) ||
-                !(item instanceof final FuncItem fi) || fi.expr.has(Flag.NDT))) return true;
+                !(item instanceof final FuncItem fi) || fi.ndt())) return true;
           }
           break;
         default:
@@ -336,9 +336,11 @@ public abstract class StandardFunc extends Arr {
     // head($nodes ! name()) → head($nodes) ! name()
     // foot((1 to 8) ! <_>{ . }</_>) → foot((1 to 8)) ! <_>{ . }</_>
     // do not rewrite positional access:  foot($nodes ! position())
+    // do not rewrite non-deterministic expressions: foot($nodes ! file:append($name, .))
     if(arg(0) instanceof SimpleMap) {
       final Expr[] ops = arg(0).args();
-      if(((Checks<Expr>) op -> op == ops[0] || op.seqType().one() && !op.has(Flag.POS)).all(ops)) {
+      if(((Checks<Expr>) op ->
+          op == ops[0] || op.seqType().one() && !op.has(Flag.POS, Flag.NDT)).all(ops)) {
         final Expr[] args = new ExprList().add(args()).set(0, ops[0]).finish();
         final Expr fn = definition.get(info, args).optimize(cc);
         return skip ? fn : SimpleMap.get(cc, info, new ExprList(ops.clone()).set(0, fn).finish());

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnCount.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnCount.java
@@ -21,9 +21,11 @@ import org.basex.util.*;
 public final class FnCount extends StandardFunc {
   @Override
   public Itr item(final QueryContext qc, final InputInfo ii) throws QueryException {
-    // iterative access: if the iterator size is unknown, iterate through all results
-    final Iter input = arg(0).iter(qc);
-    long size = input.size();
+    // iterative access: if the iterator size is unknown or nondeterministic, iterate through all
+    // results
+    final Expr expr = arg(0);
+    final Iter input = expr.iter(qc);
+    long size = expr.has(Flag.NDT) ? -1 : input.size();
     if(size == -1) {
       do ++size; while(qc.next(input) != null);
     }
@@ -32,12 +34,13 @@ public final class FnCount extends StandardFunc {
 
   @Override
   protected void simplifyArgs(final CompileContext cc) throws QueryException {
-    arg(0, arg -> arg.simplifyFor(Simplify.COUNT, cc));
+    // do not simplify nondeterministic input: the count rewrites could drop its side effects
+    arg(0, arg -> arg.has(Flag.NDT) ? arg : arg.simplifyFor(Simplify.COUNT, cc));
   }
 
   @Override
   protected Expr opt(final CompileContext cc) throws QueryException {
-    // return static result size
+    // return static result size (nondeterministic input is still evaluated for its side effects)
     final Expr input = arg(0);
     final long size = input.size();
     if(size >= 0 && !input.has(Flag.NDT)) return Itr.get(size);
@@ -60,7 +63,8 @@ public final class FnCount extends StandardFunc {
   public Expr simplifyFor(final Simplify mode, final CompileContext cc) throws QueryException {
     final Expr input = arg(0);
     Expr expr = this;
-    if(mode == Simplify.EBV) {
+    // rewrite to an existence check (skipped for nondeterministic input, which must be evaluated)
+    if(mode == Simplify.EBV && !input.has(Flag.NDT)) {
       // if(count($nodes)) → if($nodes)
       // if(count($items)) → if(exists($items))
       expr = input.seqType().type instanceof NodeType ? input : cc.function(EXISTS, info, exprs);

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnEmpty.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnEmpty.java
@@ -35,7 +35,8 @@ public class FnEmpty extends StandardFunc {
 
   @Override
   protected final void simplifyArgs(final CompileContext cc) throws QueryException {
-    arg(0, arg -> arg.simplifyFor(Simplify.COUNT, cc));
+    // do not simplify nondeterministic input: the count rewrites could drop its side effects
+    arg(0, arg -> arg.has(Flag.NDT) ? arg : arg.simplifyFor(Simplify.COUNT, cc));
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnReplicate.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnReplicate.java
@@ -95,6 +95,14 @@ public final class FnReplicate extends StandardFunc {
   @Override
   protected Expr opt(final CompileContext cc) throws QueryException {
     final Expr input = arg(0), count = arg(1);
+
+    // single evaluation suffices for deterministic input: drop a redundant repeated-evaluation
+    // flag (it may have been added conservatively for a call through a not-yet-resolved variable)
+    if(defined(2) && arg(2) == Bln.TRUE && !input.has(Flag.NDT, Flag.CNS) &&
+        !input.mayInvokeVariable()) {
+      return cc.function(REPLICATE, info, input, count);
+    }
+
     final boolean single = singleEval(true);
 
     // merge replicate functions

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnSortBy.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnSortBy.java
@@ -9,6 +9,7 @@ import org.basex.query.CompileContext.*;
 import org.basex.query.expr.*;
 import org.basex.query.func.*;
 import org.basex.query.iter.*;
+import org.basex.query.util.*;
 import org.basex.query.util.collation.*;
 import org.basex.query.util.list.*;
 import org.basex.query.value.*;
@@ -56,7 +57,8 @@ public class FnSortBy extends StandardFunc {
   public final Expr simplifyFor(final Simplify mode, final CompileContext cc)
       throws QueryException {
     // count(sort(A)) → count(A)
-    return cc.simplify(this, mode == Simplify.COUNT ? arg(0) : this, mode);
+    // keep a nondeterministic sort key, whose evaluation it would drop
+    return cc.simplify(this, mode == Simplify.COUNT && !has(Flag.NDT) ? arg(0) : this, mode);
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnSortWith.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnSortWith.java
@@ -9,6 +9,7 @@ import org.basex.query.CompileContext.*;
 import org.basex.query.expr.*;
 import org.basex.query.func.*;
 import org.basex.query.iter.*;
+import org.basex.query.util.*;
 import org.basex.query.util.list.*;
 import org.basex.query.value.*;
 import org.basex.query.value.item.*;
@@ -80,6 +81,7 @@ public class FnSortWith extends StandardFunc {
   @Override
   public Expr simplifyFor(final Simplify mode, final CompileContext cc) throws QueryException {
     // count(sort(A)) → count(A)
-    return cc.simplify(this, mode == Simplify.COUNT ? arg(0) : this, mode);
+    // keep a nondeterministic sort key, whose evaluation it would drop
+    return cc.simplify(this, mode == Simplify.COUNT && !has(Flag.NDT) ? arg(0) : this, mode);
   }
 }

--- a/basex-core/src/main/java/org/basex/query/func/util/UtilCountWithin.java
+++ b/basex-core/src/main/java/org/basex/query/func/util/UtilCountWithin.java
@@ -31,11 +31,16 @@ public final class UtilCountWithin extends StandardFunc {
     final long[] minMax = minMax(qc);
     final long min = minMax[0], max = minMax[1];
 
-    // iterative access: if the iterator size is unknown, iterate through results
-    final Iter input = arg(0).iter(qc);
-    long size = input.size();
+    // iterative access: if the iterator size is unknown or the input is nondeterministic (which
+    // must be fully evaluated for its side effects), iterate through the results
+    final Expr expr = arg(0);
+    final Iter input = expr.iter(qc);
+    final boolean enforce = expr.has(Flag.NDT);
+    long size = enforce ? -1 : input.size();
     if(size == -1) {
-      if(max == Long.MAX_VALUE) {
+      if(enforce) {
+        do ++size; while(qc.next(input) != null);
+      } else if(max == Long.MAX_VALUE) {
         // >= min: skip if minimum is reached
         do ++size; while(size < min && qc.next(input) != null);
       } else {
@@ -48,23 +53,24 @@ public final class UtilCountWithin extends StandardFunc {
 
   @Override
   protected void simplifyArgs(final CompileContext cc) throws QueryException {
-    arg(0, arg -> arg.simplifyFor(Simplify.COUNT, cc));
+    // do not simplify nondeterministic input: the count rewrites could drop its side effects
+    arg(0, arg -> arg.has(Flag.NDT) ? arg : arg.simplifyFor(Simplify.COUNT, cc));
   }
 
   @Override
   protected Expr opt(final CompileContext cc) throws QueryException {
     final Expr input = arg(0);
 
-    // return statically known size (ignore nondeterministic expressions, e.g. count(error()))
+    // skip rewrites for nondeterministic input, which must be fully evaluated for its side effects
     final long[] minMax = minMaxValues(cc.qc);
-    if(minMax != null) {
+    if(minMax != null && !input.has(Flag.NDT)) {
       final long min = minMax[0], max = minMax[1];
       if(min > max) return Bln.FALSE;
       if(min <= 0 && max == Long.MAX_VALUE) return Bln.TRUE;
 
       // evaluate static result size
       final long size = input.size();
-      if(size >= 0 && !input.has(Flag.NDT)) return Bln.get(size >= min && size <= max);
+      if(size >= 0) return Bln.get(size >= min && size <= max);
 
       if(max == 0) return cc.function(EMPTY, info, input);
       if(min == 1 && max == Long.MAX_VALUE) return cc.function(EXISTS, info, input);

--- a/basex-core/src/main/java/org/basex/query/util/ASTVisitor.java
+++ b/basex-core/src/main/java/org/basex/query/util/ASTVisitor.java
@@ -78,6 +78,16 @@ public abstract class ASTVisitor {
   }
 
   /**
+   * Notifies the visitor of a dynamic function call.
+   * @param func expression that yields the invoked function
+   * @return if more expressions should be visited ({@code true} by default)
+   */
+  @SuppressWarnings("unused")
+  public boolean dynFuncCall(final Expr func) {
+    return true;
+  }
+
+  /**
    * Notifies the visitor of database locks. Overwritten by {@link MainModule}.
    * Returns {@code false} if the lock is not known statically.
    * @param list function supplying lock strings

--- a/basex-core/src/main/java/org/basex/query/util/Flag.java
+++ b/basex-core/src/main/java/org/basex/query/util/Flag.java
@@ -22,6 +22,9 @@ public enum Flag {
   CTX,
   /**
    * Nondeterministic code. Cannot be relocated, pre-evaluated or optimized away.
+   * Implied by {@link #UPD}: see the constructor of
+   * {@link org.basex.query.func.FuncDefinition} and
+   * {@code org.basex.query.up.expr.Update#has(Flag...)}.
    * Examples: random:double(), file:write()
    */
   NDT,

--- a/basex-core/src/main/java/org/basex/query/value/item/FuncItem.java
+++ b/basex-core/src/main/java/org/basex/query/value/item/FuncItem.java
@@ -149,6 +149,14 @@ public final class FuncItem extends FItem implements Scope {
     return anns.contains(Annotation.UPDATING) || expr.has(Flag.UPD);
   }
 
+  /**
+   * Checks if the function body is non-deterministic.
+   * @return result of check
+   */
+  public boolean ndt() {
+    return expr.has(Flag.NDT);
+  }
+
   @Override
   public boolean accept(final ASTVisitor visitor) {
     return visitor.funcItem(this);

--- a/basex-core/src/test/java/org/basex/query/ast/NonDeterministicTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/NonDeterministicTest.java
@@ -1,0 +1,425 @@
+package org.basex.query.ast;
+
+import static org.basex.query.func.Function.*;
+
+import org.basex.*;
+import org.basex.io.*;
+import org.basex.query.*;
+import org.basex.query.expr.*;
+import org.basex.query.expr.gflwor.*;
+import org.basex.query.func.*;
+import org.basex.query.func.fn.*;
+import org.basex.query.func.util.*;
+import org.basex.query.util.*;
+import org.basex.query.value.item.*;
+import org.junit.jupiter.api.*;
+
+/**
+ * Checks that optimizations preserve the side effects of nondeterministic code.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public final class NonDeterministicTest extends SandboxTest {
+  /** Log file recording evaluated side effects. */
+  private IOFile log;
+
+  /** Prepares an empty log file before each test. */
+  @BeforeEach public void prepareLog() {
+    log = new IOFile(sandbox(), "log");
+    write(log, "");
+  }
+
+  /** Checks that expressions marked as nondeterministic are not rewritten. */
+  @Test public void pragma() {
+    check("count((# basex:nondeterministic #) { <x/> })", 1, exists(COUNT));
+  }
+
+  /**
+   * Checks that arithmetic keeps a nondeterministic operand instead of applying rewrites that might
+   * remove them, such as {@code $ndt * 0}.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link Arith#optimize}.
+   */
+  @Test public void arith() {
+    query("(# basex:nondeterministic #) { " + fileAppend() + ", 5 } * 0", 0, "x");
+  }
+
+  /**
+   * Checks that a binary operator keeps a nondeterministic operand when the other operand is empty.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link Arr#emptyExpr} (arithmetic and comparison
+   * operators).
+   */
+  @Test public void emptyOperand() {
+    query("() = (# basex:nondeterministic #) { " + fileAppend() + ", 5 }", false, "x");
+  }
+
+  /**
+   * Checks that comparisons of {@code fn:count} results do not shortcut the evaluation of
+   * nondeterministic input.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link Cmp#optCount} and {@link StandardFunc#embed}.
+   */
+  @Test public void countComparison() {
+    query("count((1 to 10)[" + fileExists() + "] ! (" + fileAppend() + ", .)) >= 1", true,
+        "xxxxxxxxxx");
+  }
+
+  /**
+   * Checks that {@code fn:distinct-values} does not drop equal nondeterministic operands of a list.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link List#simplifyFor}; the duplicates are
+   * non-adjacent, as adjacent ones are merged early into a side-effect-preserving replicate.
+   */
+  @Test public void distinctList() {
+    query("distinct-values((" + fileAppend() + ", 2, " + fileAppend() + "))", 2, "xx");
+  }
+
+  /**
+   * Checks that {@code fn:distinct-values} does not merge equal nondeterministic expressions in a
+   * simple map body.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link SimpleMap#simplifyFor} and
+   * {@link List#simplifyFor}; the duplicates are non-adjacent, as adjacent ones are merged early.
+   */
+  @Test public void distinctValues() {
+    query("count(distinct-values((1 to 10) ! (" + fileAppend() + ", ., " + fileAppend() + ")))", 10,
+        "xxxxxxxxxxxxxxxxxxxx");
+  }
+
+  /**
+   * Checks that {@code switch} does not drop duplicate nondeterministic case operands, whose side
+   * effects would be lost when no case matches the operand.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link Switch#opt} and {@link List#simplifyFor} (the
+   * switch is rewritten to a comparison whose operand list is deduplicated).
+   */
+  @Test public void switchCase() {
+    query("switch(5) case (" + fileAppend() + ", 9) case (" + fileAppend() + ", 9) return 'a' " +
+        "default return 'b'", "b", "xx");
+  }
+
+  /**
+   * Checks that order by clauses with nondeterministic keys are not removed when counting results.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link FnCount#simplifyArgs} (first line of defense)
+   * and {@link GFLWOR#simplifyFor} (second line, shared with {@code fn:empty} and
+   * {@code util:count-within}).
+   */
+  @Test public void orderBy() {
+    query("count(for $num in (2, 3, 1) order by (" + fileAppend() + ", $num) return $num)", 3,
+        "xxx");
+  }
+
+  /**
+   * Checks that a nondeterministic function item bound to a variable keeps its side effects when
+   * the enclosing for clause is rewritten to a single-evaluation replicate.
+   * <p>
+   * Requires the {@code referencesNdtFunction} check in {@link GFLWOR#inlineForLet} and the
+   * {@code containsNdtFunction} check in {@link DynFuncCall#optimize}.
+   */
+  @Test public void functionVariable() {
+    query("let $f := function() { " + fileAppend() + " } for $x in (1 to 2) return $f()", "", "xx");
+  }
+
+  /**
+   * Checks that a nondeterministic closure bound to a variable keeps its side effects when the
+   * enclosing for clause is rewritten to a single-evaluation replicate.
+   * <p>
+   * Requires the {@code referencesNdtFunction} check in {@link GFLWOR#inlineForLet} and the
+   * {@code containsNdtFunction} check in {@link DynFuncCall#optimize}.
+   */
+  @Test public void closureVariable() {
+    query("let $c := 'x' let $f := function() { " + _FILE_APPEND_TEXT.args(log.path(), " $c") +
+        " } for $x in (1 to 2) return $f()", "", "xx");
+  }
+
+  /**
+   * Checks that a sequence of nondeterministic function items bound to a variable keeps its side
+   * effects when the enclosing for clause is rewritten to a single-evaluation replicate.
+   * <p>
+   * Requires the {@code referencesNdtFunction} check in {@link GFLWOR#inlineForLet} and the
+   * {@code containsNdtFunction} check in {@link DynFuncCall#optimize}.
+   */
+  @Test public void functionSequence() {
+    query("let $f := (function() { " + fileAppend() + " }, function() { " + fileAppend() + " }) " +
+        "for $x in (1 to 2) return $f()", "", "xxxx");
+  }
+
+  /**
+   * Checks that a sequence of nondeterministic closures bound to a variable keeps its side effects
+   * when the enclosing for clause is rewritten to a single-evaluation replicate.
+   * <p>
+   * Requires the {@code referencesNdtFunction} check in {@link GFLWOR#inlineForLet} and the
+   * {@code containsNdtFunction} check in {@link DynFuncCall#optimize}.
+   */
+  @Test public void closureSequence() {
+    query("let $c := 'x' let $f := (function() { " + _FILE_APPEND_TEXT.args(log.path(), " $c") +
+        " }, function() { " + _FILE_APPEND_TEXT.args(log.path(), " $c") + " }) " +
+        "for $x in (1 to 2) return $f()", "", "xxxx");
+  }
+
+  /**
+   * Checks that an array of nondeterministic function items bound to a variable keeps its side
+   * effects when the enclosing for clause is rewritten to a single-evaluation replicate.
+   * <p>
+   * Requires the {@code referencesNdtFunction} check in {@link GFLWOR#inlineForLet} and the
+   * {@code containsNdtFunction} check in {@link DynFuncCall#optimize}.
+   */
+  @Test public void functionArray() {
+    query("let $f := [function() { " + fileAppend() + " }] for $x in (1 to 2) return $f?1()", "",
+        "xx");
+  }
+
+  /**
+   * Checks that a map of nondeterministic function items bound to a variable keeps its side
+   * effects when the enclosing for clause is rewritten to a single-evaluation replicate.
+   * <p>
+   * Requires the {@code referencesNdtFunction} check in {@link GFLWOR#inlineForLet} and the
+   * {@code containsNdtFunction} check in {@link DynFuncCall#optimize}.
+   */
+  @Test public void functionMap() {
+    query("let $f := map { 'k': function() { " + fileAppend() + " } } for $x in (1 to 2) " +
+        "return $f?k()", "", "xx");
+  }
+
+  /**
+   * Checks that a nondeterministic function item bound to a variable keeps its side effects when a
+   * simple map over a constant range is rewritten to a single-evaluation replicate.
+   * <p>
+   * Requires the {@link Expr#mayInvokeVariable} check in {@link CompileContext#replicate} and
+   * {@link SimpleMap#dropOps}.
+   */
+  @Test public void simpleMapVariable() {
+    query("let $f := function() { " + fileAppend() + " } return (1 to 2) ! $f()", "", "xx");
+  }
+
+  /**
+   * Checks that a sequence of nondeterministic function items bound to a variable keeps its side
+   * effects when a simple map over a constant range is rewritten to a single-evaluation replicate.
+   * <p>
+   * Requires the {@link Expr#mayInvokeVariable} check in {@link CompileContext#replicate} and
+   * {@link SimpleMap#dropOps}.
+   */
+  @Test public void simpleMapSequence() {
+    query("let $f := (function() { " + fileAppend() + " }, function() { " + fileAppend() + " }) " +
+        "return (1 to 2) ! $f()", "", "xxxx");
+  }
+
+  /**
+   * Checks that nondeterministic code in coerced function items is not discarded.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link DynFuncCall#optimize}: without inlining, the
+   * coercion of the key function wraps it in a new function item whose body is a dynamic call of
+   * the original function, hiding its nondeterministic property.
+   */
+  @Test public void functionCoercion() {
+    query("count(sort((2, 1), (), function($key) { " + fileAppend() + ", $key }))", 2, "xx");
+  }
+
+  /**
+   * Checks that nondeterministic bodies of invoked function items are visible to optimizations.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link StandardFunc#embed} (which consults
+   * {@link FuncItem#ndt}, as the pre-evaluated function item is a value and reports no flags) and
+   * {@link FnCount}.
+   */
+  @Test public void functionItem() {
+    query("count((1 to 2) ! (function($arg) as xs:integer { " + fileAppend() + ", $arg }(.)))", 2,
+        "xx");
+  }
+
+  /**
+   * Checks that {@code fn:count} does not discard the nondeterministic body of a simple map.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link StandardFunc#embed}; the nondeterministic filter
+   * makes the result size unknown until runtime.
+   */
+  @Test public void countSimpleMap() {
+    query("count((1 to 10)[" + fileExists() + "] ! (" + fileAppend() + ", .))", 10, "xxxxxxxxxx");
+  }
+
+  /**
+   * Checks that {@code fn:count} evaluates nondeterministic input even if its iterator size is
+   * known.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link FnCount#item}; the conditional
+   * prevents compile-time rewriting of the simple map.
+   */
+  @Test public void countKnownSize() {
+    query("count(if (" + fileExists() + ") then (1 to 10) ! (" + fileAppend() + ", .) else ())", 10,
+        "xxxxxxxxxx");
+  }
+
+  /**
+   * Checks that {@code fn:count} does not trigger simplifications that drop nondeterministic order
+   * by keys.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link FnCount#simplifyArgs} (first line of defense)
+   * and {@link GFLWOR#simplifyFor} (second line).
+   */
+  @Test public void countOrderBy() {
+    query("count(for $item in (2, 1) order by (" + fileAppend() + ", $item) return $item)", 2,
+        "xx");
+  }
+
+  /**
+   * Checks that {@code fn:count} used as an effective boolean value does not simplify
+   * nondeterministic input to {@code fn:exists}.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link FnCount#simplifyFor} and
+   * {@link StandardFunc#embed}.
+   */
+  @Test public void countEbv() {
+    query("if(count((1 to 10) ! (" + fileAppend() + ", .))) then true() else false()", true,
+        "xxxxxxxxxx");
+  }
+
+  /**
+   * Checks that {@code fn:empty} does not trigger simplifications that drop nondeterministic order
+   * by keys.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link FnEmpty#simplifyArgs} (first line of defense)
+   * and {@link GFLWOR#simplifyFor} (second line); retrieving the first item of the ordered
+   * sequence evaluates all order by keys.
+   */
+  @Test public void emptyOrderBy() {
+    query("empty(for $entry in (2, 1) order by (" + fileAppend() + ", $entry) return $entry)",
+        false, "xx");
+  }
+
+  /**
+   * Checks that sort operations with nondeterministic keys are not removed when counting results.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link FnCount#simplifyArgs} (first line of defense)
+   * and {@link FnSortBy#simplifyFor} (second line, covering {@code fn:sort} and
+   * {@code fn:sort-by}); inlining is enabled, as the coercion of the key function otherwise hides
+   * its nondeterministic property in a dynamic function call.
+   */
+  @Test public void sort() {
+    query("declare option db:inlinelimit '50'; count(sort((2, 1), (), function($int) { " +
+        fileAppend() + ", $int }))", 2, "xx");
+  }
+
+  /**
+   * Checks that sort operations with nondeterministic comparators are not removed when counting
+   * results.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link FnCount#simplifyArgs} (first line of defense)
+   * and {@link FnSortWith#simplifyFor} (second line); inlining is enabled, as the coercion of the
+   * comparator otherwise hides its nondeterministic property in a dynamic call.
+   */
+  @Test public void sortWith() {
+    query("declare option db:inlinelimit '50'; count(sort-with((2, 1), function($a, $b) { " +
+        fileAppend() + ", $a - $b }))", 2, "x");
+  }
+
+  /**
+   * Checks that {@code util:count-within} does not trigger simplifications that drop
+   * nondeterministic order by keys.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link UtilCountWithin#simplifyArgs} (first line of
+   * defense) and {@link GFLWOR#simplifyFor} (second line); counting up to the minimum retrieves
+   * items of the ordered sequence, evaluating all keys.
+   */
+  @Test public void countWithin() {
+    query("util:count-within(for $value in (2, 1) order by (" + fileAppend() +
+        ", $value) return $value, 2)", true, "xx");
+  }
+
+  /**
+   * Checks that {@code util:count-within} evaluates nondeterministic input even if its iterator
+   * size is known.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link UtilCountWithin#test} and
+   * {@link StandardFunc#embed}; the minimum equals the input size, so counting cannot stop before
+   * the last item.
+   */
+  @Test public void countWithinKnownSize() {
+    query("util:count-within((1 to 10) ! (" + fileAppend() + ", .), 10)", true, "xxxxxxxxxx");
+  }
+
+  /**
+   * Checks that {@code util:count-within} does not discard nondeterministic input with zero-or-one
+   * cardinality.
+   * <p>
+   * Requires the {@link Flag#NDT} check for the zero-or-one rewrites in
+   * {@link UtilCountWithin#opt}.
+   */
+  @Test public void countWithinZeroOrOne() {
+    query("util:count-within(" + fileAppend() + ", 2)", false, "x");
+  }
+
+  /**
+   * Checks that {@code util:count-within} does not simplify nondeterministic input to
+   * {@code fn:exists}.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link UtilCountWithin#opt} and
+   * {@link StandardFunc#embed}.
+   */
+  @Test public void countWithinExists() {
+    query("util:count-within((1 to 10) ! (" + fileAppend() + ", .), 1)", true, "xxxxxxxxxx");
+  }
+
+  /**
+   * Checks that {@code util:count-within} with an always-satisfied range does not drop
+   * nondeterministic input.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link UtilCountWithin#opt} and
+   * {@link StandardFunc#embed}.
+   */
+  @Test public void countWithinAlways() {
+    query("util:count-within((1 to 10) ! (" + fileAppend() + ", .), 0)", true, "xxxxxxxxxx");
+  }
+
+  /**
+   * Checks that {@code util:count-within} with an impossible range does not drop nondeterministic
+   * input.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link UtilCountWithin#opt} and
+   * {@link StandardFunc#embed}.
+   */
+  @Test public void countWithinImpossible() {
+    query("util:count-within((1 to 10) ! (" + fileAppend() + ", .), 2, 1)", false, "xxxxxxxxxx");
+  }
+
+  /**
+   * Checks that {@code fn:count} consumes all mapped items to preserve side effects in the map
+   * body.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link FnCount} and {@link StandardFunc#embed}.
+   */
+  @Test public void gh2673() {
+    query("let $ten-strings := replicate('x', 10) return count($ten-strings ! (" + fileAppend() +
+        ", .))", 10, "xxxxxxxxxx");
+  }
+
+  /**
+   * Returns a function call that records a single evaluation in the log.
+   * @return file:append-text call
+   */
+  private String fileAppend() {
+    return _FILE_APPEND_TEXT.args(log.path(), "x");
+  }
+
+  /**
+   * Returns a function call that is true if the log file exists. As the file is always present at
+   * runtime but its existence is unknown at compile time, it acts as a non-foldable condition.
+   * @return file:exists call
+   */
+  private String fileExists() {
+    return _FILE_EXISTS.args(log.path());
+  }
+
+  /**
+   * Runs a query and checks its result and the side effects recorded in the log.
+   * @param query query to run
+   * @param result expected query result
+   * @param recorded expected recorded side effects
+   */
+  private void query(final String query, final Object result, final String recorded) {
+    query(query, result);
+    query(_FILE_READ_TEXT.args(log.path()), recorded);
+  }
+}

--- a/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/RewritingsTest.java
@@ -330,11 +330,6 @@ public final class RewritingsTest extends SandboxTest {
     check("((), <x/>, ())", "<x/>", empty(List.class), empty(Empty.class), exists(CElem.class));
   }
 
-  /** Checks that expressions marked as nondeterministic will not be rewritten. */
-  @Test public void nonDeterministic() {
-    check("count((# basex:nondeterministic #) { <x/> })", 1, exists(COUNT));
-  }
-
   /** Ensures that fn:doc with URLs will not be rewritten. */
   @Test public void doc() {
     check("<a>{ doc('" + FILE + "') }</a>//x", "", exists(DBNode.class));


### PR DESCRIPTION
Following up on #2673, this PR investigates optimizer rewrites that can skip execution of nondeterministic code and thereby lose its side effects.

The review found roughly 20 distinct rewrites with this problem, covered by about 30 tests. Most were fixed by adding the missing `Flag.NDT` checks. A few needed more than that, because nondeterminism is not always visible as a flag on the operand:

- a pre-evaluated function item or closure is a value and does not carry `Flag.NDT`, so some rewrites now consult the function's own nondeterminism (e.g. in `DynFuncCall` and, for the `for`-to-`replicate` rewrite, via a deferral in `GFLWOR`),
- a function invoked through a not-yet-resolved variable (`$f()`) carries no flags of its own. A new `Expr.mayInvokeVariable()` check lets the affected rewrites treat such a call conservatively until the variable is replaced by the actual function.

All affected rewrites carry comments explaining the check. Tests have also been added, each test covers one or more fixes and documents the relationship in its Javadoc. Note that these relationships can vary depending on whether the patch is applied to a fully fixed source tree or to an otherwise unfixed one.

Care was taken not to block optimizations of deterministic code. The size and count rewrites still apply to deterministic input, and where a guard had to be conservative (a function reached through a not-yet-resolved variable), the restriction is lifted again as soon as the variable is replaced by a deterministic function - so deterministic code is optimized as before. The changes are otherwise scoped to expressions marked with `Flag.NDT`.

The tests are collected in the new `NonDeterministicTest` class. The previous `RewritingsTest.nonDeterministic` test has been moved there as `NonDeterministicTest.pragma`.

See the test Javadocs and fix comments for more details.