### PR TITLE
[MOD] Type declarations: Circular dependencies. Closes #2635

### DIFF
--- a/basex-core/src/main/java/org/basex/query/QueryContext.java
+++ b/basex-core/src/main/java/org/basex/query/QueryContext.java
@@ -129,6 +129,11 @@ public final class QueryContext extends Job implements Closeable {
   /** Stack of module files that are currently parsed. */
   public final TokenList modStack = new TokenList();
 
+  /** Public record types of all parsed modules (for resolving cross-module references). */
+  public final QNmMap<RecordType> namedRecordTypes = new QNmMap<>();
+  /** Record references that could not be resolved within their module (resolved after parsing). */
+  public final ArrayList<RecordType> deferredTypeRefs = new ArrayList<>();
+
   /** Main module (root expression). */
   public MainModule main;
   /** Context value type. */

--- a/basex-core/src/main/java/org/basex/query/QueryParser.java
+++ b/basex-core/src/main/java/org/basex/query/QueryParser.java
@@ -262,7 +262,7 @@ public class QueryParser extends InputParser {
     // completes the parsing step
     qnames.resolve(this, 0, sc.elemNS);
     if(sc.elemNS != null) sc.ns.add(EMPTY, sc.elemNS, null);
-    RecordType.resolveRefs(recordTypeRefs, namedRecordTypes);
+    RecordType.resolve(namedRecordTypes, recordTypeRefs, qc.deferredTypeRefs);
   }
 
   /**
@@ -271,6 +271,8 @@ public class QueryParser extends InputParser {
    * @throws QueryException query exception
    */
   private void check(final MainModule main) throws QueryException {
+    // resolve record references
+    RecordType.resolveDeferred(qc.namedRecordTypes, qc.deferredTypeRefs);
     // resolve function calls
     qc.functions.resolve();
     // resolve variable references
@@ -1014,6 +1016,7 @@ public class QueryParser extends InputParser {
     if(!anns.contains(Annotation.PRIVATE)) {
       if(sc.module != null && !eq(qn.uri(), sc.module.uri())) throw error(MODULENS_X, qn);
       publicTypes.put(qn, rt.seqType());
+      qc.namedRecordTypes.put(qn, rt);
     }
     if(qn.uri().length != 0) declareRecordConstructor(rt, ii);
   }

--- a/basex-core/src/main/java/org/basex/query/value/type/RecordType.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/RecordType.java
@@ -465,21 +465,50 @@ public final class RecordType extends MapType {
   }
 
   /**
-   * Resolve named record references with named record declarations. Throw "unknown type" when a
-   * reference cannot be resolved.
-   * @param recordTypeRefs record type references
-   * @param declaredRecordTypes record type declarations
+   * Resolves named record references with named record declarations. References that cannot be
+   * resolved are added to the list of deferred references.
+   * @param types record types
+   * @param referenced record type references
+   * @param deferred deferred references
+   */
+  public static void resolve(final QNmMap<RecordType> types,
+      final QNmMap<RecordType> referenced, final ArrayList<RecordType> deferred) {
+    for(final QNm name : referenced) {
+      final RecordType ref = referenced.get(name);
+      RecordType dec = types.get(name);
+      if(dec == null) dec = Records.BUILT_IN.get(name);
+      if(dec != null) ref.resolve(dec);
+      else deferred.add(ref);
+    }
+  }
+
+  /**
+   * Resolves the references that were deferred during parsing, against the public record types of
+   * all parsed modules.
+   * @param types record types
+   * @param deferred deferred references
    * @throws QueryException query exception
    */
-  public static void resolveRefs(final QNmMap<RecordType> recordTypeRefs,
-      final QNmMap<RecordType> declaredRecordTypes) throws QueryException {
-    for(final QNm name : recordTypeRefs) {
-      final RecordType ref = recordTypeRefs.get(name);
-      final RecordType dec = ref.getDeclaration(declaredRecordTypes);
-      ref.fields = dec.fields;
-      ref.info = null;
-      ref.finalizeTypes(dec.keyType(), dec.valueType());
+  public static void resolveDeferred(final QNmMap<RecordType> types,
+      final ArrayList<RecordType> deferred) throws QueryException {
+    for(final RecordType ref : deferred) {
+      if(ref.info == null) continue;
+      RecordType dec = types.get(ref.name);
+      if(dec == null) dec = Records.BUILT_IN.get(ref.name);
+      if(dec == null) throw TYPEUNKNOWN_X.get(ref.info, BasicType.similar(ref.name));
+      ref.resolve(dec);
     }
+    deferred.clear();
+  }
+
+  /**
+   * Resolves this unresolved reference to the specified record type declaration (in-place).
+   * @param dec record type declaration
+   */
+  private void resolve(final RecordType dec) {
+    fields = dec.fields;
+    info = null;
+    finalizeTypes(dec.keyType(), dec.valueType());
   }
 
   /**

--- a/basex-core/src/test/java/org/basex/query/ModuleTest.java
+++ b/basex-core/src/test/java/org/basex/query/ModuleTest.java
@@ -276,4 +276,36 @@ public final class ModuleTest extends SandboxTest {
         + "import module namespace b = 'B' at '" + b.path() + "';\n"
         + "exists(a:lookup())", true);
   }
+
+  /** Tests circular type dependencies across modules. */
+  @Test public void gh2635() {
+    final IOFile sandbox = sandbox();
+    final IOFile a = new IOFile(sandbox, "a.xqm");
+    final IOFile b = new IOFile(sandbox, "b.xqm");
+    // module a imports b and declares a record type;
+    // module b imports a and refers to a's record type (circular dependency)
+    write(a, "module namespace a = 'A';\n"
+        + "import module namespace b = 'B' at 'b.xqm';\n"
+        + "declare record a:rec(x as xs:integer);");
+    write(b, "module namespace b = 'B';\n"
+        + "import module namespace a = 'A' at 'a.xqm';\n"
+        + "declare type b:alias as a:rec;\n"
+        + "declare record b:wrap(inner as a:rec, label as xs:string);\n"
+        + "declare function b:make($n as xs:integer) as b:alias { a:rec($n) };\n"
+        + "declare function b:value($r as b:alias) as xs:integer { $r?x };");
+
+    // type alias referring to a record in a circularly imported module
+    // (raised [XPST0051] Unknown type: Q{A}rec before the fix)
+    query("import module namespace b = 'B' at '" + b.path() + "';\n"
+        + "b:value(b:make(42))", 42);
+
+    // record field whose type lives in a circularly imported module
+    query("import module namespace b = 'B' at '" + b.path() + "';\n"
+        + "b:wrap(b:make(7), 'l')?inner?x", 7);
+
+    // the circular type resolves consistently regardless of import order
+    query("import module namespace a = 'A' at '" + a.path() + "';\n"
+        + "import module namespace b = 'B' at '" + b.path() + "';\n"
+        + "b:make(1) instance of a:rec", true);
+  }
 }

--- a/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
+++ b/basex-core/src/test/java/org/basex/query/SeqTypeTest.java
@@ -7,6 +7,7 @@ import static org.basex.query.value.type.Occ.*;
 import static org.basex.query.value.type.Types.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.*;
 import java.util.function.*;
 
 import org.basex.query.expr.path.*;
@@ -138,9 +139,8 @@ public final class SeqTypeTest {
 
   /**
    * Tests for {@link SeqType#eq(SeqType)}.
-   * @throws QueryException query exception
    */
-  @Test public void eq() throws QueryException {
+  @Test public void eq() {
     final TokenObjectMap<RecordField> fld1 = new TokenObjectMap<>(),
         fld2 = new TokenObjectMap<>();
     final QNm r1Name = new QNm(Token.token("r1")),
@@ -164,7 +164,7 @@ public final class SeqTypeTest {
     recordTypeRefs.put(r2Name, (RecordType) r2.type);
     declaredRecordTypes.put(r1Name, new RecordType(fld1));
     declaredRecordTypes.put(r2Name, new RecordType(fld2));
-    RecordType.resolveRefs(recordTypeRefs, declaredRecordTypes);
+    RecordType.resolve(declaredRecordTypes, recordTypeRefs, new ArrayList<>());
 
     assertTrue(r1.eq(r2));
     assertTrue(r2.eq(r1));
@@ -187,9 +187,8 @@ public final class SeqTypeTest {
 
   /**
    * Tests for {@link SeqType#instanceOf(SeqType)}.
-   * @throws QueryException query exception
    */
-  @Test public void instanceOf() throws QueryException {
+  @Test public void instanceOf() {
     // atomic items
     assertTrue(BOOLEAN_O.instanceOf(ANY_ATOMIC_TYPE_ZM));
     assertFalse(ANY_ATOMIC_TYPE_ZM.instanceOf(BOOLEAN_O));
@@ -436,7 +435,7 @@ public final class SeqTypeTest {
     recordTypeRefs.put(r2Name, (RecordType) r2.type);
     declaredRecordTypes.put(r1Name, new RecordType(fld1));
     declaredRecordTypes.put(r2Name, new RecordType(fld2));
-    RecordType.resolveRefs(recordTypeRefs, declaredRecordTypes);
+    RecordType.resolve(declaredRecordTypes, recordTypeRefs, new ArrayList<>());
 
     assertTrue(RECORD_O.instanceOf(FUNCTION_O));
     assertFalse(MAP_O.instanceOf(RECORD_O));
@@ -447,9 +446,8 @@ public final class SeqTypeTest {
 
   /**
    * Tests for {@link SeqType#union(SeqType)}.
-   * @throws QueryException query exception
    */
-  @Test public void union() throws QueryException {
+  @Test public void union() {
     final BiFunction<SeqType, SeqType, SeqType> op = SeqType::union;
 
     combine(EMPTY_SEQUENCE_Z, op);
@@ -718,7 +716,7 @@ public final class SeqTypeTest {
     recordTypeRefs.put(r9Name, (RecordType) r9.type);
     declaredRecordTypes.put(r8Name, new RecordType(fld8));
     declaredRecordTypes.put(r9Name, new RecordType(fld9));
-    RecordType.resolveRefs(recordTypeRefs, declaredRecordTypes);
+    RecordType.resolve(declaredRecordTypes, recordTypeRefs, new ArrayList<>());
 
     combine(RECORD_O, FUNCTION_O, FUNCTION_O, op);
     combine(RECORD_O, MAP_O, MAP_O, op);
@@ -744,9 +742,8 @@ public final class SeqTypeTest {
 
   /**
    * Tests for {@link SeqType#intersect(SeqType)}.
-   * @throws QueryException query exception
    */
-  @Test public void intersect() throws QueryException {
+  @Test public void intersect() {
     final BiFunction<SeqType, SeqType, SeqType> op = SeqType::intersect;
 
     combine(EMPTY_SEQUENCE_Z, op);
@@ -1038,7 +1035,7 @@ public final class SeqTypeTest {
     recordTypeRefs.put(r9Name, (RecordType) r9.type);
     declaredRecordTypes.put(r8Name, new RecordType(fld8));
     declaredRecordTypes.put(r9Name, new RecordType(fld9));
-    RecordType.resolveRefs(recordTypeRefs, declaredRecordTypes);
+    RecordType.resolve(declaredRecordTypes, recordTypeRefs, new ArrayList<>());
 
     combine(RECORD_O, FUNCTION_O, RECORD_O, op);
     combine(RECORD_O, MAP_O, RECORD_O, op);


### PR DESCRIPTION
The pushed code resolves circular record type dependencies:

```xquery
(: x.xq :)
import module namespace a = 'A' at 'a.xqm';
()

(: a.xqm :)
module namespace a = 'A';
import module namespace b = 'B' at 'b.xqm';
declare record a:TYPE(value);

(: b.xqm :)
module namespace b = 'B';
import module namespace a = 'A' at 'a.xqm';
declare type b:TYPE as a:TYPE;
```

Non-record aliases, such as `item()`, would require a great deal more work. I have decided to exclude them, as it is not even clear whether item type declarations will remain in the language.