### PR TITLE
Fix `IndexOutOfBoundsException` for non-existing groups in `fn:replace`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/FnReplace.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnReplace.java
@@ -88,7 +88,7 @@ public final class FnReplace extends RegExFn {
           if(i == -1) {
             sb.append(string, s, sl);
             s = sl;
-          } else if(i == 0 || string.charAt(i - 1) != '\\') {
+          } else if(!isEscaped(string, i)) {
             sb.append(string, s, i);
             s = ++i;
             if(i < sl && Character.isDigit(string.charAt(i))) i++;
@@ -104,6 +104,19 @@ public final class FnReplace extends RegExFn {
       }
     }
     return Str.get(matcher.replaceAll(string));
+  }
+
+  /**
+   * Checks if the character at the specified position is escaped, i.e., if it is preceded by
+   * an odd number of backslashes.
+   * @param string string
+   * @param pos position of the character
+   * @return result of check
+   */
+  private static boolean isEscaped(final String string, final int pos) {
+    int bs = 0;
+    for(int p = pos - 1; p >= 0 && string.charAt(p) == '\\'; p--) bs++;
+    return (bs & 1) != 0;
   }
 
   @Override

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -3236,6 +3236,12 @@ return
     // GH-2692: unmatched groups supplied to replacement functions are zero-length strings
     query(func.args("", "(X)?", " fn($_, $groups) { $groups[1] }"), "");
 
+    // GH-2697: unmatched groups
+    query(func.args("a", "(a)|(b)", " fn($m){$m}"), "a");
+
+    // GH-2698: lookback for escaped dollar signs in replacement must look beyond first backslash
+    query(func.args("full stop.", "\\.", "\\\\$1"), "full stop\\");
+
     query(func.args("Chapter 9", "[0-9]+", " fn($k, $g) { string(number($k) + 1) }"),
         "Chapter 10");
     query("let $map := { 'LAX': 'Los Angeles', 'LHR': 'London' } return"


### PR DESCRIPTION
As reported by [Amanda Galtman on basex-talk](https://mailman.uni-konstanz.de/mailman3/hyperkitty/list/basex-talk@mailman.uni-konstanz.de/thread/VGVQSVY7RET2VM5VAX5SKIJZDBTY3DDL/), an `IndexOutOfBoundsException` can occur when the replacement string contains a reference to a non-existing capture group that is preceded by a backslash, e.g.

```xquery
replace('full stop.','\.','\\$1')
```

The issue is caused by `FnReplace.item`, which only examines the single character preceding a dollar sign. If that character is a backslash, the dollar sign is assumed to be escaped, and the replacement string is subsequently passed to `Matcher.replaceAll`.

The fix is to count the number of consecutive preceding backslashes. The dollar sign is escaped only if that count is odd.