### PR TITLE
More NDT checks

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/fn/FnExactlyOne.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnExactlyOne.java
@@ -6,6 +6,7 @@ import org.basex.query.*;
 import org.basex.query.expr.*;
 import org.basex.query.func.*;
 import org.basex.query.iter.*;
+import org.basex.query.util.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.seq.*;
 import org.basex.query.value.type.*;
@@ -40,7 +41,7 @@ public final class FnExactlyOne extends StandardFunc {
     final Expr input = arg(0);
     final SeqType st = input.seqType();
     if(st.one()) return input;
-    if(st.zero() || input.size() > 1) throw EXACTLYONE.get(info);
+    if((st.zero() || input.size() > 1) && !input.has(Flag.NDT)) throw EXACTLYONE.get(info);
 
     exprType.assign(st.with(Occ.EXACTLY_ONE)).data(input);
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnOneOrMore.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnOneOrMore.java
@@ -6,6 +6,7 @@ import org.basex.query.*;
 import org.basex.query.expr.*;
 import org.basex.query.func.*;
 import org.basex.query.iter.*;
+import org.basex.query.util.*;
 import org.basex.query.value.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.seq.*;
@@ -52,7 +53,7 @@ public final class FnOneOrMore extends StandardFunc {
     final Expr input = arg(0);
     final SeqType st = input.seqType();
     if(st.oneOrMore()) return input;
-    if(st.zero()) throw ONEORMORE.get(info);
+    if(st.zero() && !input.has(Flag.NDT)) throw ONEORMORE.get(info);
 
     exprType.assign(st.with(Occ.ONE_OR_MORE)).data(input);
     return this;

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnTail.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnTail.java
@@ -64,7 +64,7 @@ public final class FnTail extends StandardFunc {
     final long size = input.size();
     final SeqType st = input.seqType();
     // zero or one result: return empty sequence
-    if(size == 0 || size == 1 || st.zeroOrOne()) return Empty.VALUE;
+    if(size == 0 || size == 1 || st.zeroOrOne()) return cc.voidAndReturn(input, Empty.VALUE, info);
     // two results: return last item
     if(size == 2) return cc.function(FOOT, info, input);
 

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnTrunk.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnTrunk.java
@@ -79,7 +79,7 @@ public final class FnTrunk extends StandardFunc {
     if(input instanceof Value) return value(cc.qc);
 
     final SeqType st = input.seqType();
-    if(st.zeroOrOne()) return Empty.VALUE;
+    if(st.zeroOrOne()) return cc.voidAndReturn(input, Empty.VALUE, info);
 
     final long size = input.size();
     // trunk(TWO-RESULTS) → head(TWO-RESULTS)

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnZeroOrOne.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnZeroOrOne.java
@@ -6,6 +6,7 @@ import org.basex.query.*;
 import org.basex.query.expr.*;
 import org.basex.query.func.*;
 import org.basex.query.iter.*;
+import org.basex.query.util.*;
 import org.basex.query.value.item.*;
 import org.basex.query.value.seq.*;
 import org.basex.query.value.type.*;
@@ -32,7 +33,7 @@ public final class FnZeroOrOne extends StandardFunc {
     final Expr input = arg(0);
     final SeqType st = input.seqType();
     if(st.zeroOrOne()) return input;
-    if(input.size() > 1) throw ZEROORONE.get(info);
+    if(input.size() > 1 && !input.has(Flag.NDT)) throw ZEROORONE.get(info);
 
     exprType.assign(st.with(Occ.ZERO_OR_ONE)).data(input);
     return this;

--- a/basex-core/src/test/java/org/basex/query/ast/NonDeterministicTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/NonDeterministicTest.java
@@ -1,6 +1,9 @@
 package org.basex.query.ast;
 
+import static org.basex.query.QueryError.*;
 import static org.basex.query.func.Function.*;
+
+import java.io.*;
 
 import org.basex.*;
 import org.basex.io.*;
@@ -250,6 +253,44 @@ public final class NonDeterministicTest extends SandboxTest {
   @Test public void countKnownSize() {
     query("count(if (" + fileExists() + ") then (1 to 10) ! (" + fileAppend() + ", .) else ())", 10,
         "xxxxxxxxxx");
+  }
+
+  /**
+   * Checks that {@code fn:exactly-one} evaluates nondeterministic input before raising a
+   * cardinality error for statically oversized input.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link FnExactlyOne#opt}.
+   * @throws IOException I/O exception
+   */
+  @Test public void exactlyOneNdt() throws IOException {
+    error("exactly-one((" + fileAppend() + ", 1, 2))", EXACTLYONE);
+    query(_FILE_READ_TEXT.args(log.path()), "x");
+
+    log.write("");
+    error("exactly-one(" + fileAppend() + ")", EXACTLYONE);
+    query(_FILE_READ_TEXT.args(log.path()), "x");
+  }
+
+  /**
+   * Checks that {@code fn:zero-or-one} evaluates nondeterministic input before raising a
+   * cardinality error for statically oversized input.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link FnZeroOrOne#opt}.
+   */
+  @Test public void zeroOrOneNdt() {
+    error("zero-or-one((" + fileAppend() + ", 1, 2))", ZEROORONE);
+    query(_FILE_READ_TEXT.args(log.path()), "x");
+  }
+
+  /**
+   * Checks that {@code fn:one-or-more} evaluates nondeterministic input before raising a
+   * cardinality error for statically empty input.
+   * <p>
+   * Requires the {@link Flag#NDT} check in {@link FnOneOrMore#opt}.
+   */
+  @Test public void oneOrMoreNdt() {
+    error("one-or-more(" + fileAppend() + ")", ONEORMORE);
+    query(_FILE_READ_TEXT.args(log.path()), "x");
   }
 
   /**
@@ -515,6 +556,24 @@ public final class NonDeterministicTest extends SandboxTest {
    */
   @Test public void deepEqualNdt() {
     query("deep-equal((" + fileAppend() + ", 1), (" + fileAppend() + ", 1, 2))", false, "xx");
+  }
+
+  /**
+   * Checks that fn:tail does not drop a nondeterministic input with zero-or-one cardinality.
+   * <p>
+   * Requires the use of {@link CompileContext#voidAndReturn} in {@link FnTail#opt}.
+   */
+  @Test public void tailNdt() {
+    query("tail(" + fileAppend() + ")", "", "x");
+  }
+
+  /**
+   * Checks that fn:trunk does not drop a nondeterministic input with zero-or-one cardinality.
+   * <p>
+   * Requires the use of {@link CompileContext#voidAndReturn} in {@link FnTrunk#opt}.
+   */
+  @Test public void trunkNdt() {
+    query("trunk(" + fileAppend() + ")", "", "x");
   }
 
   /**


### PR DESCRIPTION
Some work on a different topic brought up a few more places where nondeterministic input could be dropped, which are fixed here, in
- `fn:exactly-one`
- `fn:one-or-more`
- `fn:zero-or-one`
- `fn:tail`
- `fn:trunk`