### PR TITLE
Fix syntax error for `URIQualifiedName` followed by a colon

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -4395,16 +4395,20 @@ public class QueryParser extends InputParser {
    */
   private QNm eQName(final byte[] ns, final QueryError error) throws QueryException {
     // parse URIQualifiedName
-    final int p = pos;
+    int p = pos;
     if(consume("Q{")) {
       final byte[] uri = bracedURILiteral(), name1 = ncName(null, true);
       if(name1.length != 0) {
-        if(!consume(':')) return new QNm(name1, uri);
-        final byte[] name2 = ncName(null, true);
-        if(name2.length != 0) {
-          if(uri.length == 0) throw error(PREFIXNOURI_X, name2);
-          return new QNm(name1, name2, uri);
+        p = pos;
+        if(consume(':')) {
+          final byte[] name2 = ncName(null, true);
+          if(name2.length != 0) {
+            if(uri.length == 0) throw error(PREFIXNOURI_X, name2);
+            return new QNm(name1, name2, uri);
+          }
+          pos = p;
         }
+        return new QNm(name1, uri);
       }
       pos = p;
     }

--- a/basex-core/src/test/java/org/basex/query/expr/XQuery4Test.java
+++ b/basex-core/src/test/java/org/basex/query/expr/XQuery4Test.java
@@ -841,6 +841,19 @@ public final class XQuery4Test extends SandboxTest {
       ["1",("2","3","4","5","6"),3]""");
   }
 
+  /** EQNames: optional prefix syntax (qtspecs#2227) must not swallow a following ":=". */
+  @Test public void eqName() {
+    query("let $Q{}foo := 1 return $Q{}foo", 1);
+    query("let $Q{u}foo := 1 return $Q{u}foo", 1);
+
+    // optional prefix in EQName syntax (Q{uri}prefix:local) must still be parsed
+    query("Q{http://www.w3.org/2005/xpath-functions}fn:abs(-1)", 1);
+    query("1 instance of Q{http://www.w3.org/2001/XMLSchema}xs:integer", true);
+
+    // gh-2701: URIQualifiedName variable directly followed by ":=" (no intervening whitespace)
+    query("let $Q{}foo:=1 return $Q{}foo", 1);
+  }
+
   /** Calls of dynamic function sequences. */
   @Test public void dynamicFunctionSequences() {
     // empty sequences


### PR DESCRIPTION
As reported by [Andrew Sales on basex-talk](https://mailman.uni-konstanz.de/mailman3/hyperkitty/list/basex-talk@mailman.uni-konstanz.de/thread/CCRX3IDP7HJAJGLMTQ4QYPL7BWNQV2MY/), a `URIQualifiedName` without the optional prefix raised a syntax error when immediately followed by a colon (e.g. the `:=` operator) with no intervening whitespace, as in:
```xquery
let $Q{}foo:=1 return $Q{}foo
```
When parsing an `EQName`, `QueryParser.eQName` speculatively consumes a `:` to check for the optional-prefix form `Q{uri}prefix:local` (qtspecs#2227). When no valid local name follows, the colon was not given back, so the surrounding `:=` could no longer be recognized. The parser now restores its position in that case.