### PR TITLE
Support XQuery 4.0 `xs:error` semantics

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/Convert.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Convert.java
@@ -66,7 +66,8 @@ abstract class Convert extends Single {
 
       final Type et = est.type;
       if(et.instanceOf(castType.type) && est.occ.instanceOf(castType.occ) &&
-          (et.eq(castType.type) || castType.type == BasicType.NUMERIC)) return true;
+          (et.eq(castType.type) || castType.type == BasicType.NUMERIC) &&
+          castType.type != BasicType.ERROR) return true;
     }
     return null;
   }

--- a/basex-core/src/main/java/org/basex/query/expr/TypeCheck.java
+++ b/basex-core/src/main/java/org/basex/query/expr/TypeCheck.java
@@ -58,7 +58,16 @@ public final class TypeCheck extends Single {
       final Occ nocc = et.occ.intersect(st.occ);
       // raise static error if no intersection is possible:
       //   () coerce to item()
-      if(nocc == null) throw typeError(expr, st, info);
+      if(nocc == null) {
+        // the void type xs:error is a subtype of every type, so its occurrence indicator must
+        // not trigger a cardinality error
+        //   fn:error() coerce to empty-sequence()
+        if(et.instanceOf(st)) {
+          cc.info(OPTTYPE_X_X, st, expr);
+          return expr;
+        }
+        throw typeError(expr, st, info);
+      }
       // refine result type:
       //   INTEGERS coerce to item() → INTEGERS coerce to xs:integer
       if(cardinality) st = nst;

--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -262,7 +262,7 @@ public enum Function implements AFunction {
       params(STRING_O), STRING_ZO, flag(), FN_URI, Perm.ADMIN),
   /** XQuery function. */
   ERROR(FnError::new, "error([code,description,value])",
-      params(QNAME_ZO, STRING_ZO, ITEM_ZM), ITEM_ZM, flag(NDT)),
+      params(QNAME_ZO, STRING_ZO, ITEM_ZM), ERROR_O, flag(NDT)),
   /** XQuery function. */
   ESCAPE_HTML_URI(FnEscapeHtmlUri::new, "escape-html-uri(value)",
       params(STRING_ZO), STRING_O),

