### PR TITLE
Fix signature of `fn:graphemes`

### DIFF
--- a/basex-core/src/main/java/org/basex/query/func/Function.java
+++ b/basex-core/src/main/java/org/basex/query/func/Function.java
@@ -343,8 +343,8 @@ public enum Function implements AFunction {
   GENERATE_ID(FnGenerateId::new, "generate-id([node])",
       params(GNODE_ZO), STRING_O),
   /** XQuery function. */
-  GRAPHEMES(FnGraphemes::new, "graphemes(value[,options])",
-      params(STRING_ZO, MAP_ZO), STRING_ZM),
+  GRAPHEMES(FnGraphemes::new, "graphemes(value)",
+      params(STRING_ZO), STRING_ZM),
   /** XQuery function. */
   HAS_CHILDREN(FnHasChildren::new, "has-children([node])",
       params(GNODE_ZO), BOOLEAN_O),


### PR DESCRIPTION
Enum `Function` defines `fn:graphemes` with an `options` parameter, but this does not conform to the spec or documentation, and the implementation ignores it. So it is removed here.