### PR TITLE
Inspect base items of large sequences when checking nondeterminism

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/gflwor/GFLWOR.java
+++ b/basex-core/src/main/java/org/basex/query/expr/gflwor/GFLWOR.java
@@ -395,7 +395,7 @@ public final class GFLWOR extends ParseExpr {
         if(last) {
           // merge with return expression unless a nondeterministic function is referenced
           //   for $c in 1 to 3 return $c → 1 to 3
-          if(!referencesNdtFunction(rtrn, c)) {
+          if(!referencesNdtFunction(rtrn, c, cc.qc)) {
             final Expr expr = inline(inline, rtrn, fl, cc);
             if(expr != null) {
               rtrn = expr;
@@ -443,12 +443,15 @@ public final class GFLWOR extends ParseExpr {
    * nondeterministic function item or closure.
    * @param expr expression
    * @param max index of the first clause that is not considered
+   * @param qc query context
    * @return result of check
+   * @throws QueryException query exception
    */
-  private boolean referencesNdtFunction(final Expr expr, final int max) {
+  private boolean referencesNdtFunction(final Expr expr, final int max, final QueryContext qc)
+      throws QueryException {
     for(int c = 0; c < max; c++) {
       if(clauses.get(c) instanceof final Let lt && expr.count(lt.var) != VarUsage.NEVER &&
-          DynFuncCall.containsNdtFunction(lt.expr)) return true;
+          DynFuncCall.containsNdtFunction(lt.expr, qc)) return true;
     }
     return false;
   }

--- a/basex-core/src/main/java/org/basex/query/func/DynFuncCall.java
+++ b/basex-core/src/main/java/org/basex/query/func/DynFuncCall.java
@@ -73,7 +73,8 @@ public final class DynFuncCall extends FuncCall {
     final Expr func = body();
     // the call is nondeterministic if the invoked function is (a function item is a value and so
     // carries no flag of its own, hence the explicit check)
-    if(func.has(Flag.NDT) || func instanceof final Value value && containsNdtFunction(value)) {
+    if(func.has(Flag.NDT) ||
+        func instanceof final Value value && containsNdtFunction(value, cc.qc)) {
       ndt = true;
     }
 
@@ -139,10 +140,13 @@ public final class DynFuncCall extends FuncCall {
   /**
    * Checks if an expression contains a nondeterministic function item or closure.
    * @param expr expression
+   * @param qc query context
    * @return result of check
+   * @throws QueryException query exception
    */
-  public static boolean containsNdtFunction(final Expr expr) {
-    return expr instanceof final Value value ? containsNdtFunction(value) :
+  public static boolean containsNdtFunction(final Expr expr, final QueryContext qc)
+      throws QueryException {
+    return expr instanceof final Value value ? containsNdtFunction(value, qc) :
       !expr.accept(new ASTVisitor() {
         @Override
         public boolean funcItem(final FuncItem func) {
@@ -159,19 +163,30 @@ public final class DynFuncCall extends FuncCall {
   /**
    * Checks if a value contains a nondeterministic function item or closure.
    * @param value value
+   * @param qc query context
    * @return result of check
+   * @throws QueryException query exception
    */
-  private static boolean containsNdtFunction(final Value value) {
+  private static boolean containsNdtFunction(final Value value, final QueryContext qc)
+      throws QueryException {
     if(atomic(value.seqType())) return false;
+    // inspect the base items of repeated sequences (e.g. from fn:replicate)
+    final Value base = value.baseItems();
+    if(base != value) return containsNdtFunction(base, qc);
     for(final Item item : value) {
       if(item instanceof final FuncItem fi && fi.ndt()) return true;
       if(item instanceof final XQArray array && !atomic(array.funcType().declType)) {
-        for(final Value member : array.members()) {
-          if(containsNdtFunction(member)) return true;
+        if(array instanceof ItemArray) {
+          // all members share one backing sequence (e.g. a replicate): inspect it, not each member
+          if(containsNdtFunction(array.items(qc), qc)) return true;
+        } else {
+          for(final Value member : array.members()) {
+            if(containsNdtFunction(member, qc)) return true;
+          }
         }
       } else if(item instanceof final XQMap map && !atomic(map.funcType().declType)) {
         for(final XQMap.Entry entry : map.entries()) {
-          if(containsNdtFunction(entry.value())) return true;
+          if(containsNdtFunction(entry.value(), qc)) return true;
         }
       }
     }

--- a/basex-core/src/main/java/org/basex/query/value/Value.java
+++ b/basex-core/src/main/java/org/basex/query/value/Value.java
@@ -106,6 +106,14 @@ public abstract class Value extends Expr implements Iterable<Item> {
   public abstract Value unwrappedValue(QueryContext qc);
 
   /**
+   * Returns the base items, collapsing repetitions (e.g. from {@code fn:replicate}).
+   * @return base items (default: {@code this})
+   */
+  public Value baseItems() {
+    return this;
+  }
+
+  /**
    * Returns a subsequence with the given start and length.
    * The following properties must hold:
    * <ul>

--- a/basex-core/src/main/java/org/basex/query/value/seq/SingletonSeq.java
+++ b/basex-core/src/main/java/org/basex/query/value/seq/SingletonSeq.java
@@ -77,6 +77,11 @@ public final class SingletonSeq extends Seq {
   }
 
   @Override
+  public Value baseItems() {
+    return value.baseItems();
+  }
+
+  @Override
   protected Value subSeq(final long pos, final long length, final Job job) {
     return singleItem() ? get(value, length) : super.subSeq(pos, length, job);
   }

--- a/basex-core/src/main/java/org/basex/query/value/seq/SubSeq.java
+++ b/basex-core/src/main/java/org/basex/query/value/seq/SubSeq.java
@@ -35,6 +35,13 @@ public final class SubSeq extends Seq {
   }
 
   @Override
+  public Value baseItems() {
+    // collapse only if the underlying sequence collapses (e.g. a repetition), not a dense one
+    final Value base = sub.baseItems();
+    return base == sub ? this : base;
+  }
+
+  @Override
   protected Seq subSeq(final long pos, final long length, final Job job) {
     return new SubSeq(sub, start + pos, length);
   }

--- a/basex-core/src/test/java/org/basex/query/ast/NonDeterministicTest.java
+++ b/basex-core/src/test/java/org/basex/query/ast/NonDeterministicTest.java
@@ -590,6 +590,45 @@ public final class NonDeterministicTest extends SandboxTest {
   }
 
   /**
+   * Checks that the nondeterminism check collapses repeated function sequences instead of walking
+   * them. Regression: a dynamic call on a large replicated array walked all members at compile
+   * time.
+   * <p>
+   * Requires {@code Value.baseItems} (overridden in {@code SingletonSeq} and {@code SubSeq}), and
+   * {@code containsNdtFunction} inspecting the backing of an {@code ItemArray} but the members of a
+   * multi-member array (so the members are not flattened).
+   */
+  @Test @Timeout(value = 60, threadMode = ThreadMode.SEPARATE_THREAD) public void largeFunctions() {
+    query("array { (1 to 100_000_000_000) ! identity#1 }(1)(42)", 42);
+    query("array { (1 to 100_000_000_000) ! (identity#1, abs#1) }(1)(1)", 1);
+    query("array { subsequence((1 to 100_000_000_000) ! (identity#1, abs#1), 3) }(1)(1)", 1);
+    query("[ (1 to 100_000_000_000) ! identity#1, (1 to 100_000_000_000) ! abs#1 ](1)[1](42)", 42);
+  }
+
+  /**
+   * Checks that a nondeterministic function item repeated across a large array is still detected,
+   * so its side effects are preserved when the enclosing for clause is collapsed.
+   * <p>
+   * Requires {@code Value.baseItems} to inspect the distinct members rather than skipping them.
+   */
+  @Test public void largeNdtFunctions() {
+    query("let $f := array { (1 to 300000) ! (function() { " + fileAppend() + " }, identity#1) } " +
+        "for $x in (1 to 2) return $f(1)()", "", "xx");
+  }
+
+  /**
+   * Checks that a nondeterministic function item in a member of a large multi-member array is still
+   * detected, so its side effects are preserved.
+   * <p>
+   * Guards the {@code members()} branch of {@code containsNdtFunction}: a multi-member array is not
+   * an {@code ItemArray}, so its members are inspected individually rather than flattened.
+   */
+  @Test public void squareArrayNdtFunction() {
+    query("let $f := [ (1 to 300000) ! function() { " + fileAppend() +
+        " }, (1 to 300000) ! identity#1 ] for $x in (1 to 2) return $f(1)[1]()", "", "xx");
+  }
+
+  /**
    * Returns a function call that records a single evaluation in the log.
    * @return file:append-text call
    */


### PR DESCRIPTION
This is a follow-up to the recent atomic-type check in `DynFuncCall.containsNdtFunction`, which still walked every item of large non-atomic sequences and arrays, e.g.
```
array { (1 to 100_000_000_000) ! identity#1 }(1)
```

The check now inspects the compact base items instead: a new `Value.baseItems()` (overridden in `SingletonSeq` and `SubSeq`) collapses `fn:replicate` sequences, and arrays are inspected via an `ItemArray`'s backing or a multi-member array's members (never flattened).

Regression tests have been added to `NonDeterministicTest`.