--- a/basex-core/src/main/java/org/basex/query/func/fn/FnDuplicateValues.java
+++ b/basex-core/src/main/java/org/basex/query/func/fn/FnDuplicateValues.java
@@ -97,7 +97,7 @@ public class FnDuplicateValues extends StandardFunc {
       if(!defined(1)) {
         // util:duplicates(1 to 10) → ()
         if(values instanceof RangeSeq || values instanceof Range || st.zeroOrOne())
-          return Empty.VALUE;
+          return cc.voidAndReturn(values, Empty.VALUE, info);
         // util:duplicates((1 to 3) ! 1) → 1
         if(values instanceof final SingletonSeq ss && !st.mayBeWrapped() && ss.singleItem()) {
           return type == st.type ? ss.itemAt(0) : cc.function(Function.DATA, info, ss.itemAt(0));

--- a/basex-core/src/main/java/org/basex/query/value/type/ArrayType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/ArrayType.java
@@ -101,10 +101,10 @@ public final class ArrayType extends FType {
   }
 
   @Override
-  public ArrayType intersect(final Type type) {
-    if(type instanceof ChoiceItemType) return (ArrayType) type.intersect(this);
+  public Type intersect(final Type type) {
+    if(type instanceof ChoiceItemType) return type.intersect(this);
     if(instanceOf(type)) return this;
-    if(type.instanceOf(this)) return (ArrayType) type;
+    if(type.instanceOf(this)) return type;
 
     if(type instanceof final ArrayType at) {
       final SeqType mt = valueType.intersect(at.valueType);

--- a/basex-core/src/main/java/org/basex/query/value/type/BasicType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/BasicType.java
@@ -43,7 +43,13 @@ public enum BasicType implements Type {
   ANY_ATOMIC_TYPE("anyAtomicType", ITEM, Type.ID.AAT, false, false),
 
   /** Error type. */
-  ERROR("error", ANY_ATOMIC_TYPE, Type.ID.ERR, false, false),
+  ERROR("error", ANY_ATOMIC_TYPE, Type.ID.ERR, false, false) {
+    @Override
+    public Item cast(final Item item, final QueryContext qc, final InputInfo info)
+        throws QueryException {
+      return cast((Object) item, qc, info);
+    }
+  },
 
   /** Untyped Atomic type. */
   UNTYPED_ATOMIC("untypedAtomic", ANY_ATOMIC_TYPE, Type.ID.ATM, false, false) {
@@ -1045,7 +1051,8 @@ public enum BasicType implements Type {
 
   @Override
   public final boolean instanceOf(final Type type) {
-    if(type == this || type == ITEM) return true;
+    // xs:error is a union type with no members, a subtype of every item type
+    if(this == ERROR || type == this || type == ITEM) return true;
     if(type instanceof final BasicType bt) {
       return (prePost & 0xFF) >= (bt.prePost & 0xFF) && (prePost & 0xFF00) <= (bt.prePost & 0xFF00);
     }
@@ -1071,8 +1078,8 @@ public enum BasicType implements Type {
 
   @Override
   public final Type intersect(final Type type) {
-    if(this == ERROR) return type;
-    if(type == ERROR) return this;
+    // xs:error is the bottom type, so it is the intersection (greatest lower bound) with any type
+    if(ERROR.oneOf(this, type)) return ERROR;
     if(type instanceof ChoiceItemType) return type.intersect(this);
     if(instanceOf(type)) return this;
     if(type.instanceOf(this)) return type;

--- a/basex-core/src/main/java/org/basex/query/value/type/ChoiceItemType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/ChoiceItemType.java
@@ -135,7 +135,7 @@ public final class ChoiceItemType implements Type {
 
   @Override
   public Type union(final Type type) {
-    return union.union(type);
+    return type == BasicType.ERROR ? this : union.union(type);
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/value/type/EnumType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/EnumType.java
@@ -106,6 +106,7 @@ public final class EnumType implements Type {
   public Type union(final Type type) {
     if(type == this) return this;
     if(type instanceof ChoiceItemType) return type.union(this);
+    if(type.instanceOf(this)) return this;
     if(type instanceof final EnumType et) {
       final TokenSet tv = et.values;
       final TokenSet ts = new TokenSet();
@@ -122,6 +123,7 @@ public final class EnumType implements Type {
   public Type intersect(final Type type) {
     if(type instanceof ChoiceItemType) return type.intersect(this);
     if(instanceOf(type)) return this;
+    if(type.instanceOf(this)) return type;
     if(type instanceof final EnumType et) {
       final TokenSet ts = new TokenSet();
       final TokenSet tv = et.values;

--- a/basex-core/src/main/java/org/basex/query/value/type/ExprType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/ExprType.java
@@ -108,7 +108,9 @@ public final class ExprType {
    * @return self reference
    */
   public ExprType assign(final SeqType st) {
-    if(st != seqType) asg(st, st.zero() ? 0 : st.one() ? 1 : -1);
+    // a void type (xs:error) has no instances and never returns, so its result size is unknown;
+    // otherwise the size is derived from the occurrence indicator
+    if(st != seqType) asg(st, st.voidType() ? -1 : st.zero() ? 0 : st.one() ? 1 : -1);
     return this;
   }
 

--- a/basex-core/src/main/java/org/basex/query/value/type/ListType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/ListType.java
@@ -136,7 +136,8 @@ public enum ListType implements Type {
 
   @Override
   public final Type union(final Type tp) {
-    return this == tp ? tp : tp instanceof ChoiceItemType ? tp.union(this) : BasicType.ITEM;
+    return this == tp ? tp : tp instanceof ChoiceItemType ? tp.union(this) :
+      tp.instanceOf(this) ? this : BasicType.ITEM;
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/SeqType.java
@@ -310,6 +310,9 @@ public final class SeqType {
       throws QueryException {
     final Type at = item.type;
     if(at.instanceOf(type)) return item;
+    // xs:error has an empty value space: function conversion never casts to it, so coercion
+    // always fails and the caller reports a type error (XPTY0004)
+    if(type == ERROR) return null;
 
     Item relabel = null;
     if(at == UNTYPED_ATOMIC) {
@@ -390,6 +393,11 @@ public final class SeqType {
    */
   public SeqType intersect(final SeqType st) {
     if(this == st) return this;
+    // a void type (xs:error, xs:error+) is the bottom of the sequence-type lattice, so it is the
+    // intersection (greatest lower bound) with any type, irrespective of the occurrence indicator.
+    // if both are void, the occurrences are intersected, so the result is order-independent
+    if(voidType()) return st.voidType() ? get(type, occ.intersect(st.occ)) : this;
+    if(st.voidType()) return st;
     final Type tp = type.intersect(st.type);
     if(tp == null) return null;
     final Occ oc = occ.intersect(st.occ);
@@ -430,6 +438,25 @@ public final class SeqType {
   }
 
   /**
+   * Tests if this is a sequence type of the <i>void</i> category ({@code xs:error} or
+   * {@code xs:error+}): it has no instances, so an expression of this type never returns a value
+   * (see the subtype rules in the specification, "Subtypes of Sequence Types").
+   * @return result of check
+   */
+  public boolean voidType() {
+    return type == BasicType.ERROR && oneOrMore();
+  }
+
+  /**
+   * Tests if this is a sequence type of the <i>empty</i> category ({@code empty-sequence()},
+   * {@code xs:error?} or {@code xs:error*}): the empty sequence is its only instance.
+   * @return result of check
+   */
+  public boolean emptyType() {
+    return zero() || type == BasicType.ERROR && !oneOrMore();
+  }
+
+  /**
    * Tests if expressions of this type may yield numbers.
    * @return result of check
    */
@@ -457,8 +484,11 @@ public final class SeqType {
    */
   public boolean instanceOf(final SeqType st) {
     if(this == st) return true;
-    // empty sequence: only check cardinality
-    if(zero()) return !st.oneOrMore();
+    // void category (xs:error, xs:error+): no instances, a subtype of every sequence type
+    if(voidType()) return true;
+    // empty category (empty-sequence(), xs:error?, xs:error*): the empty sequence is the only
+    // instance, a subtype of every sequence type that permits the empty sequence
+    if(emptyType()) return !st.oneOrMore();
     if(!occ.instanceOf(st.occ)) return false;
     return st.type instanceof final ChoiceItemType cit ? cit.hasInstance(type)
                                                        : type.instanceOf(st.type);

--- a/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
+++ b/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
@@ -26,8 +26,14 @@ import org.junit.jupiter.api.Test;
 public final class SeqTypeTest {
   /** Occurrences. */
   private static final Occ[] OCCS = { ZERO, ZERO_OR_ONE, EXACTLY_ONE, ZERO_OR_MORE, ONE_OR_MORE };
-  /** Error type. */
+  /** Error type (void category). */
   private static final SeqType ERROR_O = ERROR.seqType();
+  /** Error type {@code xs:error?} (empty category). */
+  private static final SeqType ERROR_ZO = ERROR.seqType(ZERO_OR_ONE);
+  /** Error type {@code xs:error*} (empty category). */
+  private static final SeqType ERROR_ZM = ERROR.seqType(ZERO_OR_MORE);
+  /** Error type {@code xs:error+} (void category). */
+  private static final SeqType ERROR_OM = ERROR.seqType(ONE_OR_MORE);
 
   /** Type gnode(). */
   private static final SeqType GNODE_O = GNODE.seqType();
@@ -167,6 +173,19 @@ public final class SeqTypeTest {
   }
 
   /**
+   * Tests that a void type ({@code xs:error}) reports an unknown result size: it has no instances
+   * and never returns a value, so size-based optimizations must not treat it as a single item (e.g.
+   * {@code count(local:f())} for a recursive {@code local:f() as xs:error} must not fold to 1).
+   */
+  @Test public void voidSize() {
+    assertEquals(-1, new ExprType(ERROR_O).size());
+    assertEquals(-1, new ExprType(ERROR.seqType(ONE_OR_MORE)).size());
+    // ordinary occurrences still derive the size from the occurrence indicator
+    assertEquals(1, new ExprType(STRING_O).size());
+    assertEquals(0, new ExprType(EMPTY_SEQUENCE_Z).size());
+  }
+
+  /**
    * Tests for {@link SeqType#instanceOf(SeqType)}.
    * @throws QueryException query exception
    */
@@ -178,7 +197,36 @@ public final class SeqTypeTest {
     assertFalse(DOUBLE_ZM.instanceOf(DOUBLE_O));
     assertFalse(DATE_TIME_O.instanceOf(DATE_TIME_STAMP_O));
     assertTrue(DATE_TIME_STAMP_O.instanceOf(DATE_TIME_O));
+
     assertTrue(ERROR_O.instanceOf(ANY_ATOMIC_TYPE_O));
+    assertTrue(ERROR.instanceOf(STRING));
+    assertTrue(ERROR.instanceOf(NUMERIC));
+    assertTrue(ERROR.instanceOf(NODE));
+    assertTrue(ERROR.instanceOf(FUNCTION));
+    assertTrue(ERROR.instanceOf(MAP));
+    assertTrue(ERROR.instanceOf(ARRAY));
+    assertTrue(ERROR.instanceOf(RECORD));
+    assertTrue(ERROR.instanceOf(ChoiceItemType.get(STRING, ELEMENT)));
+
+    assertFalse(STRING.instanceOf(ERROR));
+    assertFalse(NODE.instanceOf(ERROR));
+
+    assertTrue(ERROR_ZO.instanceOf(EMPTY_SEQUENCE_Z));
+    assertTrue(ERROR_ZO.instanceOf(STRING_ZO));
+    assertTrue(ERROR_ZO.instanceOf(STRING_ZM));
+    assertFalse(ERROR_ZO.instanceOf(STRING_O));
+    assertFalse(ERROR_ZO.instanceOf(STRING_OM));
+    assertFalse(ERROR_ZO.instanceOf(ERROR_O));
+    assertTrue(ERROR_ZM.instanceOf(EMPTY_SEQUENCE_Z));
+    assertTrue(ERROR_ZM.instanceOf(STRING_ZM));
+    assertFalse(ERROR_ZM.instanceOf(STRING_O));
+    assertTrue(ERROR_O.instanceOf(ERROR_ZO));
+    assertTrue(ERROR_O.instanceOf(ERROR_OM));
+    assertTrue(ERROR_OM.instanceOf(ERROR_O));
+    assertFalse(ERROR_ZO.instanceOf(ERROR_O));
+    assertTrue(EMPTY_SEQUENCE_Z.instanceOf(ERROR_ZO));
+    assertFalse(STRING_ZO.instanceOf(ERROR_ZO));
+    assertFalse(STRING_O.instanceOf(ERROR_ZO));
 
     // functions
     final SeqType f = FuncType.get(DECIMAL_ZO, BOOLEAN_O).seqType();
@@ -415,7 +463,6 @@ public final class SeqTypeTest {
     combine(NODE_O, op);
     combine(DATE_TIME_O, op);
     combine(DATE_TIME_STAMP_O, op);
-    combine(ERROR_O, op);
 
     combine(STRING_O, INTEGER_O, ANY_ATOMIC_TYPE_O, op);
     combine(STRING_O, STRING_O, STRING_O, op);
@@ -424,7 +471,32 @@ public final class SeqTypeTest {
     combine(STRING_O, NORMALIZED_STRING.seqType(), STRING_O, op);
     combine(DATE_TIME_STAMP_O, DATE_TIME_O, DATE_TIME_O, op);
     combine(DATE_TIME_O, DATE_TIME_STAMP_O, DATE_TIME_O, op);
+
+    combine(ERROR_O, op);
+    combine(ERROR_O, STRING_O, STRING_O, op);
+    combine(ERROR_O, STRING_ZO, STRING_ZO, op);
+    combine(ERROR_O, STRING_OM, STRING_OM, op);
+    combine(ERROR_O, STRING_ZM, STRING_ZM, op);
+    combine(ERROR_O, EMPTY_SEQUENCE_Z, ERROR_ZO, op);
+    combine(ERROR_OM, STRING_O, STRING_OM, op);
+    combine(ERROR_OM, STRING_ZO, STRING_ZM, op);
+    combine(ERROR_OM, STRING_OM, STRING_OM, op);
+    combine(ERROR_OM, STRING_ZM, STRING_ZM, op);
+    combine(ERROR_OM, EMPTY_SEQUENCE_Z, ERROR_ZM, op);
+    combine(ERROR_ZO, STRING_O, STRING_ZO, op);
+    combine(ERROR_ZO, STRING_ZO, STRING_ZO, op);
+    combine(ERROR_ZO, STRING_OM, STRING_ZM, op);
+    combine(ERROR_ZO, STRING_ZM, STRING_ZM, op);
+    combine(ERROR_ZO, EMPTY_SEQUENCE_Z, ERROR_ZO, op);
+    combine(ERROR_ZM, STRING_O, STRING_ZM, op);
+    combine(ERROR_ZM, STRING_ZO, STRING_ZM, op);
+    combine(ERROR_ZM, STRING_OM, STRING_ZM, op);
+    combine(ERROR_ZM, STRING_ZM, STRING_ZM, op);
+    combine(ERROR_ZM, EMPTY_SEQUENCE_Z, ERROR_ZM, op);
+    combine(ERROR_ZO, ERROR_O, ERROR_ZO, op);
     combine(ERROR_O, POSITIVE_INTEGER_O, POSITIVE_INTEGER_O, op);
+    combine(ERROR_O, NMTOKENS.seqType(), NMTOKENS.seqType(), op);
+    combine(ERROR_O, ERROR_OM, ERROR_OM, op);
 
     combine(ELEMENT_O, STRING_O, ITEM_O, op);
     combine(JNODE_O, GNODE_O, GNODE_O, op);
@@ -447,6 +519,7 @@ public final class SeqTypeTest {
     combine(ATTRIBUTE_O, ELEMENT_O, NODE_O, op);
     combine(ELEMENT_O, JNODE_O, GNODE_O, op);
     combine(ELEMENT_X_O, ATTRIBUTE_O, NODE_O, op);
+    combine(GNODE_O, ERROR_O, GNODE_O, op);
 
     combine(JNODE_XX_O, JNODE_XX_O, JNODE_XX_O, op);
     combine(JNODE_XX_O, JNODE_XI_O, JNODE_XX_O, op);
@@ -462,6 +535,7 @@ public final class SeqTypeTest {
     combine(MAP_O, ITEM_O, ITEM_O, op);
     combine(MAP_O, FUNCTION_O, FUNCTION_O, op);
     combine(MAP_O, ARRAY_O, FUNCTION_O, op);
+    combine(MAP_O, ERROR_O, MAP_O, op);
 
     // functions
     final SeqType
@@ -486,6 +560,7 @@ public final class SeqTypeTest {
 
     combine(f1, INTEGER_O, ITEM_O, op);
     combine(f1, FUNCTION_O, FUNCTION_O, op);
+    combine(f1, ERROR_O, f1, op);
     combine(f1, f2, f1, op);
     combine(f1, f3, FUNCTION_O, op);
     combine(f1, f4, FUNCTION_O, op);
@@ -513,7 +588,9 @@ public final class SeqTypeTest {
     combine(m4, op);
 
     combine(MAP_O, m1, MAP_O, op);
+    combine(MAP_O, ERROR_O, MAP_O, op);
     combine(m1, INTEGER_O, ITEM_O, op);
+    combine(m1, ERROR_O, m1, op);
     combine(m1, f1, f1, op);
     combine(m1, f2, f6, op);
     combine(m1, m2, m1, op);
@@ -536,7 +613,9 @@ public final class SeqTypeTest {
     combine(a4, op);
 
     combine(ARRAY_O, a1, ARRAY_O, op);
+    combine(ARRAY_O, ERROR_O, ARRAY_O, op);
     combine(a1, INTEGER_O, ITEM_O, op);
+    combine(a1, ERROR_O, a1, op);
     combine(a1, a2, a2, op);
     combine(a1, a3, a1, op);
     combine(a1, f1, FUNCTION_O, op);
@@ -558,6 +637,7 @@ public final class SeqTypeTest {
     combine(e1, STRING_O, STRING_O, op);
     combine(e1, LANGUAGE_O, STRING_O, op);
     combine(e1, INTEGER_O, ANY_ATOMIC_TYPE_O, op);
+    combine(e1, ERROR_O, e1, op);
 
     final SeqType
       // (xs:date | xs:string)
@@ -576,6 +656,7 @@ public final class SeqTypeTest {
     combine(c1, op);
     combine(c1, DATE_O, ANY_ATOMIC_TYPE_O, op);
     combine(c1, STRING_O, ANY_ATOMIC_TYPE_O, op);
+    combine(c1, ERROR_O, c1, op);
     combine(c2, op);
     combine(c2, ELEMENT_O, ITEM_O, op);
     combine(c2, STRING_O, ITEM_O, op);
@@ -659,11 +740,15 @@ public final class SeqTypeTest {
     combine(RECORD_O, FUNCTION_O, FUNCTION_O, op);
     combine(RECORD_O, MAP_O, MAP_O, op);
     combine(RECORD_O, r1, r5, op);
+    combine(RECORD_O, ERROR_O, RECORD_O, op);
     combine(FUNCTION_O, r1, FUNCTION_O, op);
+    combine(FUNCTION_O, ERROR_O, FUNCTION_O, op);
     combine(MAP_O, r1, MAP_O, op);
+    combine(MAP_O, ERROR_O, MAP_O, op);
     combine(r1, r2, r3, op);
     combine(r1, r3, r3, op);
     combine(r1, r1, r1, op);
+    combine(r1, ERROR_O, r1, op);
     combine(r5, r1, r5, op);
     combine(r1, r6, r7, op);
     combine(r2, r6, r11, op);
@@ -689,7 +774,33 @@ public final class SeqTypeTest {
     combine(NODE_O, op);
     combine(DATE_TIME_O, op);
     combine(DATE_TIME_STAMP_O, op);
-    combine(ERROR_O, ITEM_O, ITEM_O, op);
+
+    combine(ERROR_O, ITEM_O, ERROR_O, op);
+    combine(ERROR_O, POSITIVE_INTEGER_O, ERROR_O, op);
+    combine(ERROR_O, STRING_O, ERROR_O, op);
+    combine(ERROR_O, STRING_ZO, ERROR_O, op);
+    combine(ERROR_O, STRING_OM, ERROR_O, op);
+    combine(ERROR_O, STRING_ZM, ERROR_O, op);
+    combine(ERROR_O, EMPTY_SEQUENCE_Z, ERROR_O, op);
+    combine(ERROR_OM, STRING_O, ERROR_OM, op);
+    combine(ERROR_OM, STRING_ZO, ERROR_OM, op);
+    combine(ERROR_OM, STRING_OM, ERROR_OM, op);
+    combine(ERROR_OM, STRING_ZM, ERROR_OM, op);
+    combine(ERROR_OM, EMPTY_SEQUENCE_Z, ERROR_OM, op);
+    combine(ERROR_ZO, STRING_O, ERROR_O, op);
+    combine(ERROR_ZO, STRING_ZO, ERROR_ZO, op);
+    combine(ERROR_ZO, STRING_OM, ERROR_O, op);
+    combine(ERROR_ZO, STRING_ZM, ERROR_ZO, op);
+    combine(ERROR_ZO, EMPTY_SEQUENCE_Z, EMPTY_SEQUENCE_Z, op);
+    combine(ERROR_ZM, STRING_O, ERROR_O, op);
+    combine(ERROR_ZM, STRING_ZO, ERROR_ZO, op);
+    combine(ERROR_ZM, STRING_OM, ERROR_OM, op);
+    combine(ERROR_ZM, STRING_ZM, ERROR_ZM, op);
+    combine(ERROR_ZM, EMPTY_SEQUENCE_Z, EMPTY_SEQUENCE_Z, op);
+    combine(ERROR_ZO, ERROR_O, ERROR_O, op);
+    combine(ERROR_O, ARRAY_O, ERROR_O, op);
+    combine(ERROR_O, NMTOKENS.seqType(), ERROR_O, op);
+    combine(ERROR_O, ERROR_OM, ERROR_O, op);
 
     combine(DATE_TIME_O, DATE_TIME_STAMP_O, DATE_TIME_STAMP_O, op);
     combine(DATE_TIME_STAMP_O, DATE_TIME_O, DATE_TIME_STAMP_O, op);
@@ -717,6 +828,7 @@ public final class SeqTypeTest {
     combine(ATTRIBUTE_O, ELEMENT_O, null, op);
     combine(ELEMENT_O, JNODE_O, null, op);
     combine(ELEMENT_X_O, ATTRIBUTE_O, null, op);
+    combine(GNODE_O, ERROR_O, ERROR_O, op);
 
     combine(JNODE_XX_O, JNODE_XX_O, JNODE_XX_O, op);
     combine(JNODE_XX_O, JNODE_XI_O, JNODE_XI_O, op);
@@ -760,6 +872,7 @@ public final class SeqTypeTest {
 
     combine(NODE_O, INTEGER_O, null, op);
     combine(f1, INTEGER_O, null, op);
+    combine(f1, ERROR_O, ERROR_O, op);
     combine(f1, f1, f1, op);
     combine(f1, f2, f2, op);
     combine(f1, f5, f5, op);
@@ -785,6 +898,7 @@ public final class SeqTypeTest {
     combine(m1, f1, m1, op);
     combine(m1, ITEM_O, m1, op);
     combine(m1, INTEGER_O, null, op);
+    combine(m1, ERROR_O, ERROR_O, op);
     combine(m1, m2, m2, op);
     combine(m2, MapType.get(BOOLEAN, BOOLEAN_O).seqType(), null, op);
     combine(m1, FUNCTION_O, m1, op);
@@ -839,6 +953,7 @@ public final class SeqTypeTest {
     combine(e1, STRING_O, e1, op);
     combine(e1, LANGUAGE_O, null, op);
     combine(e1, INTEGER_O, null, op);
+    combine(e1, ERROR_O, ERROR_O, op);
 
     final SeqType
       // (xs:date | xs:string)
@@ -859,6 +974,7 @@ public final class SeqTypeTest {
     combine(c1, STRING_O, STRING_O, op);
     combine(c1, INTEGER_O, null, op);
     combine(c1, ITEM_O, c1, op);
+    combine(c1, ERROR_O, ERROR_O, op);
     combine(c2, op);
     combine(c2, ELEMENT_O, ELEMENT_O, op);
     combine(c2, STRING_O, STRING_O, op);
@@ -941,11 +1057,15 @@ public final class SeqTypeTest {
     combine(RECORD_O, FUNCTION_O, RECORD_O, op);
     combine(RECORD_O, MAP_O, RECORD_O, op);
     combine(RECORD_O, r1, null, op);
+    combine(RECORD_O, ERROR_O, ERROR_O, op);
     combine(FUNCTION_O, r1, r1, op);
+    combine(FUNCTION_O, ERROR_O, ERROR_O, op);
     combine(MAP_O, r1, r1, op);
+    combine(MAP_O, ERROR_O, ERROR_O, op);
     combine(r1, r2, null, op);
     combine(r1, r3, r1, op);
     combine(r1, r1, r1, op);
+    combine(r1, ERROR_O, ERROR_O, op);
     combine(r5, r1, r1, op);
     combine(r1, r6, null, op);
     combine(r2, r6, null, op);

--- a/basex-core/src/test/java/org/basex/query/expr/XQuery4Test.java
+++ b/basex-core/src/test/java/org/basex/query/expr/XQuery4Test.java
@@ -878,4 +878,54 @@ public final class XQuery4Test extends SandboxTest {
     check("(substring-before(?, 'b'), substring-before(?, 'c'))('abc')", "a\nab",
         root(StrSeq.class));
   }
+
+  /** Tests involving type xs:error. */
+  @Test public void xsError() {
+    error("23 ! xs:error()", FUNCCAST_X_X);
+    error("xs:error(23)", FUNCCAST_X_X);
+    error("23 cast as xs:error", FUNCCAST_X_X);
+    error("23 cast as xs:error?", FUNCCAST_X_X);
+    error("() cast as xs:error", INVTYPE_X);
+    error("(1, 2) cast as xs:error", INVTYPE_X);
+    error("(1, 2) cast as xs:error?", INVTYPE_X);
+    query("xs:error(())", "");
+    query("() cast as xs:error?", "");
+    query("23 instance of xs:error", false);
+    query("23 castable as xs:error", false);
+
+    // xs:error? (empty category) and xs:error (void category) as function return types
+    query("xs:error#1 instance of function(xs:anyAtomicType?) as empty-sequence()", true);
+    query("xs:error#1 instance of function(xs:anyAtomicType?) as xs:error?", true);
+    query("xs:error#1 instance of function(xs:anyAtomicType?) as xs:string", false);
+    query("fn() as xs:error { error() } instance of function() as empty-sequence()", true);
+
+    // coercion to xs:error (function conversion, type declarations) is a type error, not a cast
+    error("declare function local:f($a as xs:error) { $a }; local:f(1)", INVTYPE_X);
+    error("fn($a as xs:error) { $a }(1)", INVTYPE_X);
+    error("fn($a as xs:error) { $a }(xs:untypedAtomic('x'))", INVTYPE_X);
+    error("let $x as xs:error := 1 return $x", INVTYPE_X);
+
+    query("fn:error(code := ?, description := ?, value := ?) instance of function(xs:QName?, xs:str"
+        + "ing?, item()*) as xs:error", true);
+
+    // error() is void: optimizations must not discard it without evaluating it
+    error("exactly-one((true(), error()))", FUNERR1);
+    error("zero-or-one((true(), error()))", FUNERR1);
+    error("remove(error(), 1)", FUNERR1);
+    error("tail(error())", FUNERR1);
+    error("trunk(error())", FUNERR1);
+    error("error() castable as xs:error", FUNERR1);
+    error("declare function local:f() as empty-sequence() { error() }; local:f()", FUNERR1);
+
+    // functions whose result depends on the value or cardinality of error() must evaluate it
+    error("empty(error())", FUNERR1);
+    error("exists(error())", FUNERR1);
+    error("count(error())", FUNERR1);
+    error("boolean(error())", FUNERR1);
+    error("sum(error())", FUNERR1);
+    error("head(error())", FUNERR1);
+    error("reverse(error())", FUNERR1);
+    error("string(error())", FUNERR1);
+    error("duplicate-values(error())", FUNERR1);
+  }
 }


### PR DESCRIPTION
This PR implements the updated XQuery 4.0 semantics for `xs:error`:

- treat `xs:error` as a subtype of every item type 
- distinguish void sequence types (`xs:error`, `xs:error+`) from empty sequence types (`empty-sequence()`, `xs:error?`, `xs:error*`)
- make union, intersection, and instance-of consistent for `xs:error` across all item-type kinds (choice, enum, list, array, map, function, record, node)
- set the `fn:error` return type to `xs:error`
- preserve dynamic errors instead of optimizing them away in casts and castability checks, type checks and function coercion
- stop size-based optimizations from treating a void expression as a known singleton result

All QT4 tests for `xs:error` and `fn:error` now pass. Regression tests were added in `SeqTypeTest` and `XQuery4Test.xsError`.