### PR TITLE
Fix relative module resolution in fatjar URLs

### DIFF
--- a/basex-core/src/main/java/org/basex/io/IO.java
+++ b/basex-core/src/main/java/org/basex/io/IO.java
@@ -252,6 +252,11 @@ public abstract class IO {
     if(io.isAbsolute()) return io;
     if(IOUrl.isJarURL(pth)) {
       try {
+        final int sep = pth.lastIndexOf("!/");
+        if(sep != -1) {
+          return get(pth.substring(0, sep + 2) +
+              new URI(pth.substring(sep + 2)).resolve(path).normalize());
+        }
         return get(JARPREF + new URI(pth.substring(JARPREF.length())).resolve(path));
       } catch(final URISyntaxException | IllegalArgumentException ex) {
         Util.stack(ex);

--- a/basex-core/src/test/java/org/basex/io/IOTest.java
+++ b/basex-core/src/test/java/org/basex/io/IOTest.java
@@ -106,4 +106,15 @@ public final class IOTest {
     assertEquals("https://user@xn--bcher-kva.example:8080/p",
         IOUrl.toAscii("https://user@bücher.example:8080/p"));
   }
+
+  /** JAR URL merges. */
+  @Test public void jarMerge() {
+    assertEquals("jar:file:/a/b.jar!/x/z.xq",
+        IO.get("jar:file:/a/b.jar!/x/y.xq").merge("z.xq").path());
+    assertEquals("jar:file:/a/b.jar!/z.xq",
+        IO.get("jar:file:/a/b.jar!/x/y.xq").merge("../z.xq").path());
+    assertEquals("jar:fatjar:WEB-INF/lib/rr.jar!/de/bottlecaps/railroad/xq/cst-to-ast.xq",
+        IO.get("jar:fatjar:WEB-INF/lib/rr.jar!/de/bottlecaps/railroad/xq/basic-interface.xq").
+            merge("cst-to-ast.xq").path());
+  }
 }


### PR DESCRIPTION
The changes that were done in the context of moving on to Java 21 brought up a regression in the code that supports fatjar loading (originally added in #2154). Commit 2d905d8678 replaced the deprecated `new URL(new URL(pth), path)` with `URI.resolve`:
```java
return get(JARPREF + new URI(pth.substring(JARPREF.length())).resolve(path));
```

The problem: for a plain jar URL like `jar:file:/a/b.jar!/…`, stripping `jar:` leaves `file:/a/b.jar!/…`, which is a hierarchical URI, so resolve merges paths correctly. But a fatjar URL nests a custom scheme - `jar:fatjar:WEB-INF/lib/rr.jar!/…`. Stripping `jar:` leaves `fatjar:WEB-INF/…`, whose scheme-specific part doesn't start with `/`, making it an opaque URI. `URI.resolve` against an opaque base discards the base entirely and just returns the relative reference.

The old `new URL(...)` path never had this issue because the `jar:` URL handler splits at `!/` and resolves only the entry.

Consequently the fix is to check for the presence of `!/`, keep the jar-location prefix (`jar:…!/`) intact and resolve the relative reference only against the entry path, which is always hierarchical.