### PR TITLE
Prevent `TextPanel.setText` from mutating its argument

### DIFF
--- a/basex-core/src/main/java/org/basex/gui/text/TextPanel.java
+++ b/basex-core/src/main/java/org/basex/gui/text/TextPanel.java
@@ -207,19 +207,9 @@ public class TextPanel extends BaseXPanel {
    * @param size text size
    */
   public final void setText(final byte[] text, final int size) {
-    byte[] txt = text;
-    if(Token.contains(text, '\r')) {
-      // remove carriage returns
-      int ns = 0;
-      for(int r = 0; r < size; ++r) {
-        final byte b = text[r];
-        if(b != '\r') text[ns++] = b;
-      }
-      // new text is different...
-      txt = Arrays.copyOf(text, ns);
-    } else if(text.length != size) {
-      txt = Arrays.copyOf(text, size);
-    }
+    byte[] txt = text.length == size ? text : Arrays.copyOf(text, size);
+    // remove carriage returns
+    if(Token.contains(txt, '\r')) txt = Token.replace(txt, new byte[] { '\r' }, Token.EMPTY);
     if(editor.text(txt)) hist.store(txt, editor.pos(), 0);
     resetError();
     updateCode.invokeLater();

--- a/basex-core/src/main/java/org/basex/gui/text/TextPanel.java
+++ b/basex-core/src/main/java/org/basex/gui/text/TextPanel.java
@@ -209,7 +209,7 @@ public class TextPanel extends BaseXPanel {
   public final void setText(final byte[] text, final int size) {
     byte[] txt = text.length == size ? text : Arrays.copyOf(text, size);
     // remove carriage returns
-    if(Token.contains(txt, '\r')) txt = Token.replace(txt, new byte[] { '\r' }, Token.EMPTY);
+    txt = Token.replace(txt, new byte[] { '\r' }, Token.EMPTY);
     if(editor.text(txt)) hist.store(txt, editor.pos(), 0);
     resetError();
     updateCode.invokeLater();


### PR DESCRIPTION
In BaseXGUI on Windows, XQUnit trace output in the "Info" pane may contain excess text. This can be reproduced by running this query, which creates a temp folder with two test modules, 

```xquery
let $temp := translate(environment-variable('TEMP'), '\', '/')
let $dir := $temp || '/excess-info-output'
let $content := ``[
  module namespace m = 'm';
  declare %unit:test function m:t() {
    (1 to 5) 
    ! string-join((1 to 10) ! 'x')
    => string-join(char(10))
    => message()
  };
]``
return (
  if (file:exists($dir)) then file:delete($dir, true()) else (),
  file:create-dir($dir),
  (1 to 2) ! file:write-text($dir || '/' || . || '.xqm', $content),
  "TEST " || $dir
)
```

and then running the resulting `TEST .../excess-info-output` command. It should result in 10 lines with 10 `x` each. But it often shows one or two extra lines containing 3 `x`.

This is caused by `TextPanel.setText` stripping CRs in place, leaving the array longer than its real content, with a number of extra bytes at the end that equals the number of stripped CRs. `InfoView` keeps that array as `all` and, the next time it is used, re-reads its full length. The extra bytes are then shown as the extra line.

The fix makes sure that the argument of `TextPanel.setText` remains unchanged.