### PR TITLE
Fix JSON `duplicates` option handling

### DIFF
--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonAttsConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonAttsConverter.java
@@ -26,18 +26,17 @@ public final class JsonAttsConverter extends JsonXmlConverter {
 
   @Override
   protected void openObject() {
-    openOuter(OBJECT);
+    if(!skipOpen()) openOuter(OBJECT);
   }
 
   @Override
   protected void closeObject() {
-    closeOuter();
+    if(!skipClose()) closeOuter();
   }
 
   @Override
   protected void openPair(final byte[] key, final boolean add) {
-    addValues.add(add);
-    if(add) {
+    if(!skipPair(add)) {
       openInner(Q_PAIR);
       name = shared.token(key);
       curr.attr(Q_NAME, name);
@@ -46,36 +45,35 @@ public final class JsonAttsConverter extends JsonXmlConverter {
 
   @Override
   protected void closePair(final boolean add) {
-    if(add) {
+    if(!skipClose() && add) {
       closeInner();
       name = null;
     }
-    addValues.pop();
   }
 
   @Override
   protected void openArray() {
-    openOuter(ARRAY);
+    if(!skipOpen()) openOuter(ARRAY);
   }
 
   @Override
   protected void closeArray() {
-    closeOuter();
+    if(!skipClose()) closeOuter();
   }
 
   @Override
   protected void openItem() {
-    openInner(Q_ITEM);
+    if(!skip()) openInner(Q_ITEM);
   }
 
   @Override
   protected void closeItem() {
-    closeInner();
+    if(!skip()) closeInner();
   }
 
   @Override
   void addValue(final byte[] type, final byte[] value) {
-    if(addValues.peek()) element(type).text(value != null ? shared.token(value) : null);
+    if(!skip()) element(type).text(value != null ? shared.token(value) : null);
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonConverter.java
@@ -60,6 +60,17 @@ public abstract class JsonConverter extends Job {
   }
 
   /**
+   * Raises an error for an option value that is not supported by the target format.
+   * @param name option name
+   * @param value option value
+   * @return query exception
+   */
+  protected static QueryException optionError(final String name, final Object value) {
+    return QueryError.OPTION_JSON_X.get(null,
+        Util.info("'%':'%' is not supported by the target format.", name, value));
+  }
+
+  /**
    * Assigns a fallback function for invalid characters.
    * @param func fallback function
    */

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonDirectConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonDirectConverter.java
@@ -65,33 +65,32 @@ public final class JsonDirectConverter extends JsonXmlConverter {
 
   @Override
   protected void openObject() {
-    openOuter(OBJECT);
+    if(!skipOpen()) openOuter(OBJECT);
   }
 
   @Override
   protected void closeObject() {
-    closeOuter();
+    if(!skipClose()) closeOuter();
   }
 
   @Override
   protected void openPair(final byte[] key, final boolean add) {
-    addValues.add(add);
-    if(add) name = shared.token(XMLToken.encode(key, lax));
+    if(!skipPair(add)) name = shared.token(XMLToken.encode(key, lax));
   }
 
   @Override
   protected void closePair(final boolean add) {
-    addValues.pop();
+    skipClose();
   }
 
   @Override
   protected void openArray() {
-    openOuter(ARRAY);
+    if(!skipOpen()) openOuter(ARRAY);
   }
 
   @Override
   protected void closeArray() {
-    closeOuter();
+    if(!skipClose()) closeOuter();
   }
 
   @Override
@@ -104,7 +103,7 @@ public final class JsonDirectConverter extends JsonXmlConverter {
 
   @Override
   void addValue(final byte[] type, final byte[] value) {
-    if(addValues.peek()) {
+    if(!skip()) {
       final byte[] val = value != null ? shared.token(value) : null;
       final FBuilder elem = element(type).text(val);
       if(curr != null) curr.node(elem);

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonW3Converter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonW3Converter.java
@@ -59,7 +59,7 @@ public final class JsonW3Converter extends JsonConverter {
     fmt = jopts.get(JsonParserOptions.NUMBER_FORMAT);
     final JsonDuplicates dupl = jopts.get(JsonParserOptions.DUPLICATES);
     if(dupl == JsonDuplicates.RETAIN) {
-      throw OPTION_JSON_X.get(null, JsonParserOptions.DUPLICATES.name(), dupl);
+      throw optionError(JsonParserOptions.DUPLICATES.name(), dupl);
     }
   }
 

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonW3XmlConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonW3XmlConverter.java
@@ -29,33 +29,32 @@ public final class JsonW3XmlConverter extends JsonXmlConverter {
 
   @Override
   protected void openObject() {
-    openOuter(MAP);
+    if(!skipOpen()) openOuter(MAP);
   }
 
   @Override
   protected void closeObject() {
-    closeOuter();
+    if(!skipClose()) closeOuter();
   }
 
   @Override
   protected void openPair(final byte[] key, final boolean add) {
-    addValues.add(add);
-    if(add) name = shared.token(key);
+    if(!skipPair(add)) name = shared.token(key);
   }
 
   @Override
   protected void closePair(final boolean add) {
-    addValues.pop();
+    skipClose();
   }
 
   @Override
   protected void openArray() {
-    openOuter(ARRAY);
+    if(!skipOpen()) openOuter(ARRAY);
   }
 
   @Override
   protected void closeArray() {
-    closeOuter();
+    if(!skipClose()) closeOuter();
   }
 
   @Override
@@ -66,7 +65,7 @@ public final class JsonW3XmlConverter extends JsonXmlConverter {
 
   @Override
   void addValue(final byte[] type, final byte[] value) {
-    if(addValues.peek()) {
+    if(!skip()) {
       final byte[] val = value != null ? shared.token(value) : null;
       final FBuilder elem = element(type).text(val);
       if(escape && value != null && contains(val, '\\')) elem.attr(Q_ESCAPED, TRUE);

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonXmlConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonXmlConverter.java
@@ -1,7 +1,6 @@
 package org.basex.io.parse.json;
 
 import static org.basex.io.parse.json.JsonConstants.*;
-import static org.basex.query.QueryError.*;
 import static org.basex.util.Token.*;
 
 import java.util.*;
@@ -38,8 +37,8 @@ abstract class JsonXmlConverter extends JsonConverter {
 
   /** Stack for intermediate nodes. */
   final Stack<FBuilder> stack = new Stack<>();
-  /** Add value pairs. */
-  final BoolList addValues = new BoolList();
+  /** Nesting depth of a suppressed duplicate value (0: nothing suppressed). */
+  private int skipDepth;
 
   /** Map from element name to a pair of all its nodes and the collective node type. */
   private final TokenObjectMap<TypeCache> names = new TokenObjectMap<>();
@@ -64,11 +63,10 @@ abstract class JsonXmlConverter extends JsonConverter {
     super(opts);
     merge = jopts.get(JsonOptions.MERGE);
     strings = jopts.get(JsonOptions.STRINGS);
-    addValues.add(true);
 
     final JsonDuplicates dupl = jopts.get(JsonParserOptions.DUPLICATES);
     if(dupl == JsonDuplicates.USE_LAST) {
-      throw OPTION_JSON_X.get(null, JsonParserOptions.DUPLICATES.name(), dupl);
+      throw optionError(JsonParserOptions.DUPLICATES.name(), dupl);
     }
   }
 
@@ -129,6 +127,50 @@ abstract class JsonXmlConverter extends JsonConverter {
    * @throws QueryException query exception
    */
   abstract void addValue(byte[] type, byte[] value) throws QueryException;
+
+  /**
+   * Registers an opening object or array.
+   * @return {@code true} if the event belongs to a suppressed duplicate and must be ignored
+   */
+  final boolean skipOpen() {
+    if(skipDepth == 0) return false;
+    skipDepth++;
+    return true;
+  }
+
+  /**
+   * Registers a closing object, array or pair.
+   * @return {@code true} if the event belongs to a suppressed duplicate and must be ignored
+   */
+  final boolean skipClose() {
+    if(skipDepth == 0) return false;
+    skipDepth--;
+    return true;
+  }
+
+  /**
+   * Registers an opening pair. A pair that is not added (suppressed duplicate, 'use-first')
+   * starts skipping its entire value, including nested objects and arrays.
+   * @param add add pair
+   * @return {@code true} if the pair and its value are suppressed and must be ignored
+   */
+  final boolean skipPair(final boolean add) {
+    if(skipDepth > 0) {
+      skipDepth++;
+      return true;
+    }
+    if(add) return false;
+    skipDepth = 1;
+    return true;
+  }
+
+  /**
+   * Indicates if the current value is part of a suppressed duplicate.
+   * @return result of check
+   */
+  final boolean skip() {
+    return skipDepth > 0;
+  }
 
   /**
    * Adds type information to an element or the type cache.

--- a/basex-core/src/main/java/org/basex/query/QueryError.java
+++ b/basex-core/src/main/java/org/basex/query/QueryError.java
@@ -346,7 +346,7 @@ public enum QueryError {
   /** Error code. */
   JSON_SERIALIZE_X(JSON, "serialize", "%."),
   /** Error code. */
-  JSON_OPTIONS_X(JSON, "options", "'%':'%' is not supported by the target format."),
+  JSON_OPTIONS_X(JSON, "options", "%"),
 
   // Process Module
 
@@ -669,7 +669,7 @@ public enum QueryError {
   /** Error code. */
   PARSE_JSON_X_X_X(FOJS, 1, "(%:%): %."),
   /** Error code. */
-  DUPLICATE_JSON_X(FOJS, 3, "%"),
+  DUPLICATE_JSON_X(FOJS, 3, "(%:%): %."),
   /** Error code. */
   MERGE_DUPLICATE_X(FOJS, 3, "Key % occurs more than once."),
   /** Error code. */

--- a/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/FnModuleTest.java
@@ -2084,6 +2084,23 @@ return
     final Function func = JSON_TO_XML;
     contains(func.args("null"), "xmlns");
     contains(func.args("null") + " update {}", "xmlns");
+
+    // duplicates: reject errors, use-first keeps the first, use-last is unsupported,
+    // retain (the default for this format) keeps both
+    final String dup = "{\"x\":1,\"x\":2}", ns = "http://www.w3.org/2005/xpath-functions";
+    error(func.args(dup, " { 'duplicates': 'reject' }"), DUPLICATE_JSON_X);
+    query("try { " + func.args(dup, " { 'duplicates': 'reject' }") +
+        " } catch * { $err:description }", "(1:11): Key \"x\" occurs more than once.");
+    query(func.args(dup, " { 'duplicates': 'use-first' }"),
+        "<map xmlns=\"" + ns + "\"><number key=\"x\">1</number></map>");
+    error(func.args(dup, " { 'duplicates': 'use-last' }"), OPTION_JSON_X);
+    query("try { " + func.args(dup, " { 'duplicates': 'use-last' }") +
+        " } catch * { $err:description }",
+        "'duplicates':'use-last' is not supported by the target format.");
+    final String both = "<map xmlns=\"" + ns + "\"><number key=\"x\">1</number>" +
+        "<number key=\"x\">2</number></map>";
+    query(func.args(dup, " { 'duplicates': 'retain' }"), both);
+    query(func.args(dup), both);
   }
 
   /**
@@ -2924,6 +2941,20 @@ return
 
     error(func.args("1", " { 'number-parser': xs:decimal#1 }"), INVALIDOPTION_X);
     error(func.args("1e9999", " { 'number-format': 'decimal' }"), FUNCCAST_X_X);
+
+    // duplicates (maps): reject errors, use-first/use-last select a value, retain is unsupported,
+    // the default is use-first
+    final String dup = "{\"x\":1,\"x\":2}";
+    error(func.args(dup, " { 'duplicates': 'reject' }"), DUPLICATE_JSON_X);
+    query("try { " + func.args(dup, " { 'duplicates': 'reject' }") +
+        " } catch * { $err:description }", "(1:11): Key \"x\" occurs more than once.");
+    query(func.args(dup, " { 'duplicates': 'use-first' }"), "{\"x\":1}");
+    query(func.args(dup, " { 'duplicates': 'use-last' }"), "{\"x\":2}");
+    error(func.args(dup, " { 'duplicates': 'retain' }"), OPTION_JSON_X);
+    query("try { " + func.args(dup, " { 'duplicates': 'retain' }") +
+        " } catch * { $err:description }",
+        "'duplicates':'retain' is not supported by the target format.");
+    query(func.args(dup), "{\"x\":1}");
   }
 
   /** Test method. */

--- a/basex-core/src/test/java/org/basex/query/func/JsonModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/func/JsonModuleTest.java
@@ -83,6 +83,80 @@ public final class JsonModuleTest extends SandboxTest {
     parseError("{ \"a\" : 0, }", "'liberal': false()");
   }
 
+  /** Duplicate keys, 'use-first' policy: the suppressed value and its nested content is dropped. */
+  @Test public void parseDuplicates() {
+    final String first = "<json type=\"object\"><x type=\"number\">1</x></json>";
+    final String opt = "'duplicates': 'use-first'";
+    // scalar duplicate
+    parse("{ \"x\": 1, \"x\": 2 }", opt, first);
+    // object duplicate (and its nested pairs) must not leak through
+    parse("{ \"x\": 1, \"x\": { \"y\": 2 } }", opt, first);
+    // array duplicate (and its items) must not leak through
+    parse("{ \"x\": 1, \"x\": [ 1, 2 ] }", opt, first);
+    // deeply nested duplicate value
+    parse("{ \"x\": 1, \"x\": { \"y\": { \"z\": 2 } } }", opt, first);
+    // duplicate within the suppressed value
+    parse("{ \"x\": 1, \"x\": { \"y\": 1, \"y\": 2 } }", opt, first);
+    // a valid container sibling after a suppressed duplicate is still emitted
+    parse("{ \"x\": 1, \"x\": { \"y\": 2 }, \"z\": { \"w\": 3 } }", opt,
+        "<json type=\"object\"><x type=\"number\">1</x><z type=\"object\">" +
+        "<w type=\"number\">3</w></z></json>");
+
+    // same suppression for the 'attributes' format
+    final String attsOpt = opt + ", 'format': 'attributes'";
+    final String attsFirst =
+        "<json type=\"object\"><pair name=\"x\" type=\"number\">1</pair></json>";
+    parse("{ \"x\": 1, \"x\": { \"y\": 2 } }", attsOpt, attsFirst);
+    parse("{ \"x\": 1, \"x\": [ 1, 2 ] }", attsOpt, attsFirst);
+
+    // same suppression for the 'basic' (W3 XML) format, as used by fn:json-to-xml
+    final String basicOpt = opt + ", 'format': 'basic'";
+    final String basicFirst = "<map xmlns=\"http://www.w3.org/2005/xpath-functions\">" +
+        "<number key=\"x\">1</number></map>";
+    parse("{ \"x\": 1, \"x\": { \"y\": 2 } }", basicOpt, basicFirst);
+    parse("{ \"x\": 1, \"x\": [ 1, 2 ] }", basicOpt, basicFirst);
+  }
+
+  /** Coverage for every value of the 'duplicates' option and its per-format defaults. */
+  @Test public void parseDuplicatesPolicies() {
+    final Function func = _JSON_PARSE;
+    final String in = "{ \"x\": 1, \"x\": 2 }";
+
+    // tree formats (direct): reject errors, use-first keeps the first, use-last is unsupported,
+    // retain keeps both; the default for non-W3 formats is 'use-first'
+    final String one = "<json type=\"object\"><x type=\"number\">1</x></json>";
+    final String two =
+        "<json type=\"object\"><x type=\"number\">1</x><x type=\"number\">2</x></json>";
+    error(func.args(in, " { 'duplicates': 'reject' }"), JSON_PARSE_X);
+    query(func.args(in, " { 'duplicates': 'use-first' }"), one);
+    error(func.args(in, " { 'duplicates': 'use-last' }"), JSON_OPTIONS_X);
+    query(func.args(in, " { 'duplicates': 'retain' }"), two);
+    query(func.args(in), one);
+
+    // xquery format (maps): reject errors, use-first/use-last select a value, retain is unsupported
+    error(func.args(in, " { 'format': 'xquery', 'duplicates': 'reject' }"), JSON_PARSE_X);
+    query(func.args(in, " { 'format': 'xquery', 'duplicates': 'use-first' }"), "{\"x\":1}");
+    query(func.args(in, " { 'format': 'xquery', 'duplicates': 'use-last' }"), "{\"x\":2}");
+    error(func.args(in, " { 'format': 'xquery', 'duplicates': 'retain' }"), JSON_OPTIONS_X);
+
+    // W3 XML format (basic): the default is 'retain' (both kept), use-last is unsupported
+    query(func.args(in, " { 'format': 'basic' }"), "<map xmlns=\"http://www.w3.org/2005/" +
+        "xpath-functions\"><number key=\"x\">1</number><number key=\"x\">2</number></map>");
+    error(func.args(in, " { 'format': 'basic', 'duplicates': 'use-last' }"), JSON_OPTIONS_X);
+
+    // jsonml rejects duplicate object keys regardless of the chosen policy
+    error(func.args("[ \"a\", { \"b\": \"1\", \"b\": \"2\" } ]",
+        " { 'format': 'jsonml', 'duplicates': 'retain' }"), JSON_PARSE_X);
+
+    // the wrapped json:* error messages must stay intact (no truncation to '1' or 'duplicates')
+    final String dup = "{\"x\":1,\"x\":2}";
+    query("try { " + func.args(dup, " { 'duplicates': 'reject' }") +
+        " } catch * { $err:description }", "(1:11): Key \"x\" occurs more than once.");
+    query("try { " + func.args(dup, " { 'duplicates': 'use-last' }") +
+        " } catch * { $err:description }",
+        "'duplicates':'use-last' is not supported by the target format.");
+  }
+
   /** Test method. */
   @Test public void parseJsonML() {
     parse("[ \"a\" ]", "'format': 'jsonml'", "<a/>");
@@ -153,6 +227,13 @@ public final class JsonModuleTest extends SandboxTest {
         "9\n10");
 
     error(func.args("42", " { 'spec': 'garbage' }"), INVALIDOPTION_X);
+
+    // escape cannot be combined with a fallback function; the json:options message must pass
+    // through the wrapping intact (regression for the JSON_OPTIONS_X template)
+    final String escFb = " { 'escape': true(), 'fallback': fn($s) { $s } }";
+    error(func.args("\"x\"", escFb), JSON_OPTIONS_X);
+    query("try { " + func.args("\"x\"", escFb) + " } catch * { $err:description }",
+        "Escape cannot be combined with fallback function.");
   }
 
   /** Test method. */


### PR DESCRIPTION
Some work on #2655 revealed JSON parser/converter bugs - fixing them first helps move #2655 forward.

  - `'duplicates': 'use-first'` did not skip nested objects/arrays in a suppressed duplicate value, so content from the second value could leak into the result. Affected formats: `direct`, `attributes`, `w3-xml`. `w3`/`xquery` and  `jsonml` were not affected.
  - The duplicate-key error (`FOJS0003`) reported a bare `1` instead of `(1:11): Key "x" occurs more than once.`
  - The unsupported option-value error (`FOJS0005`, e.g. `use-last`/`retain`) reported a bare `duplicates` instead of the full message. The same root cause also mangled the `json:parse` `escape` + `fallback` message.

The fixes affect `fn:parse-json`, `fn:json-to-xml`, and `json:parse`, and are covered by tests in `JsonModuleTest` and `FnModuleTest`, including message-text regressions.