### PR TITLE
JSON parsing: add streaming for DIRECT, W3_XML, ATTRIBUTES formats

### DIFF
--- a/basex-core/src/main/java/org/basex/build/Parser.java
+++ b/basex-core/src/main/java/org/basex/build/Parser.java
@@ -144,7 +144,7 @@ public class Parser extends Job {
     final MainParser mp = options.get(MainOptions.PARSER);
     final SingleParser p = switch(mp) {
       case HTML -> new HtmlParser(source, options, options.get(MainOptions.HTMLPARSER));
-      case JSON -> new JsonParser(source, options, options.get(MainOptions.JSONPARSER));
+      case JSON -> JsonStreamingParser.get(source, options);
       case CSV -> new CsvParser(source, options, options.get(MainOptions.CSVPARSER));
       default -> options.get(MainOptions.INTPARSE) ? new XMLParser(source, options) :
         new SAXWrapper(source, options);

--- a/basex-core/src/main/java/org/basex/build/json/JsonAttsBuilderConverter.java
+++ b/basex-core/src/main/java/org/basex/build/json/JsonAttsBuilderConverter.java
@@ -38,32 +38,17 @@ final class JsonAttsBuilderConverter extends JsonBuilderConverter {
 
   @Override
   protected void openObject() {
-    if(!skipOpen()) openElem(OBJECT);
+    openElem(OBJECT);
   }
 
   @Override
-  protected void closeObject() {
-    if(!skipClose()) closeElem();
-  }
-
-  @Override
-  protected void openPair(final byte[] key, final boolean add) {
-    if(!skipPair(add)) pendingKey = key;
-  }
-
-  @Override
-  protected void closePair(final boolean add) {
-    skipClose();
+  protected void openPair(final byte[] key) {
+    pendingKey = key;
   }
 
   @Override
   protected void openArray() {
-    if(!skipOpen()) openElem(ARRAY);
-  }
-
-  @Override
-  protected void closeArray() {
-    if(!skipClose()) closeElem();
+    openElem(ARRAY);
   }
 
   @Override
@@ -92,7 +77,6 @@ final class JsonAttsBuilderConverter extends JsonBuilderConverter {
    * @param value text content, or {@code null} for the null literal
    */
   private void addValue(final byte[] type, final byte[] value) {
-    if(skip()) return;
     try {
       atts.reset();
       final byte[] en = prepareElem();

--- a/basex-core/src/main/java/org/basex/build/json/JsonAttsBuilderConverter.java
+++ b/basex-core/src/main/java/org/basex/build/json/JsonAttsBuilderConverter.java
@@ -1,0 +1,137 @@
+package org.basex.build.json;
+
+import static org.basex.io.parse.json.JsonConstants.*;
+
+import java.io.*;
+
+import org.basex.build.*;
+import org.basex.io.parse.json.*;
+import org.basex.query.*;
+
+/**
+ * Converts a JSON document to XML and emits the result as events to a database builder,
+ * equivalent to {@link JsonAttsConverter} but without building an in-memory tree.
+ * Supports {@link JsonOptions#MERGE}{@code =false} only.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+final class JsonAttsBuilderConverter extends JsonBuilderConverter {
+  /** Whether to emit explicit {@code type="string"} attributes. */
+  private final boolean strings;
+  /** Key of the next pair element; null when not inside an object pair. */
+  private byte[] pendingKey;
+  /** Whether the root element has been opened. */
+  private boolean rootOpened;
+
+  /**
+   * Constructor.
+   * @param jopts JSON options
+   * @param builder database builder
+   * @throws QueryException query exception
+   */
+  JsonAttsBuilderConverter(final JsonParserOptions jopts, final Builder builder)
+      throws QueryException {
+    super(jopts, builder);
+    strings = jopts.get(JsonOptions.STRINGS);
+  }
+
+  @Override
+  protected void openObject() {
+    if(!skipOpen()) openElem(OBJECT);
+  }
+
+  @Override
+  protected void closeObject() {
+    if(!skipClose()) closeElem();
+  }
+
+  @Override
+  protected void openPair(final byte[] key, final boolean add) {
+    if(!skipPair(add)) pendingKey = key;
+  }
+
+  @Override
+  protected void closePair(final boolean add) {
+    skipClose();
+  }
+
+  @Override
+  protected void openArray() {
+    if(!skipOpen()) openElem(ARRAY);
+  }
+
+  @Override
+  protected void closeArray() {
+    if(!skipClose()) closeElem();
+  }
+
+  @Override
+  protected void numberLit(final byte[] value) {
+    addValue(NUMBER, value);
+  }
+
+  @Override
+  protected void stringLit(final byte[] value) {
+    addValue(STRING, value);
+  }
+
+  @Override
+  protected void nullLit() {
+    addValue(NULL, null);
+  }
+
+  @Override
+  protected void booleanLit(final byte[] value) {
+    addValue(BOOLEAN, value);
+  }
+
+  /**
+   * Emits a leaf value element with optional text content.
+   * @param type JSON type token
+   * @param value text content, or {@code null} for the null literal
+   */
+  private void addValue(final byte[] type, final byte[] value) {
+    if(skip()) return;
+    try {
+      atts.reset();
+      final byte[] en = prepareElem();
+      if(strings || type != STRING) atts.add(TYPE, type);
+      builder.openElem(en, atts, EMPTY_NSP);
+      if(value != null) builder.text(value);
+      builder.closeElem();
+    } catch(final IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  /**
+   * Opens a container element for an object or array.
+   * @param type JSON type token ({@code OBJECT} or {@code ARRAY})
+   */
+  private void openElem(final byte[] type) {
+    try {
+      atts.reset();
+      final byte[] en = prepareElem();
+      atts.add(TYPE, type);
+      builder.openElem(en, atts, EMPTY_NSP);
+    } catch(final IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  /**
+   * Returns the element name for the next container or value element.
+   * @return element name
+   */
+  private byte[] prepareElem() {
+    if(pendingKey != null) {
+      atts.add(NAME, pendingKey);
+      pendingKey = null;
+      return PAIR;
+    }
+    if(rootOpened) return ITEM;
+    rootOpened = true;
+    return JSON;
+  }
+}

--- a/basex-core/src/main/java/org/basex/build/json/JsonBuilderConverter.java
+++ b/basex-core/src/main/java/org/basex/build/json/JsonBuilderConverter.java
@@ -1,0 +1,68 @@
+package org.basex.build.json;
+
+import java.io.*;
+
+import org.basex.build.*;
+import org.basex.build.json.JsonParserOptions.*;
+import org.basex.io.parse.json.*;
+import org.basex.query.*;
+import org.basex.query.value.item.*;
+import org.basex.util.*;
+
+/**
+ * Abstract base for JSON converters that emit events directly to a database builder,
+ * bypassing in-memory tree construction.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+abstract class JsonBuilderConverter extends JsonConverter {
+  /** Empty namespace declarations. */
+  static final Atts EMPTY_NSP = new Atts();
+
+  /** Database builder. */
+  final Builder builder;
+  /** Reusable attribute list. */
+  final Atts atts = new Atts();
+
+  /**
+   * Constructor.
+   * @param jopts JSON parser options
+   * @param builder database builder
+   * @throws QueryException if the USE_LAST duplicates option is set
+   */
+  JsonBuilderConverter(final JsonParserOptions jopts, final Builder builder)
+      throws QueryException {
+    super(jopts);
+    this.builder = builder;
+    final JsonDuplicates dupl = jopts.get(JsonParserOptions.DUPLICATES);
+    if(dupl == JsonDuplicates.USE_LAST) {
+      throw optionError(JsonParserOptions.DUPLICATES.name(), dupl);
+    }
+  }
+
+  @Override
+  protected final void init(final String uri) { }
+
+  @Override
+  protected final Item finish() {
+    return null;
+  }
+
+  @Override
+  protected void openItem() { }
+
+  @Override
+  protected void closeItem() { }
+
+  /**
+   * Closes the current builder element, wrapping any I/O exception.
+   */
+  final void closeElem() {
+    try {
+      builder.closeElem();
+    } catch(final IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+}

--- a/basex-core/src/main/java/org/basex/build/json/JsonBuilderConverter.java
+++ b/basex-core/src/main/java/org/basex/build/json/JsonBuilderConverter.java
@@ -50,6 +50,19 @@ abstract class JsonBuilderConverter extends JsonConverter {
   }
 
   @Override
+  protected void closePair() { }
+
+  @Override
+  protected void closeObject() {
+    closeElem();
+  }
+
+  @Override
+  protected void closeArray() {
+    closeElem();
+  }
+
+  @Override
   protected void openItem() { }
 
   @Override

--- a/basex-core/src/main/java/org/basex/build/json/JsonDirectBuilderConverter.java
+++ b/basex-core/src/main/java/org/basex/build/json/JsonDirectBuilderConverter.java
@@ -41,37 +41,22 @@ final class JsonDirectBuilderConverter extends JsonBuilderConverter {
 
   @Override
   protected void openObject() {
-    if(!skipOpen()) openElem(OBJECT);
+    openElem(OBJECT);
   }
 
   @Override
-  protected void closeObject() {
-    if(!skipClose()) closeElem();
-  }
-
-  @Override
-  protected void openPair(final byte[] key, final boolean add) {
-    if(!skipPair(add)) name = XMLToken.encode(key, lax);
-  }
-
-  @Override
-  protected void closePair(final boolean add) {
-    skipClose();
+  protected void openPair(final byte[] key) {
+    name = XMLToken.encode(key, lax);
   }
 
   @Override
   protected void openArray() {
-    if(!skipOpen()) openElem(ARRAY);
-  }
-
-  @Override
-  protected void closeArray() {
-    if(!skipClose()) closeElem();
+    openElem(ARRAY);
   }
 
   @Override
   protected void openItem() {
-    if(!skip()) name = VALUE;
+    name = VALUE;
   }
 
   @Override
@@ -100,7 +85,6 @@ final class JsonDirectBuilderConverter extends JsonBuilderConverter {
    * @param value text content, or {@code null} for the null literal
    */
   private void addValue(final byte[] type, final byte[] value) {
-    if(skip()) return;
     try {
       atts.reset();
       if(strings || type != STRING) atts.add(TYPE, type);

--- a/basex-core/src/main/java/org/basex/build/json/JsonDirectBuilderConverter.java
+++ b/basex-core/src/main/java/org/basex/build/json/JsonDirectBuilderConverter.java
@@ -1,0 +1,128 @@
+package org.basex.build.json;
+
+import static org.basex.io.parse.json.JsonConstants.*;
+
+import java.io.*;
+
+import org.basex.build.*;
+import org.basex.io.parse.json.*;
+import org.basex.query.*;
+import org.basex.util.*;
+
+/**
+ * Converts a JSON document to XML and emits the result as events to a database builder,
+ * equivalent to {@link JsonDirectConverter} but without building an in-memory tree.
+ * Supports {@link JsonOptions#MERGE}{@code =false} only.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+final class JsonDirectBuilderConverter extends JsonBuilderConverter {
+  /** Whether to emit explicit {@code type="string"} attributes. */
+  private final boolean strings;
+  /** Whether to use lax QName encoding for object keys. */
+  private final boolean lax;
+  /** Name to use for the next element to be opened. */
+  private byte[] name;
+
+  /**
+   * Constructor.
+   * @param jopts JSON options
+   * @param builder database builder
+   * @throws QueryException query exception
+   */
+  JsonDirectBuilderConverter(final JsonParserOptions jopts, final Builder builder)
+      throws QueryException {
+    super(jopts, builder);
+    strings = jopts.get(JsonOptions.STRINGS);
+    lax = jopts.get(JsonOptions.LAX);
+    name = JSON;
+  }
+
+  @Override
+  protected void openObject() {
+    if(!skipOpen()) openElem(OBJECT);
+  }
+
+  @Override
+  protected void closeObject() {
+    if(!skipClose()) closeElem();
+  }
+
+  @Override
+  protected void openPair(final byte[] key, final boolean add) {
+    if(!skipPair(add)) name = XMLToken.encode(key, lax);
+  }
+
+  @Override
+  protected void closePair(final boolean add) {
+    skipClose();
+  }
+
+  @Override
+  protected void openArray() {
+    if(!skipOpen()) openElem(ARRAY);
+  }
+
+  @Override
+  protected void closeArray() {
+    if(!skipClose()) closeElem();
+  }
+
+  @Override
+  protected void openItem() {
+    if(!skip()) name = VALUE;
+  }
+
+  @Override
+  protected void numberLit(final byte[] value) {
+    addValue(NUMBER, value);
+  }
+
+  @Override
+  protected void stringLit(final byte[] value) {
+    addValue(STRING, value);
+  }
+
+  @Override
+  protected void nullLit() {
+    addValue(NULL, null);
+  }
+
+  @Override
+  protected void booleanLit(final byte[] value) {
+    addValue(BOOLEAN, value);
+  }
+
+  /**
+   * Emits a leaf value element with optional text content.
+   * @param type JSON type token
+   * @param value text content, or {@code null} for the null literal
+   */
+  private void addValue(final byte[] type, final byte[] value) {
+    if(skip()) return;
+    try {
+      atts.reset();
+      if(strings || type != STRING) atts.add(TYPE, type);
+      builder.openElem(name, atts, EMPTY_NSP);
+      if(value != null) builder.text(value);
+      builder.closeElem();
+    } catch(final IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  /**
+   * Opens a container element for an object or array.
+   * @param type JSON type token ({@code OBJECT} or {@code ARRAY})
+   */
+  private void openElem(final byte[] type) {
+    try {
+      atts.reset();
+      atts.add(TYPE, type);
+      builder.openElem(name, atts, EMPTY_NSP);
+    } catch(final IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+}

--- a/basex-core/src/main/java/org/basex/build/json/JsonStreamingParser.java
+++ b/basex-core/src/main/java/org/basex/build/json/JsonStreamingParser.java
@@ -1,0 +1,79 @@
+package org.basex.build.json;
+
+import static org.basex.build.json.JsonOptions.*;
+
+import java.io.*;
+
+import org.basex.build.*;
+import org.basex.core.*;
+import org.basex.io.*;
+import org.basex.io.in.*;
+import org.basex.io.parse.json.*;
+import org.basex.query.*;
+
+/**
+ * Streams a JSON file as events directly to a database builder, bypassing in-memory
+ * tree construction.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public final class JsonStreamingParser extends SingleParser {
+  /** JSON parser options. */
+  private final JsonParserOptions jopts;
+  /** Factory that creates the appropriate converter for the given builder. */
+  private final QueryFunction<Builder, JsonBuilderConverter> converterFactory;
+
+  /**
+   * Constructor.
+   * @param source document source
+   * @param options main options
+   * @param jopts JSON parser options
+   * @param converterFactory converter factory
+   */
+  JsonStreamingParser(final IO source, final MainOptions options, final JsonParserOptions jopts,
+      final QueryFunction<Builder, JsonBuilderConverter> converterFactory) {
+    super(source, options);
+    this.jopts = jopts;
+    this.converterFactory = converterFactory;
+  }
+
+  /**
+   * Returns a parser for the given JSON options, using the streaming path where applicable.
+   * @param source document source
+   * @param options main options
+   * @return JSON parser (streaming or classic)
+   * @throws IOException I/O exception
+   */
+  public static SingleParser get(final IO source, final MainOptions options) throws IOException {
+    final JsonParserOptions jopts = options.get(MainOptions.JSONPARSER);
+    final JsonOptions.JsonFormat fmt = jopts.get(FORMAT);
+    final boolean merge = jopts.get(MERGE);
+    final QueryFunction<Builder, JsonBuilderConverter> conv = switch(fmt) {
+      case W3_XML, BASIC -> b -> new JsonW3XmlBuilderConverter(jopts, b);
+      case DIRECT -> merge ? null : b -> new JsonDirectBuilderConverter(jopts, b);
+      case ATTRIBUTES -> merge ? null : b -> new JsonAttsBuilderConverter(jopts, b);
+      case JSONML -> null; // not yet supported; fall back to non-streaming
+      default -> null;
+    };
+    // fallback to non-streaming parser if streaming path is not applicable
+    return conv == null
+        ? new JsonParser(source, options, jopts)
+        : new JsonStreamingParser(source, options, jopts, conv);
+  }
+
+  @Override
+  protected void parse() throws IOException {
+    try {
+      final JsonConverter conv = converterFactory.apply(builder);
+      final String encoding = jopts.get(JsonParserOptions.ENCODING);
+      try(NewlineInput ni = new NewlineInput(source, encoding)) {
+        new org.basex.io.parse.json.JsonParser(ni, jopts, conv).parse(null);
+      }
+    } catch(final UncheckedIOException ex) {
+      throw ex.getCause();
+    } catch(final QueryException ex) {
+      throw new QueryIOException(ex);
+    }
+  }
+}

--- a/basex-core/src/main/java/org/basex/build/json/JsonW3XmlBuilderConverter.java
+++ b/basex-core/src/main/java/org/basex/build/json/JsonW3XmlBuilderConverter.java
@@ -43,32 +43,17 @@ final class JsonW3XmlBuilderConverter extends JsonBuilderConverter {
 
   @Override
   protected void openObject() {
-    if(!skipOpen()) openContainer(MAP);
+    openContainer(MAP);
   }
 
   @Override
-  protected void closeObject() {
-    if(!skipClose()) closeElem();
-  }
-
-  @Override
-  protected void openPair(final byte[] key, final boolean add) {
-    if(!skipPair(add)) pendingKey = key;
-  }
-
-  @Override
-  protected void closePair(final boolean add) {
-    skipClose();
+  protected void openPair(final byte[] key) {
+    pendingKey = key;
   }
 
   @Override
   protected void openArray() {
-    if(!skipOpen()) openContainer(ARRAY);
-  }
-
-  @Override
-  protected void closeArray() {
-    if(!skipClose()) closeElem();
+    openContainer(ARRAY);
   }
 
   @Override
@@ -97,7 +82,6 @@ final class JsonW3XmlBuilderConverter extends JsonBuilderConverter {
    * @param value text content, or {@code null} for the null literal
    */
   private void addValue(final byte[] elemName, final byte[] value) {
-    if(skip()) return;
     try {
       atts.reset();
       addKeyAtts();

--- a/basex-core/src/main/java/org/basex/build/json/JsonW3XmlBuilderConverter.java
+++ b/basex-core/src/main/java/org/basex/build/json/JsonW3XmlBuilderConverter.java
@@ -1,0 +1,150 @@
+package org.basex.build.json;
+
+import static org.basex.io.parse.json.JsonConstants.*;
+import static org.basex.util.Token.*;
+
+import java.io.*;
+
+import org.basex.build.*;
+import org.basex.io.parse.json.*;
+import org.basex.query.*;
+import org.basex.util.*;
+
+/**
+ * Converts a JSON document to W3C XML representation and emits the result as events to a
+ * database builder, equivalent to {@link JsonW3XmlConverter} but without building an
+ * in-memory tree.
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+final class JsonW3XmlBuilderConverter extends JsonBuilderConverter {
+  /** Default namespace declaration for the XPath functions namespace, emitted on the root. */
+  private static final Atts FN_NSP = new Atts().add(EMPTY, QueryText.FN_URI);
+
+  /** Whether to add escape attributes for values containing backslashes. */
+  private final boolean escape;
+  /** Key of the next value element; null inside arrays or at root. */
+  private byte[] pendingKey;
+  /** Whether the root element has been opened; controls namespace declaration. */
+  private boolean rootOpened;
+
+  /**
+   * Constructor.
+   * @param jopts JSON options
+   * @param builder database builder
+   * @throws QueryException query exception
+   */
+  JsonW3XmlBuilderConverter(final JsonParserOptions jopts, final Builder builder)
+      throws QueryException {
+    super(jopts, builder);
+    escape = jopts.get(JsonParserOptions.ESCAPE);
+  }
+
+  @Override
+  protected void openObject() {
+    if(!skipOpen()) openContainer(MAP);
+  }
+
+  @Override
+  protected void closeObject() {
+    if(!skipClose()) closeElem();
+  }
+
+  @Override
+  protected void openPair(final byte[] key, final boolean add) {
+    if(!skipPair(add)) pendingKey = key;
+  }
+
+  @Override
+  protected void closePair(final boolean add) {
+    skipClose();
+  }
+
+  @Override
+  protected void openArray() {
+    if(!skipOpen()) openContainer(ARRAY);
+  }
+
+  @Override
+  protected void closeArray() {
+    if(!skipClose()) closeElem();
+  }
+
+  @Override
+  protected void numberLit(final byte[] value) {
+    addValue(NUMBER, value);
+  }
+
+  @Override
+  protected void stringLit(final byte[] value) {
+    addValue(STRING, value);
+  }
+
+  @Override
+  protected void nullLit() {
+    addValue(NULL, null);
+  }
+
+  @Override
+  protected void booleanLit(final byte[] value) {
+    addValue(BOOLEAN, value);
+  }
+
+  /**
+   * Emits a leaf value element with optional text content.
+   * @param elemName local element name in the XPath functions namespace
+   * @param value text content, or {@code null} for the null literal
+   */
+  private void addValue(final byte[] elemName, final byte[] value) {
+    if(skip()) return;
+    try {
+      atts.reset();
+      addKeyAtts();
+      if(escape && value != null && contains(value, '\\')) atts.add(ESCAPED, TRUE);
+      builder.openElem(elemName, atts, nsDecl());
+      if(value != null) builder.text(value);
+      builder.closeElem();
+    } catch(final IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  /**
+   * Opens a container element (map or array).
+   * @param elemName local element name in the XPath functions namespace
+   */
+  private void openContainer(final byte[] elemName) {
+    try {
+      atts.reset();
+      addKeyAtts();
+      builder.openElem(elemName, atts, nsDecl());
+    } catch(final IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  /**
+   * Adds key and escaped-key attributes from {@link #pendingKey} if one is set.
+   */
+  private void addKeyAtts() {
+    if(pendingKey != null) {
+      atts.add(KEY, pendingKey);
+      if(escape && contains(pendingKey, '\\')) atts.add(ESCAPED_KEY, TRUE);
+      pendingKey = null;
+    }
+  }
+
+  /**
+   * Returns the namespace declaration for the current element.
+   * The XPath functions namespace is declared as default on the root element only.
+   * @return namespace Atts
+   */
+  private Atts nsDecl() {
+    if(!rootOpened) {
+      rootOpened = true;
+      return FN_NSP;
+    }
+    return EMPTY_NSP;
+  }
+}

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonAttsConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonAttsConverter.java
@@ -26,54 +26,50 @@ public final class JsonAttsConverter extends JsonXmlConverter {
 
   @Override
   protected void openObject() {
-    if(!skipOpen()) openOuter(OBJECT);
+    openOuter(OBJECT);
   }
 
   @Override
   protected void closeObject() {
-    if(!skipClose()) closeOuter();
+    closeOuter();
   }
 
   @Override
-  protected void openPair(final byte[] key, final boolean add) {
-    if(!skipPair(add)) {
-      openInner(Q_PAIR);
-      name = shared.token(key);
-      curr.attr(Q_NAME, name);
-    }
+  protected void openPair(final byte[] key) {
+    openInner(Q_PAIR);
+    name = shared.token(key);
+    curr.attr(Q_NAME, name);
   }
 
   @Override
-  protected void closePair(final boolean add) {
-    if(!skipClose() && add) {
-      closeInner();
-      name = null;
-    }
+  protected void closePair() {
+    closeInner();
+    name = null;
   }
 
   @Override
   protected void openArray() {
-    if(!skipOpen()) openOuter(ARRAY);
+    openOuter(ARRAY);
   }
 
   @Override
   protected void closeArray() {
-    if(!skipClose()) closeOuter();
+    closeOuter();
   }
 
   @Override
   protected void openItem() {
-    if(!skip()) openInner(Q_ITEM);
+    openInner(Q_ITEM);
   }
 
   @Override
   protected void closeItem() {
-    if(!skip()) closeInner();
+    closeInner();
   }
 
   @Override
   void addValue(final byte[] type, final byte[] value) {
-    if(!skip()) element(type).text(value != null ? shared.token(value) : null);
+    element(type).text(value != null ? shared.token(value) : null);
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonConverter.java
@@ -24,8 +24,6 @@ public abstract class JsonConverter extends Job {
   protected final SharedData shared = new SharedData();
   /** JSON options. */
   protected final JsonParserOptions jopts;
-  /** Nesting depth of a suppressed duplicate value (0: nothing suppressed). */
-  private int skipDepth;
 
   /** Fallback function. */
   protected QueryFunction<byte[], byte[]> fallback;
@@ -70,50 +68,6 @@ public abstract class JsonConverter extends Job {
   protected static QueryException optionError(final String name, final Object value) {
     return QueryError.OPTION_JSON_X.get(null,
         Util.info("'%':'%' is not supported by the target format.", name, value));
-  }
-
-  /**
-   * Registers an opening object or array.
-   * @return {@code true} if the event belongs to a suppressed duplicate and must be ignored
-   */
-  protected final boolean skipOpen() {
-    if(skipDepth == 0) return false;
-    skipDepth++;
-    return true;
-  }
-
-  /**
-   * Registers a closing object, array or pair.
-   * @return {@code true} if the event belongs to a suppressed duplicate and must be ignored
-   */
-  protected final boolean skipClose() {
-    if(skipDepth == 0) return false;
-    skipDepth--;
-    return true;
-  }
-
-  /**
-   * Registers an opening pair. A pair that is not added (suppressed duplicate, 'use-first')
-   * starts skipping its entire value, including nested objects and arrays.
-   * @param add add pair
-   * @return {@code true} if the pair and its value are suppressed and must be ignored
-   */
-  protected final boolean skipPair(final boolean add) {
-    if(skipDepth > 0) {
-      skipDepth++;
-      return true;
-    }
-    if(add) return false;
-    skipDepth = 1;
-    return true;
-  }
-
-  /**
-   * Indicates if the current value is part of a suppressed duplicate.
-   * @return result of check
-   */
-  protected final boolean skip() {
-    return skipDepth > 0;
   }
 
   /**
@@ -191,17 +145,15 @@ public abstract class JsonConverter extends Job {
   /**
    * Called when a pair of a JSON object is opened.
    * @param key the key of the entry
-   * @param add add pair
    * @throws QueryException query exception
    */
-  protected abstract void openPair(byte[] key, boolean add) throws QueryException;
+  protected abstract void openPair(byte[] key) throws QueryException;
 
   /**
    * Called when a pair of a JSON object is closed.
-   * @param add add pair
    * @throws QueryException query exception
    */
-  protected abstract void closePair(boolean add) throws QueryException;
+  protected abstract void closePair() throws QueryException;
 
   /**
    * Called when a JSON array is opened.

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonConverter.java
@@ -24,6 +24,8 @@ public abstract class JsonConverter extends Job {
   protected final SharedData shared = new SharedData();
   /** JSON options. */
   protected final JsonParserOptions jopts;
+  /** Nesting depth of a suppressed duplicate value (0: nothing suppressed). */
+  private int skipDepth;
 
   /** Fallback function. */
   protected QueryFunction<byte[], byte[]> fallback;
@@ -68,6 +70,50 @@ public abstract class JsonConverter extends Job {
   protected static QueryException optionError(final String name, final Object value) {
     return QueryError.OPTION_JSON_X.get(null,
         Util.info("'%':'%' is not supported by the target format.", name, value));
+  }
+
+  /**
+   * Registers an opening object or array.
+   * @return {@code true} if the event belongs to a suppressed duplicate and must be ignored
+   */
+  protected final boolean skipOpen() {
+    if(skipDepth == 0) return false;
+    skipDepth++;
+    return true;
+  }
+
+  /**
+   * Registers a closing object, array or pair.
+   * @return {@code true} if the event belongs to a suppressed duplicate and must be ignored
+   */
+  protected final boolean skipClose() {
+    if(skipDepth == 0) return false;
+    skipDepth--;
+    return true;
+  }
+
+  /**
+   * Registers an opening pair. A pair that is not added (suppressed duplicate, 'use-first')
+   * starts skipping its entire value, including nested objects and arrays.
+   * @param add add pair
+   * @return {@code true} if the pair and its value are suppressed and must be ignored
+   */
+  protected final boolean skipPair(final boolean add) {
+    if(skipDepth > 0) {
+      skipDepth++;
+      return true;
+    }
+    if(add) return false;
+    skipDepth = 1;
+    return true;
+  }
+
+  /**
+   * Indicates if the current value is part of a suppressed duplicate.
+   * @return result of check
+   */
+  protected final boolean skip() {
+    return skipDepth > 0;
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonDirectConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonDirectConverter.java
@@ -65,32 +65,30 @@ public final class JsonDirectConverter extends JsonXmlConverter {
 
   @Override
   protected void openObject() {
-    if(!skipOpen()) openOuter(OBJECT);
+    openOuter(OBJECT);
   }
 
   @Override
   protected void closeObject() {
-    if(!skipClose()) closeOuter();
+    closeOuter();
   }
 
   @Override
-  protected void openPair(final byte[] key, final boolean add) {
-    if(!skipPair(add)) name = shared.token(XMLToken.encode(key, lax));
+  protected void openPair(final byte[] key) {
+    name = shared.token(XMLToken.encode(key, lax));
   }
 
   @Override
-  protected void closePair(final boolean add) {
-    skipClose();
-  }
+  protected void closePair() { }
 
   @Override
   protected void openArray() {
-    if(!skipOpen()) openOuter(ARRAY);
+    openOuter(ARRAY);
   }
 
   @Override
   protected void closeArray() {
-    if(!skipClose()) closeOuter();
+    closeOuter();
   }
 
   @Override
@@ -103,12 +101,10 @@ public final class JsonDirectConverter extends JsonXmlConverter {
 
   @Override
   void addValue(final byte[] type, final byte[] value) {
-    if(!skip()) {
-      final byte[] val = value != null ? shared.token(value) : null;
-      final FBuilder elem = element(type).text(val);
-      if(curr != null) curr.node(elem);
-      else curr = elem;
-    }
+    final byte[] val = value != null ? shared.token(value) : null;
+    final FBuilder elem = element(type).text(val);
+    if(curr != null) curr.node(elem);
+    else curr = elem;
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonMLConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonMLConverter.java
@@ -50,13 +50,13 @@ final class JsonMLConverter extends JsonXmlConverter {
   }
 
   @Override
-  protected void openPair(final byte[] key, final boolean add) throws QueryException {
+  protected void openPair(final byte[] key) throws QueryException {
     name = shared.token(check(key));
     if(!atts.add(name)) throw error("Duplicate attribute found");
   }
 
   @Override
-  protected void closePair(final boolean add) { }
+  protected void closePair() { }
 
   @Override
   protected void openArray() throws QueryException {

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonParser.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonParser.java
@@ -70,7 +70,9 @@ public final class JsonParser {
     escape = opts.get(JsonParserOptions.ESCAPE);
     final JsonDuplicates dupl = opts.get(JsonParserOptions.DUPLICATES);
     final JsonFormat jf = opts.get(JsonOptions.FORMAT);
-    duplicates = dupl != null ? dupl : jf == JsonFormat.W3_XML || jf == JsonFormat.BASIC ?
+    // JsonML always rejects duplicate attributes, regardless of the duplicates policy
+    duplicates = jf == JsonFormat.JSONML ? JsonDuplicates.REJECT :
+      dupl != null ? dupl : jf == JsonFormat.W3_XML || jf == JsonFormat.BASIC ?
       JsonDuplicates.RETAIN : JsonDuplicates.USE_FIRST;
   }
 
@@ -139,17 +141,70 @@ public final class JsonParser {
         final boolean dupl = set.contains(key);
         if(dupl && duplicates == JsonDuplicates.REJECT)
           throw error(DUPLICATE_JSON_X, "Key \"%\" occurs more than once", key);
-
-        final boolean add = !(dupl && duplicates == JsonDuplicates.USE_FIRST);
-        conv.openPair(key, add);
         consumeWs(':', true);
-        value();
-        conv.closePair(add);
+        if(dupl && duplicates == JsonDuplicates.USE_FIRST) {
+          skipValue();
+        } else {
+          conv.openPair(key);
+          value();
+          conv.closePair();
+        }
         set.put(key);
       } while(consumeWs(',', false) && !(liberal && current == '}'));
       consumeWs('}', true);
     }
     conv.closeObject();
+  }
+
+  /**
+   * Skips a JSON value without generating parse events.
+   * @throws QueryException query exception
+   * @throws IOException I/O exception
+   */
+  private void skipValue() throws QueryException, IOException {
+    if(!more()) throw eof(", expected JSON value");
+    switch(current) {
+      case '[' -> skipArray();
+      case '{' -> skipObject();
+      case '"' -> string();
+      case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> number();
+      case 't' -> consume("true");
+      case 'f' -> consume("false");
+      case 'n' -> consume("null");
+      default -> throw error("Unexpected JSON value: '%'", remaining());
+    }
+  }
+
+  /**
+   * Skips a JSON object without generating parse events.
+   * @throws QueryException query exception
+   * @throws IOException I/O exception
+   */
+  private void skipObject() throws QueryException, IOException {
+    consumeWs('{', true);
+    if(!consumeWs('}', false)) {
+      do {
+        if(!liberal || current == '"') string(); else unquoted();
+        consumeWs(':', true);
+        skipValue();
+      } while(consumeWs(',', false) && !(liberal && current == '}'));
+      consumeWs('}', true);
+    }
+  }
+
+  /**
+   * Skips a JSON array without generating parse events.
+   * @throws QueryException query exception
+   * @throws IOException I/O exception
+   */
+  private void skipArray() throws QueryException, IOException {
+    consumeWs('[', true);
+    if(!consumeWs(']', false)) {
+      do {
+        skipValue();
+      } while(consumeWs(',', false) && !(liberal && current == ']'));
+      consumeWs(']', true);
+    }
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonW3Converter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonW3Converter.java
@@ -79,15 +79,15 @@ public final class JsonW3Converter extends JsonConverter {
   }
 
   @Override
-  protected void openPair(final byte[] key, final boolean add) {
+  protected void openPair(final byte[] key) {
     stack.push(Str.get(shared.token(key)));
   }
 
   @Override
-  protected void closePair(final boolean add) throws QueryException {
+  protected void closePair() throws QueryException {
     final Value value = stack.pop();
     final Item key = (Item) stack.pop();
-    if(add) maps.peek().put(key, value);
+    maps.peek().put(key, value);
   }
 
   @Override

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonW3XmlConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonW3XmlConverter.java
@@ -29,32 +29,30 @@ public final class JsonW3XmlConverter extends JsonXmlConverter {
 
   @Override
   protected void openObject() {
-    if(!skipOpen()) openOuter(MAP);
+    openOuter(MAP);
   }
 
   @Override
   protected void closeObject() {
-    if(!skipClose()) closeOuter();
+    closeOuter();
   }
 
   @Override
-  protected void openPair(final byte[] key, final boolean add) {
-    if(!skipPair(add)) name = shared.token(key);
+  protected void openPair(final byte[] key) {
+    name = shared.token(key);
   }
 
   @Override
-  protected void closePair(final boolean add) {
-    skipClose();
-  }
+  protected void closePair() { }
 
   @Override
   protected void openArray() {
-    if(!skipOpen()) openOuter(ARRAY);
+    openOuter(ARRAY);
   }
 
   @Override
   protected void closeArray() {
-    if(!skipClose()) closeOuter();
+    closeOuter();
   }
 
   @Override
@@ -65,13 +63,11 @@ public final class JsonW3XmlConverter extends JsonXmlConverter {
 
   @Override
   void addValue(final byte[] type, final byte[] value) {
-    if(!skip()) {
-      final byte[] val = value != null ? shared.token(value) : null;
-      final FBuilder elem = element(type).text(val);
-      if(escape && value != null && contains(val, '\\')) elem.attr(Q_ESCAPED, TRUE);
-      if(curr != null) curr.node(elem);
-      else curr = elem;
-    }
+    final byte[] val = value != null ? shared.token(value) : null;
+    final FBuilder elem = element(type).text(val);
+    if(escape && value != null && contains(val, '\\')) elem.attr(Q_ESCAPED, TRUE);
+    if(curr != null) curr.node(elem);
+    else curr = elem;
   }
 
   /**

--- a/basex-core/src/main/java/org/basex/io/parse/json/JsonXmlConverter.java
+++ b/basex-core/src/main/java/org/basex/io/parse/json/JsonXmlConverter.java
@@ -37,8 +37,6 @@ abstract class JsonXmlConverter extends JsonConverter {
 
   /** Stack for intermediate nodes. */
   final Stack<FBuilder> stack = new Stack<>();
-  /** Nesting depth of a suppressed duplicate value (0: nothing suppressed). */
-  private int skipDepth;
 
   /** Map from element name to a pair of all its nodes and the collective node type. */
   private final TokenObjectMap<TypeCache> names = new TokenObjectMap<>();
@@ -127,50 +125,6 @@ abstract class JsonXmlConverter extends JsonConverter {
    * @throws QueryException query exception
    */
   abstract void addValue(byte[] type, byte[] value) throws QueryException;
-
-  /**
-   * Registers an opening object or array.
-   * @return {@code true} if the event belongs to a suppressed duplicate and must be ignored
-   */
-  final boolean skipOpen() {
-    if(skipDepth == 0) return false;
-    skipDepth++;
-    return true;
-  }
-
-  /**
-   * Registers a closing object, array or pair.
-   * @return {@code true} if the event belongs to a suppressed duplicate and must be ignored
-   */
-  final boolean skipClose() {
-    if(skipDepth == 0) return false;
-    skipDepth--;
-    return true;
-  }
-
-  /**
-   * Registers an opening pair. A pair that is not added (suppressed duplicate, 'use-first')
-   * starts skipping its entire value, including nested objects and arrays.
-   * @param add add pair
-   * @return {@code true} if the pair and its value are suppressed and must be ignored
-   */
-  final boolean skipPair(final boolean add) {
-    if(skipDepth > 0) {
-      skipDepth++;
-      return true;
-    }
-    if(add) return false;
-    skipDepth = 1;
-    return true;
-  }
-
-  /**
-   * Indicates if the current value is part of a suppressed duplicate.
-   * @return result of check
-   */
-  final boolean skip() {
-    return skipDepth > 0;
-  }
 
   /**
    * Adds type information to an element or the type cache.

--- a/basex-core/src/test/java/org/basex/build/JsonStreamingParserTest.java
+++ b/basex-core/src/test/java/org/basex/build/JsonStreamingParserTest.java
@@ -1,0 +1,356 @@
+package org.basex.build;
+
+import static org.basex.build.json.JsonOptions.JsonFormat.*;
+import static org.basex.query.QueryError.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.basex.*;
+import org.basex.build.json.*;
+import org.basex.build.json.JsonParser;
+import org.basex.core.*;
+import org.basex.io.*;
+import org.basex.io.parse.json.*;
+import org.basex.query.*;
+import org.basex.query.value.node.*;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link JsonStreamingParser}: JSON-to-XML via direct builder events
+ * (the streaming path, active for format=(DIRECT, ATTRIBUTES) with merge=false,
+ * as well as for format=(W3_XML, BASIC).
+ *
+ * @author BaseX Team, BSD License
+ * @author Gunther Rademacher
+ */
+public final class JsonStreamingParserTest extends SandboxTest {
+  /** JSON test resource. */
+  private static final String FILE = "src/test/resources/example.json";
+
+  /**
+   * Object with string, nested object, and boolean values.
+   * @throws Exception exception
+   */
+  @Test public void exampleFile() throws Exception {
+    final XNode result = parse(new IOFile(FILE), opts(DIRECT));
+    query(result, "//name/data()",             "Smith");
+    query(result, "//city/data()",             "New York");
+    query(result, "//postalCode/data()",       "10021");
+    query(result, "//postalCode/@type/data()", "number");
+    query(result, "//active/data()",           "true");
+    query(result, "//active/@type/data()",     "boolean");
+    query(result, "//name/@type/data()",       "");  // string type omitted by default
+  }
+
+  /**
+   * Top-level array with mixed-type items.
+   * @throws Exception exception
+   */
+  @Test public void topLevelArray() throws Exception {
+    final XNode result = parse("[1, \"two\", true, null]", opts(DIRECT));
+    query(result, "/json/@type/data()",  "array");
+    query(result, "//_ [1]/data()",      "1");
+    query(result, "//_[1]/@type/data()", "number");
+    query(result, "//_[2]/data()",       "two");
+    query(result, "//_[2]/@type/data()", "");       // string type omitted
+    query(result, "//_[3]/@type/data()", "boolean");
+    query(result, "//_[4]/@type/data()", "null");
+    query(result, "//_[4]/data()",       "");       // null has no text content
+  }
+
+  /**
+   * Nested objects and arrays.
+   * @throws Exception exception
+   */
+  @Test public void nested() throws Exception {
+    final XNode result = parse("{\"a\":{\"b\":[1,2]}}", opts(DIRECT));
+    query(result, "/json/@type/data()", "object");
+    query(result, "//a/@type/data()",   "object");
+    query(result, "//b/@type/data()",   "array");
+    query(result, "count(//b/_)",       "2");
+    query(result, "//b/_[1]/data()",    "1");
+    query(result, "//b/_[2]/data()",    "2");
+  }
+
+  /**
+   * Duplicate key with scalar value: USE_FIRST must suppress the second occurrence.
+   * @throws Exception exception
+   */
+  @Test public void duplicateKeyScalar() throws Exception {
+    final XNode result = parse("{\"x\":1,\"x\":2}", opts(DIRECT));
+    query(result, "count(//x)", "1");
+    query(result, "//x/data()", "1");
+  }
+
+  /**
+   * Duplicate key where the suppressed value is a nested object (tests skip-depth tracking).
+   * @throws Exception exception
+   */
+  @Test public void duplicateKeyObject() throws Exception {
+    final XNode result = parse("{\"x\":1,\"x\":{\"y\":2}}", opts(DIRECT));
+    query(result, "count(//x)", "1");
+    query(result, "//x/data()", "1");
+  }
+
+  /**
+   * strings=true makes string type explicit.
+   * @throws Exception exception
+   */
+  @Test public void stringsOption() throws Exception {
+    final JsonParserOptions jopts = new JsonParserOptions();
+    jopts.set(JsonOptions.STRINGS, true);
+    final XNode result = parse("\"hello\"", jopts);
+    query(result, "/json/@type/data()", "string");
+  }
+
+  /**
+   * Invalid JSON syntax is rejected.
+   * @throws Exception exception
+   */
+  @Test public void invalidSyntax() throws Exception {
+    error("{invalid}", opts(DIRECT), PARSE_JSON_X_X_X);
+  }
+
+  /**
+   * Truncated JSON is rejected.
+   * @throws Exception exception
+   */
+  @Test public void truncated() throws Exception {
+    error("{\"a\":", opts(DIRECT), PARSE_JSON_X_X_X);
+  }
+
+  /**
+   * Empty input is rejected.
+   * @throws Exception exception
+   */
+  @Test public void emptyInput() throws Exception {
+    error("", opts(DIRECT), PARSE_JSON_X_X_X);
+  }
+
+  /**
+   * W3_XML: object with string, nested object, number and boolean fields.
+   * @throws Exception exception
+   */
+  @Test public void w3XmlObject() throws Exception {
+    final XNode result = parse(new IOFile(FILE), opts(W3_XML));
+    query(result, "name(/*)",                               "map");  // not fn:map
+    query(result, "//fn:string[@key='name']/data()",       "Smith");
+    query(result, "//fn:string[@key='city']/data()",       "New York");
+    query(result, "//fn:number[@key='postalCode']/data()", "10021");
+    query(result, "//fn:boolean[@key='active']/data()",    "true");
+  }
+
+  /**
+   * W3_XML: top-level array with mixed-type items (no key attributes on items).
+   * @throws Exception exception
+   */
+  @Test public void w3XmlArray() throws Exception {
+    final XNode result = parse("[1, \"two\", true, null]", opts(W3_XML));
+    query(result, "local-name(/*)",              "array");
+    query(result, "/fn:array/fn:number/data()",  "1");
+    query(result, "/fn:array/fn:string/data()",  "two");
+    query(result, "/fn:array/fn:boolean/data()", "true");
+    query(result, "/fn:array/fn:null/data()",    "");
+  }
+
+  /**
+   * W3_XML: nested objects and arrays.
+   * @throws Exception exception
+   */
+  @Test public void w3XmlNested() throws Exception {
+    final XNode result = parse("{\"a\":{\"b\":[1,2]}}", opts(W3_XML));
+    query(result, "//fn:map[@key='a']/fn:array[@key='b']/fn:number[1]/data()", "1");
+    query(result, "//fn:map[@key='a']/fn:array[@key='b']/fn:number[2]/data()", "2");
+  }
+
+  /**
+   * W3_XML: duplicate keys are retained (W3C default — both occurrences kept).
+   * @throws Exception exception
+   */
+  @Test public void w3XmlDuplicateKey() throws Exception {
+    final XNode result = parse("{\"x\":1,\"x\":2}", opts(W3_XML));
+    query(result, "count(//fn:number[@key='x'])",    "2");
+    query(result, "//fn:number[@key='x'][1]/data()", "1");
+    query(result, "//fn:number[@key='x'][2]/data()", "2");
+  }
+
+  /**
+   * BASIC is a deprecated synonym for W3_XML and must use the streaming path.
+   * @throws Exception exception
+   */
+  @Test public void basicFormat() throws Exception {
+    final XNode result = parse(new IOFile(FILE), opts(BASIC));
+    query(result, "local-name(/*)", "map");
+  }
+
+  /**
+   * ATTRIBUTES: object with string, nested object, number and boolean fields.
+   * @throws Exception exception
+   */
+  @Test public void attsExampleFile() throws Exception {
+    final XNode result = parse(new IOFile(FILE), opts(ATTRIBUTES));
+    query(result, "/json/@type/data()",                   "object");
+    query(result, "//pair[@name='name']/data()",          "Smith");
+    query(result, "//pair[@name='city']/data()",          "New York");
+    query(result, "//pair[@name='postalCode']/@type/data()", "number");
+    query(result, "//pair[@name='active']/@type/data()",  "boolean");
+    query(result, "//pair[@name='name']/@type/data()",    "");  // string type omitted by default
+  }
+
+  /**
+   * ATTRIBUTES: top-level array with mixed-type items.
+   * @throws Exception exception
+   */
+  @Test public void attsTopLevelArray() throws Exception {
+    final XNode result = parse("[1, \"two\", true, null]", opts(ATTRIBUTES));
+    query(result, "/json/@type/data()",   "array");
+    query(result, "//item[1]/data()",     "1");
+    query(result, "//item[1]/@type/data()", "number");
+    query(result, "//item[2]/data()",     "two");
+    query(result, "//item[2]/@type/data()", "");      // string type omitted
+    query(result, "//item[3]/@type/data()", "boolean");
+    query(result, "//item[4]/@type/data()", "null");
+  }
+
+  /**
+   * ATTRIBUTES: nested objects and arrays.
+   * @throws Exception exception
+   */
+  @Test public void attsNested() throws Exception {
+    final XNode result = parse("{\"a\":{\"b\":[1,2]}}", opts(ATTRIBUTES));
+    query(result, "//pair[@name='a']/@type/data()",         "object");
+    query(result, "//pair[@name='b']/@type/data()",         "array");
+    query(result, "count(//pair[@name='b']/item)",          "2");
+    query(result, "//pair[@name='b']/item[1]/data()",       "1");
+    query(result, "//pair[@name='b']/item[2]/data()",       "2");
+  }
+
+  /**
+   * ATTRIBUTES: duplicate key with scalar value: USE_FIRST must suppress the second occurrence.
+   * @throws Exception exception
+   */
+  @Test public void attsDuplicateKey() throws Exception {
+    final XNode result = parse("{\"x\":1,\"x\":2}", opts(ATTRIBUTES));
+    query(result, "count(//pair[@name='x'])", "1");
+    query(result, "//pair[@name='x']/data()", "1");
+  }
+
+  /**
+   * merge=true falls back to the non-streaming path.
+   * @throws Exception exception
+   */
+  @Test public void directMergeOption() throws Exception {
+    final JsonParserOptions jopts = new JsonParserOptions();
+    jopts.set(JsonOptions.MERGE, true);
+    context.options.set(MainOptions.JSONPARSER, jopts);
+    final SingleParser sp = JsonStreamingParser.get(new IOFile(FILE), context.options);
+    assertInstanceOf(JsonParser.class, sp);
+    final XNode result = new DBNode(MemBuilder.build(sp), 0);
+    query(result, "//name/data()", "Smith");
+  }
+
+  /**
+   * merge=true falls back to the non-streaming path.
+   * @throws Exception exception
+   */
+  @Test public void attsMergeOption() throws Exception {
+    final JsonParserOptions jopts = new JsonParserOptions();
+    jopts.set(JsonOptions.FORMAT, ATTRIBUTES);
+    jopts.set(JsonOptions.MERGE, true);
+    context.options.set(MainOptions.JSONPARSER, jopts);
+    final SingleParser sp = JsonStreamingParser.get(new IOFile(FILE), context.options);
+    assertInstanceOf(JsonParser.class, sp);
+    final XNode result = new DBNode(MemBuilder.build(sp), 0);
+    query(result, "//pair[@name='name']/data()", "Smith");
+  }
+
+  // ==========================================================================================
+  // HELPERS
+  // ==========================================================================================
+
+  /**
+   * Parses JSON with both the streaming and non-streaming parsers, asserts they produce
+   * equivalent results, and returns the resulting document node.
+   * @param source JSON source
+   * @param jopts JSON parser options
+   * @return document node (streaming result)
+   * @throws Exception exception
+   */
+  private static XNode parse(final IO source, final JsonParserOptions jopts) throws Exception {
+    context.options.set(MainOptions.JSONPARSER, jopts);
+
+    // streaming parse — verify streaming parser is selected
+    final SingleParser sp = JsonStreamingParser.get(source, context.options);
+    assertInstanceOf(JsonStreamingParser.class, sp);
+    final XNode streamResult = new DBNode(MemBuilder.build(sp), 0);
+
+    // non-streaming parse — verify non-streaming converter is selected
+    final XNode nonStreamResult = (XNode) JsonConverter.get(jopts).convert(source);
+    assertNotNull(nonStreamResult);
+
+    // verify both parsers produce equivalent output (deep-equal ignores namespace prefix)
+    try(QueryProcessor qp = new QueryProcessor(
+        "declare variable $a external; declare variable $b external; deep-equal($a,$b)", context)) {
+      qp.variable("a", streamResult).variable("b", nonStreamResult);
+      assertEquals("true", qp.value().serialize().toString());
+    }
+
+    return streamResult;
+  }
+
+  /**
+   * Wraps JSON in an {@link IOContent} and delegates to {@link #parse(IO, JsonParserOptions)}.
+   * @param json JSON content
+   * @param jopts JSON parser options
+   * @return document node
+   * @throws Exception exception
+   */
+  private static XNode parse(final String json, final JsonParserOptions jopts) throws Exception {
+    return parse(new IOContent(json), jopts);
+  }
+
+  /**
+   * Evaluates an XQuery expression with the given document node as context.
+   * @param ctx context document node
+   * @param expr XQuery expression
+   * @param expected expected result
+   * @throws Exception exception
+   */
+  private static void query(final XNode ctx, final String expr, final String expected)
+      throws Exception {
+    try(QueryProcessor qp = new QueryProcessor(expr, context)) {
+      qp.context(ctx);
+      compare(expr, qp.value().serialize().toString(), expected, null);
+    }
+  }
+
+  /**
+   * Returns JSON parser options for the given format.
+   * @param fmt JSON format
+   * @return options
+   */
+  private static JsonParserOptions opts(final JsonOptions.JsonFormat fmt) {
+    final JsonParserOptions jopts = new JsonParserOptions();
+    jopts.set(JsonOptions.FORMAT, fmt);
+    return jopts;
+  }
+
+  /**
+   * Asserts that the streaming parser rejects the given JSON with the expected error.
+   * @param json JSON content
+   * @param jopts JSON parser options
+   * @param error expected error
+   * @throws Exception exception
+   */
+  private static void error(final String json, final JsonParserOptions jopts,
+      final QueryError error) throws Exception {
+    context.options.set(MainOptions.JSONPARSER, jopts);
+    final SingleParser sp = JsonStreamingParser.get(new IOContent(json), context.options);
+    assertInstanceOf(JsonStreamingParser.class, sp);
+    try {
+      MemBuilder.build(sp);
+      fail("Expected parse error for: " + json);
+    } catch(final QueryIOException ex) {
+      assertEquals(error, ex.getCause().error());
+    }
+  }
+}

--- a/basex-core/src/test/java/org/basex/io/parse/json/JsonStringConverter.java
+++ b/basex-core/src/test/java/org/basex/io/parse/json/JsonStringConverter.java
@@ -57,14 +57,14 @@ final class JsonStringConverter extends JsonConverter {
   }
 
   @Override
-  public void openPair(final byte[] key, final boolean add) {
+  public void openPair(final byte[] key) {
     if(!first) tb.add(", ");
     stringLit(key);
     tb.add(": ");
   }
 
   @Override
-  public void closePair(final boolean add) {
+  public void closePair() {
     first = false;
   }
 


### PR DESCRIPTION
This adds a streaming JSON parser path for database builds, avoiding the intermediate in-memory XML tree for JSON-to-XML conversion.

Streaming is now used for the `direct`, `attributes`, `w3-xml`, and deprecated `basic` formats. The existing conversion path is retained for `jsonml` and for `merge=true` direct/attributes conversions, where the output depends on whole-document type aggregation.

The change adds builder-backed JSON converters and regression coverage comparing streaming output with the existing non-streaming converters, including duplicate handling, W3 XML namespace/name compatibility, parse errors, and the `merge=true` fallback to the non-streaming path.

With these changes, the `CREATE DB` mentioned in #2655 can be executed successfully. Please close #2655 if you consider these changes sufficient, otherwise please add any requirements that should be met in addition.
