### PR TITLE
Fix declared return types of `fn:expanded-QName` and `fn:hash`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -277,7 +277,7 @@ public enum Function implements AFunction {
       params(ITEM_ZM), BOOLEAN_O),
   /** XQuery function. */
   EXPANDED_QNAME(FnExpandedQName::new, "expanded-QName(value)",
-      params(QNAME_ZO), STRING_O),
+      params(QNAME_ZO), STRING_ZO),
   /** XQuery function. */
   FALSE(FnFalse::new, "false()",
       params(), BOOLEAN_O),
@@ -350,7 +350,7 @@ public enum Function implements AFunction {
       params(GNODE_ZO), BOOLEAN_O),
   /** XQuery function. */
   HASH(FnHash::new, "hash(value[,algorithm,options])",
-      params(STRING_OR_BINARY_ZO, STRING_ZO, MAP_ZO), HEX_BINARY_O),
+      params(STRING_OR_BINARY_ZO, STRING_ZO, MAP_ZO), HEX_BINARY_ZO),
   /** XQuery function. */
   HEAD(FnHead::new, "head(input)",
       params(ITEM_ZM), ITEM_ZO),

--- a/basex-core/src/main/java/org/basex/query/value/type/Types.java
+++ b/basex-core/src/main/java/org/basex/query/value/type/Types.java
@@ -146,6 +146,8 @@ public final class Types {
   public static final SeqType BINARY_ZM = BINARY.seqType(ZERO_OR_MORE);
   /** One xs:hexBinary. */
   public static final SeqType HEX_BINARY_O = HEX_BINARY.seqType();
+  /** Zero or one xs:hexBinary. */
+  public static final SeqType HEX_BINARY_ZO = HEX_BINARY.seqType(ZERO_OR_ONE);
   /** Single xs:base64Binary. */
   public static final SeqType BASE64_BINARY_O = BASE64_BINARY.seqType();
   /** Zero or one xs:base64Binary. */


### PR DESCRIPTION
The return types are declared with with occurence `ONE`, but it should be `ZERO_OR_ONE`, both per the spec, and per the function implementations.