### PR TITLE
Fix positional comparisons with empty bounds

### DIFF
--- a/basex-core/src/main/java/org/basex/query/expr/Filter.java
+++ b/basex-core/src/main/java/org/basex/query/expr/Filter.java
@@ -143,7 +143,9 @@ public abstract class Filter extends Preds {
           ex = cc.function(ITEMS_AT, info, add.apply(expr), pred.arg(0));
         } else {
           // E[pos: MIN, MAX] → util:range(E, MIN, MAX)
-          ex = cc.function(_UTIL_RANGE, info, add.apply(expr), pred.arg(0), pred.arg(1));
+          final Expr min = pred.arg(0), max = pred.arg(1);
+          if(min.seqType().one() && max.seqType().one())
+            ex = cc.function(_UTIL_RANGE, info, add.apply(expr), min, max);
         }
       } else if(pred instanceof final Pos pos) {
         final Expr posExpr = pos.expr;

--- a/basex-core/src/test/java/org/basex/query/expr/ExprTest.java
+++ b/basex-core/src/test/java/org/basex/query/expr/ExprTest.java
@@ -651,6 +651,15 @@ public final class ExprTest extends SandboxTest {
     // GH-2224: Unexpected exception, arithmetic operations with positional expression
     check("document { <X/> }//X[not(position() * 2 = last())]", "<X/>");
     check("document { <X/> }//X[not(position() + position() = last())]", "<X/>");
+
+    // GH-2747: Avoid rewriting positional range predicates to util:range if bounds may be empty
+    final String empty = "let $x := 0\n"
+        + "let $empty := head(for $c at $i in $x where $c != 0 return $i)\n"
+        + "return ";
+    query(empty + "$x[position() >= $empty]", "");
+    query(empty + "$x[position() >  $empty]", "");
+    query(empty + "$x[position() <= $empty]", "");
+    query(empty + "$x[position() <  $empty]", "");
   }
 
   /** Predicates. */


### PR DESCRIPTION
Some XQuery code incorrectly resulted in 
```txt
[XPTY0004] Number expected, item() found: ().
```

for a general comparison with an empty operand. This can be reproduced by
```xquery
let $x := 0
let $first-nonzero := trace(head(for $c at $i in $x where $c!=0 return $i), "first-nonzero")
return $x[position() >= $first-nonzero]
```

It is caused by positional comparisons being rewritten to `util:range` regardless of the empty argument.