### PR TITLE
Buffer `ByteArrayOutputStream` in serialization

### DIFF
--- a/basex-core/src/main/java/org/basex/io/out/PrintOutput.java
+++ b/basex-core/src/main/java/org/basex/io/out/PrintOutput.java
@@ -45,8 +45,8 @@ public class PrintOutput extends OutputStream {
    * @return print output
    */
   public static PrintOutput get(final OutputStream out) {
+    // buffer a ByteArrayOutputStream as well: its synchronized, array-growing writes are costly
     return out instanceof final PrintOutput po ? po : new PrintOutput(
-           out instanceof ByteArrayOutputStream ||
            out instanceof BufferedOutputStream ||
            out instanceof BufferOutput ? out : new BufferOutput(out));
   }


### PR DESCRIPTION
`PrintOutput.get()` left a `java.io.ByteArrayOutputStream` unbuffered, so every serialized codepoint went through a synchronized single-byte write + `ensureCapacity`. In a benchmark this caused about 28% of the total runtime.

It is now wrapped in `BufferOutput` like any other stream. `OutputSerializer.close()` flushes, and internally the serializer is fed `ArrayOutput`, not a JDK `ByteArrayOutputStream` - only external BAOS sinks are affected.